### PR TITLE
fix(docker): exclude nested node_modules and add pnpm deploy --legacy flag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Dépendances et caches
-node_modules
+**/node_modules
 .pnpm-store
 
 # Builds et artefacts

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,15 +10,16 @@ WORKDIR /app
 
 # --- Étape 1 : installation des dépendances ---
 FROM base AS deps
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY apps/api/package.json apps/api/
+COPY apps/client/package.json apps/client/
 RUN pnpm install --frozen-lockfile
 
 # --- Étape 2 : build TypeScript ---
 FROM deps AS build
 COPY apps/api/ apps/api/
 RUN pnpm --filter @kraak/api build
-RUN pnpm deploy --filter @kraak/api --prod /prod/api
+RUN pnpm deploy --filter @kraak/api --prod --legacy /prod/api
 
 # --- Étape 3 : image de production ---
 FROM node:24-alpine AS production


### PR DESCRIPTION
## Problème

Le build Docker de l'API échouait sur Render avec `Cannot find module '/app/apps/api/node_modules/@nestjs/cli/bin/nest.js'`.

## Cause racine

1. **Symlinks Windows copiés dans le conteneur** : Le pattern `.dockerignore` `node_modules` ne matchait qu'au niveau racine. `apps/api/node_modules` (contenant des symlinks pnpm avec des chemins Windows absolus comme `C:/Users/...`) était inclus dans le contexte Docker et écrasait les symlinks Linux corrects créés par `pnpm install` dans le stage `deps`.

2. **pnpm v10 deploy** : `pnpm deploy` en v10 exige soit `inject-workspace-packages=true` soit le flag `--legacy`.

## Corrections

- `.dockerignore` : `node_modules` → `**/node_modules` pour exclure à tous les niveaux
- `apps/api/Dockerfile` : ajout du flag `--legacy` à `pnpm deploy`

## Validation

- Build Docker local complet réussi (4 stages : base, deps, build, production)