### PR TITLE
test: configure test infrastructure (Vitest + Playwright E2E)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,12 @@ desktop.ini
 coverage/
 .nyc_output/
 
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
 # Déploiement
 .vercel/
 .netlify/

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,6 +11,8 @@
     "build:mobile": "ng build mobile",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "lint": "ng lint",
     "serve:ssr:web": "node dist/web/server/server.mjs"
   },
@@ -45,6 +47,7 @@
     "@capacitor/cli": "^7.3.0",
     "@eslint/js": "^10.0.1",
     "@ionic/angular-toolkit": "^12.1.1",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/express": "^5.0.1",
     "@types/node": "^20.17.19",

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Configuration Playwright pour les tests E2E du site web KRAAK.
+ * Voir https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env['CI'],
+  retries: process.env['CI'] ? 2 : 0,
+  workers: process.env['CI'] ? 1 : undefined,
+  reporter: process.env['CI'] ? 'github' : 'html',
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm ng serve web',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120_000,
+  },
+});

--- a/apps/client/tests/e2e/smoke.spec.ts
+++ b/apps/client/tests/e2e/smoke.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+// Smoke E2E — page d'accueil par défaut
+// Given/When/Then : vérification des éléments visibles après chargement
+
+test.describe(`Page d'accueil — smoke tests`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test(`Given la page d'accueil, When elle se charge, Then le titre du document est "Web"`, async ({
+    page,
+  }) => {
+    await expect(page).toHaveTitle('Web');
+  });
+
+  test(`Given la page d'accueil, When elle se charge, Then le heading principal affiche "Hello, web"`, async ({
+    page,
+  }) => {
+    await expect(page.locator('h1')).toHaveText('Hello, web');
+  });
+
+  test(`Given la page d'accueil, When elle se charge, Then le message de bienvenue est visible`, async ({
+    page,
+  }) => {
+    await expect(
+      page.getByText('Congratulations! Your app is running.'),
+    ).toBeVisible();
+  });
+
+  test(`Given la page d'accueil, When elle se charge, Then le logo Angular est présent`, async ({
+    page,
+  }) => {
+    await expect(page.locator('.angular-logo')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev:mobile": "pnpm --filter @kraak/client dev:mobile",
     "build:mobile": "pnpm --filter @kraak/client build:mobile",
     "lint": "pnpm -r lint",
+    "test:unit": "pnpm --filter @kraak/client test",
+    "test:e2e": "pnpm --filter @kraak/client e2e",
     "format": "prettier --write \"**/*.{ts,html,scss,css,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,html,scss,css,json,md}\"",
     "prepare": "husky"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@ionic/angular-toolkit':
         specifier: ^12.1.1
         version: 12.3.0
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1434,6 +1437,11 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@primeuix/motion@0.0.10':
     resolution: {integrity: sha512-PsZwOPq79Scp7/ionshRcQ5xKVf9+zuLcyY5mf6onK8chHT5C9JGphmcIZ4CzcqxuGEpsm8AIbTGy+zS3RtzLA==}
     engines: {node: '>=12.11.0'}
@@ -2646,6 +2654,11 @@ packages:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3371,6 +3384,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -5404,6 +5427,10 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@primeuix/motion@0.0.10':
     dependencies:
       '@primeuix/utils': 0.6.4
@@ -6605,6 +6632,9 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7360,6 +7390,14 @@ snapshots:
       '@napi-rs/nice': 1.1.1
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:


### PR DESCRIPTION
## Résumé

Configure l'infrastructure de tests pour le monorepo :
- **Vitest** (natif Angular 21) pour les tests unitaires / intégration
- **Playwright** pour les tests E2E

## Changements

- Installation de `@playwright/test` 1.59.1 avec navigateur Chromium
- Création de `playwright.config.ts` ciblant `localhost:4200`
- Création de 4 smoke tests E2E pour la page d'accueil (BDD `Given/When/Then`)
- Ajout des scripts `e2e` et `e2e:ui` dans le `package.json` client
- Ajout des scripts `test:unit` et `test:e2e` dans le `package.json` racine
- Mise à jour de `.gitignore` avec les artefacts Playwright

## Validation

- ✅ 2 tests unitaires Vitest passent
- ✅ 4 tests E2E Playwright passent
- ✅ TDD RED → GREEN → REFACTOR respecté

Closes #67, Closes #68