### PR TITLE
chore: remove debug/env endpoint after CORS verification

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -9,16 +9,4 @@ export class AppController {
   getHealth(): { status: string } {
     return this.appService.getHealth();
   }
-
-  @Get('debug/env')
-  getDebugEnv(): Record<string, string> {
-    return {
-      corsOriginsSet: process.env['CORS_ALLOWED_ORIGINS'] ? 'true' : 'false',
-      corsOriginsLength: String(
-        process.env['CORS_ALLOWED_ORIGINS']?.length ?? 0,
-      ),
-      nodeEnv: process.env['NODE_ENV'] ?? 'NOT_SET',
-      port: process.env['PORT'] ?? 'NOT_SET',
-    };
-  }
 }


### PR DESCRIPTION
Supprime le endpoint /debug/env temporaire ajouté dans PR #134 pour diagnostiquer l'injection des variables d'environnement sur Render. CORS est maintenant vérifié et fonctionnel.