### PR TITLE
chore(husky): use pnpm hooks and run tests on push

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit "$1"
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+pnpm format:check
+pnpm lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,3 @@
-npx --no -- validate-branch-name
+pnpm exec validate-branch-name
+pnpm test:api
+pnpm --filter @kraak/client exec ng test --watch=false


### PR DESCRIPTION
## Résumé
Met à jour les hooks Husky pour utiliser pnpm et ajoute des tests automatiques au push.

## Changements
- ajoute .husky/pre-commit
- remplace npx par pnpm exec dans commit-msg et pre-push
- pre-push exécute maintenant:
  - pnpm test:api
  - pnpm --filter @kraak/client exec ng test --watch=false

## Note
Le formatage global du dépôt n'est pas vert actuellement (fichiers historiques hors scope). Ce changement reste ciblé aux hooks Husky.