### PR TITLE
fix: always enable CORS + add debug/env endpoint

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -9,4 +9,16 @@ export class AppController {
   getHealth(): { status: string } {
     return this.appService.getHealth();
   }
+
+  @Get('debug/env')
+  getDebugEnv(): Record<string, string> {
+    return {
+      corsOriginsSet: process.env['CORS_ALLOWED_ORIGINS'] ? 'true' : 'false',
+      corsOriginsLength: String(
+        process.env['CORS_ALLOWED_ORIGINS']?.length ?? 0,
+      ),
+      nodeEnv: process.env['NODE_ENV'] ?? 'NOT_SET',
+      port: process.env['PORT'] ?? 'NOT_SET',
+    };
+  }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,6 +9,8 @@ async function bootstrap() {
     app.enableCors({
       origin: corsOrigins.split(',').map((o) => o.trim()),
     });
+  } else {
+    app.enableCors();
   }
 
   const port = process.env['PORT'] ?? 3000;


### PR DESCRIPTION
- Rend CORS toujours actif (wildcard si la variable d'env est absente, origins spécifiques sinon)
- Ajoute un endpoint GET /debug/env pour vérifier l'injection des variables d'environnement sur Render
- Corrige le problème: OPTIONS renvoyait 404 car le middleware CORS n'était pas enregistré