### PR TITLE
chore: use production build command in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter @kraak/client run build:staging",
+  "buildCommand": "pnpm --filter @kraak/client run build",
   "outputDirectory": "apps/client/dist/web/browser",
   "framework": null
 }


### PR DESCRIPTION
Remplace `build:staging` (script inexistant) par `build` dans le `buildCommand` Vercel.

Le CLI Angular `ng build web` utilise par défaut la configuration de production (remplacement de fichiers d'environnement, budgets, hachage de sortie).