### PR TITLE
fix(docker): correct dist output path for NestJS main entry

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,4 +36,4 @@ COPY --from=build /app/apps/api/dist ./dist
 USER nestjs
 EXPOSE 3000
 
-CMD ["node", "dist/main.js"]
+CMD ["node", "dist/src/main.js"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "build": "nest build",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:prod": "node dist/main.js",
+    "start:prod": "node dist/src/main.js",
     "lint": "eslint \"src/**/*.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Problème

Le conteneur Docker sur Render crash au démarrage avec :

```
Error: Cannot find module '/app/dist/main.js'
```

## Cause racine

La config TypeScript (`tsconfig.json`) utilise `outDir: "./dist"` et `baseUrl: "./"`, ce qui compile `src/main.ts` vers `dist/src/main.js` (et non `dist/main.js`).

## Correctif

- **Dockerfile** : `CMD ["node", "dist/src/main.js"]` (au lieu de `dist/main.js`)
- **package.json** : `"start:prod": "node dist/src/main.js"` (au lieu de `dist/main.js`)

## Validation

- Build Docker local ✅
- Conteneur démarre sans erreur ✅
- `/health` retourne `{"status":"ok"}` ✅
- Tests unitaires passent ✅