### PR TITLE
feat(contracts): implement shared enums, DTOs, and Zod schemas

### DIFF
--- a/packages/contracts/dto.ts
+++ b/packages/contracts/dto.ts
@@ -1,0 +1,236 @@
+import type {
+  UserRoleValue,
+  LifecycleStatusValue,
+  PublicationStatusValue,
+  ProgramVisibilityValue,
+  CohortStatusValue,
+  SessionStatusValue,
+  LocationTypeValue,
+  ResourceTypeValue,
+  AudienceTypeValue,
+  EnrollmentStatusValue,
+  NotificationTypeValue,
+  NotificationChannelValue,
+  SupportRequestStatusValue,
+  SupportCategoryValue,
+} from './enums';
+
+// ---------------------------------------------------------------------------
+// AppUser
+// ---------------------------------------------------------------------------
+export interface AppUserDto {
+  id: string;
+  email: string;
+  role: UserRoleValue;
+  firstName: string;
+  lastName: string;
+  phone: string | null;
+  preferredContactChannel: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateAppUserDto = Omit<
+  AppUserDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateAppUserDto = Partial<CreateAppUserDto>;
+
+// ---------------------------------------------------------------------------
+// Participant
+// ---------------------------------------------------------------------------
+export interface ParticipantDto {
+  id: string;
+  userId: string;
+  lifecycleStatus: LifecycleStatusValue;
+  referenceCode: string | null;
+  country: string | null;
+  city: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateParticipantDto = Omit<
+  ParticipantDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateParticipantDto = Partial<CreateParticipantDto>;
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+export interface ProgramDto {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  status: PublicationStatusValue;
+  visibility: ProgramVisibilityValue;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateProgramDto = Omit<
+  ProgramDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateProgramDto = Partial<CreateProgramDto>;
+
+// ---------------------------------------------------------------------------
+// Cohort
+// ---------------------------------------------------------------------------
+export interface CohortDto {
+  id: string;
+  programId: string;
+  name: string;
+  code: string | null;
+  status: CohortStatusValue;
+  startDate: string;
+  endDate: string | null;
+  capacity: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateCohortDto = Omit<CohortDto, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateCohortDto = Partial<CreateCohortDto>;
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+export interface SessionDto {
+  id: string;
+  cohortId: string;
+  title: string;
+  description: string | null;
+  status: SessionStatusValue;
+  startsAt: string;
+  endsAt: string;
+  locationType: LocationTypeValue;
+  locationLabel: string | null;
+  meetingLink: string | null;
+  trainerUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateSessionDto = Omit<
+  SessionDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateSessionDto = Partial<CreateSessionDto>;
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+export interface ResourceDto {
+  id: string;
+  programId: string | null;
+  cohortId: string | null;
+  title: string;
+  description: string | null;
+  resourceType: ResourceTypeValue;
+  url: string | null;
+  filePath: string | null;
+  status: PublicationStatusValue;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateResourceDto = Omit<
+  ResourceDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateResourceDto = Partial<CreateResourceDto>;
+
+// ---------------------------------------------------------------------------
+// Announcement
+// ---------------------------------------------------------------------------
+export interface AnnouncementDto {
+  id: string;
+  title: string;
+  body: string;
+  audienceType: AudienceTypeValue;
+  programId: string | null;
+  cohortId: string | null;
+  status: PublicationStatusValue;
+  publishedAt: string | null;
+  createdByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateAnnouncementDto = Omit<
+  AnnouncementDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateAnnouncementDto = Partial<CreateAnnouncementDto>;
+
+// ---------------------------------------------------------------------------
+// Enrollment
+// ---------------------------------------------------------------------------
+export interface EnrollmentDto {
+  id: string;
+  participantId: string;
+  programId: string;
+  cohortId: string | null;
+  status: EnrollmentStatusValue;
+  enrolledAt: string;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateEnrollmentDto = Omit<
+  EnrollmentDto,
+  'id' | 'createdAt' | 'updatedAt' | 'enrolledAt'
+>;
+export type UpdateEnrollmentDto = Partial<CreateEnrollmentDto>;
+
+// ---------------------------------------------------------------------------
+// Notification (immutable — no UpdateDto, no updatedAt)
+// ---------------------------------------------------------------------------
+export interface NotificationDto {
+  id: string;
+  userId: string;
+  title: string;
+  body: string;
+  notificationType: NotificationTypeValue;
+  channel: NotificationChannelValue;
+  isRead: boolean;
+  readAt: string | null;
+  sourceType: string | null;
+  sourceId: string | null;
+  createdAt: string;
+}
+
+export type CreateNotificationDto = Omit<
+  NotificationDto,
+  'id' | 'createdAt' | 'isRead' | 'readAt'
+>;
+
+// ---------------------------------------------------------------------------
+// SupportRequest
+// ---------------------------------------------------------------------------
+export interface SupportRequestDto {
+  id: string;
+  userId: string;
+  participantId: string | null;
+  subject: string;
+  message: string;
+  status: SupportRequestStatusValue;
+  category: SupportCategoryValue;
+  assignedToUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateSupportRequestDto = Omit<
+  SupportRequestDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateSupportRequestDto = Partial<CreateSupportRequestDto>;

--- a/packages/contracts/enums.ts
+++ b/packages/contracts/enums.ts
@@ -1,0 +1,122 @@
+export const UserRole = {
+  PARTICIPANT: 'participant',
+  ADMIN: 'admin',
+  TRAINER: 'trainer',
+} as const;
+
+export const LifecycleStatus = {
+  INVITED: 'invited',
+  REGISTERED: 'registered',
+  ACTIVE: 'active',
+  COMPLETED: 'completed',
+  INACTIVE: 'inactive',
+} as const;
+
+export const PublicationStatus = {
+  DRAFT: 'draft',
+  PUBLISHED: 'published',
+  ARCHIVED: 'archived',
+} as const;
+
+export const ProgramVisibility = {
+  PRIVATE: 'private',
+  PARTICIPANTS: 'participants',
+  PUBLIC: 'public',
+} as const;
+
+export const CohortStatus = {
+  DRAFT: 'draft',
+  OPEN: 'open',
+  ACTIVE: 'active',
+  COMPLETED: 'completed',
+  ARCHIVED: 'archived',
+} as const;
+
+export const SessionStatus = {
+  SCHEDULED: 'scheduled',
+  LIVE: 'live',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+} as const;
+
+export const LocationType = {
+  ONLINE: 'online',
+  ONSITE: 'onsite',
+  HYBRID: 'hybrid',
+} as const;
+
+export const ResourceType = {
+  LINK: 'link',
+  FILE: 'file',
+  VIDEO: 'video',
+  DOCUMENT: 'document',
+} as const;
+
+export const AudienceType = {
+  ALL_PARTICIPANTS: 'all_participants',
+  PROGRAM: 'program',
+  COHORT: 'cohort',
+  CUSTOM: 'custom',
+} as const;
+
+export const EnrollmentStatus = {
+  PENDING: 'pending',
+  ACTIVE: 'active',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+} as const;
+
+export const NotificationType = {
+  ANNOUNCEMENT: 'announcement',
+  SESSION_REMINDER: 'session_reminder',
+  SYSTEM: 'system',
+  SUPPORT_UPDATE: 'support_update',
+} as const;
+
+export const NotificationChannel = {
+  IN_APP: 'in_app',
+  PUSH: 'push',
+} as const;
+
+export const SupportRequestStatus = {
+  OPEN: 'open',
+  IN_PROGRESS: 'in_progress',
+  RESOLVED: 'resolved',
+  CLOSED: 'closed',
+} as const;
+
+export const SupportCategory = {
+  TECHNICAL: 'technical',
+  PROGRAM: 'program',
+  SESSION: 'session',
+  BILLING: 'billing',
+  OTHER: 'other',
+} as const;
+
+export type UserRoleValue = (typeof UserRole)[keyof typeof UserRole];
+export type LifecycleStatusValue =
+  (typeof LifecycleStatus)[keyof typeof LifecycleStatus];
+export type PublicationStatusValue =
+  (typeof PublicationStatus)[keyof typeof PublicationStatus];
+export type ProgramVisibilityValue =
+  (typeof ProgramVisibility)[keyof typeof ProgramVisibility];
+export type CohortStatusValue =
+  (typeof CohortStatus)[keyof typeof CohortStatus];
+export type SessionStatusValue =
+  (typeof SessionStatus)[keyof typeof SessionStatus];
+export type LocationTypeValue =
+  (typeof LocationType)[keyof typeof LocationType];
+export type ResourceTypeValue =
+  (typeof ResourceType)[keyof typeof ResourceType];
+export type AudienceTypeValue =
+  (typeof AudienceType)[keyof typeof AudienceType];
+export type EnrollmentStatusValue =
+  (typeof EnrollmentStatus)[keyof typeof EnrollmentStatus];
+export type NotificationTypeValue =
+  (typeof NotificationType)[keyof typeof NotificationType];
+export type NotificationChannelValue =
+  (typeof NotificationChannel)[keyof typeof NotificationChannel];
+export type SupportRequestStatusValue =
+  (typeof SupportRequestStatus)[keyof typeof SupportRequestStatus];
+export type SupportCategoryValue =
+  (typeof SupportCategory)[keyof typeof SupportCategory];

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@kraak/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.8",
+    "typescript": "~5.8.3"
+  },
+  "dependencies": {
+    "zod": "^3.25.67"
+  }
+}

--- a/packages/contracts/schemas.ts
+++ b/packages/contracts/schemas.ts
@@ -1,0 +1,258 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// AppUser
+// ---------------------------------------------------------------------------
+export const AppUserSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  role: z.enum(['participant', 'admin', 'trainer']),
+  firstName: z.string(),
+  lastName: z.string(),
+  phone: z.string().nullable(),
+  preferredContactChannel: z.string().nullable(),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateAppUserSchema = AppUserSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateAppUserSchema = CreateAppUserSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Participant
+// ---------------------------------------------------------------------------
+export const ParticipantSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  lifecycleStatus: z.enum([
+    'invited',
+    'registered',
+    'active',
+    'completed',
+    'inactive',
+  ]),
+  referenceCode: z.string().nullable(),
+  country: z.string().nullable(),
+  city: z.string().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateParticipantSchema = ParticipantSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateParticipantSchema = CreateParticipantSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+export const ProgramSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  summary: z.string(),
+  description: z.string(),
+  status: z.enum(['draft', 'published', 'archived']),
+  visibility: z.enum(['private', 'participants', 'public']),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateProgramSchema = ProgramSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateProgramSchema = CreateProgramSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Cohort
+// ---------------------------------------------------------------------------
+export const CohortSchema = z.object({
+  id: z.string(),
+  programId: z.string(),
+  name: z.string(),
+  code: z.string().nullable(),
+  status: z.enum(['draft', 'open', 'active', 'completed', 'archived']),
+  startDate: z.string(),
+  endDate: z.string().nullable(),
+  capacity: z.number().int().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateCohortSchema = CohortSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateCohortSchema = CreateCohortSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+export const SessionSchema = z.object({
+  id: z.string(),
+  cohortId: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  status: z.enum(['scheduled', 'live', 'completed', 'cancelled']),
+  startsAt: z.string(),
+  endsAt: z.string(),
+  locationType: z.enum(['online', 'onsite', 'hybrid']),
+  locationLabel: z.string().nullable(),
+  meetingLink: z.string().nullable(),
+  trainerUserId: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateSessionSchema = SessionSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateSessionSchema = CreateSessionSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+export const ResourceSchema = z.object({
+  id: z.string(),
+  programId: z.string().nullable(),
+  cohortId: z.string().nullable(),
+  title: z.string(),
+  description: z.string().nullable(),
+  resourceType: z.enum(['link', 'file', 'video', 'document']),
+  url: z.string().nullable(),
+  filePath: z.string().nullable(),
+  status: z.enum(['draft', 'published', 'archived']),
+  publishedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateResourceSchema = ResourceSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateResourceSchema = CreateResourceSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Announcement
+// ---------------------------------------------------------------------------
+export const AnnouncementSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  body: z.string(),
+  audienceType: z.enum(['all_participants', 'program', 'cohort', 'custom']),
+  programId: z.string().nullable(),
+  cohortId: z.string().nullable(),
+  status: z.enum(['draft', 'published', 'archived']),
+  publishedAt: z.string().nullable(),
+  createdByUserId: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateAnnouncementSchema = AnnouncementSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateAnnouncementSchema = CreateAnnouncementSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Enrollment
+// ---------------------------------------------------------------------------
+export const EnrollmentSchema = z.object({
+  id: z.string(),
+  participantId: z.string(),
+  programId: z.string(),
+  cohortId: z.string().nullable(),
+  status: z.enum(['pending', 'active', 'completed', 'cancelled']),
+  enrolledAt: z.string(),
+  completedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateEnrollmentSchema = EnrollmentSchema.omit({
+  id: true,
+  enrolledAt: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateEnrollmentSchema = CreateEnrollmentSchema.partial();
+
+// ---------------------------------------------------------------------------
+// Notification (immutable — pas de updatedAt, pas de Update schema)
+// ---------------------------------------------------------------------------
+export const NotificationSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+    title: z.string(),
+    body: z.string(),
+    notificationType: z.enum([
+      'announcement',
+      'session_reminder',
+      'system',
+      'support_update',
+    ]),
+    channel: z.enum(['in_app', 'push']),
+    isRead: z.boolean(),
+    readAt: z.string().nullable(),
+    sourceType: z.string().nullable(),
+    sourceId: z.string().nullable(),
+    createdAt: z.string(),
+  })
+  .strict();
+
+export const CreateNotificationSchema = NotificationSchema.omit({
+  id: true,
+  isRead: true,
+  readAt: true,
+  createdAt: true,
+});
+
+// ---------------------------------------------------------------------------
+// SupportRequest
+// ---------------------------------------------------------------------------
+export const SupportRequestSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  participantId: z.string().nullable(),
+  subject: z.string(),
+  message: z.string(),
+  status: z.enum(['open', 'in_progress', 'resolved', 'closed']),
+  category: z.enum(['technical', 'program', 'session', 'billing', 'other']),
+  assignedToUserId: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const CreateSupportRequestSchema = SupportRequestSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateSupportRequestSchema = CreateSupportRequestSchema.partial();

--- a/packages/contracts/src/dto.spec.ts
+++ b/packages/contracts/src/dto.spec.ts
@@ -1,0 +1,499 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type {
+  AppUserDto,
+  CreateAppUserDto,
+  UpdateAppUserDto,
+  ParticipantDto,
+  CreateParticipantDto,
+  UpdateParticipantDto,
+  ProgramDto,
+  CreateProgramDto,
+  UpdateProgramDto,
+  CohortDto,
+  CreateCohortDto,
+  UpdateCohortDto,
+  SessionDto,
+  CreateSessionDto,
+  UpdateSessionDto,
+  ResourceDto,
+  CreateResourceDto,
+  UpdateResourceDto,
+  AnnouncementDto,
+  CreateAnnouncementDto,
+  UpdateAnnouncementDto,
+  EnrollmentDto,
+  CreateEnrollmentDto,
+  UpdateEnrollmentDto,
+  NotificationDto,
+  CreateNotificationDto,
+  SupportRequestDto,
+  CreateSupportRequestDto,
+  UpdateSupportRequestDto,
+} from '../dto';
+
+// Runtime import to ensure the module actually exists (prevents vacuous type test passes)
+import * as dtoModule from '../dto';
+import type {
+  UserRoleValue,
+  LifecycleStatusValue,
+  PublicationStatusValue,
+  ProgramVisibilityValue,
+  CohortStatusValue,
+  SessionStatusValue,
+  LocationTypeValue,
+  ResourceTypeValue,
+  AudienceTypeValue,
+  EnrollmentStatusValue,
+  NotificationTypeValue,
+  NotificationChannelValue,
+  SupportRequestStatusValue,
+  SupportCategoryValue,
+} from '../enums';
+
+// ---------------------------------------------------------------------------
+// Module existence smoke test
+// ---------------------------------------------------------------------------
+describe('dto module', () => {
+  it('should be importable at runtime', () => {
+    expect(dtoModule).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AppUser
+// ---------------------------------------------------------------------------
+describe('AppUserDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<AppUserDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<AppUserDto>().toHaveProperty('email').toBeString();
+    expectTypeOf<AppUserDto>()
+      .toHaveProperty('role')
+      .toEqualTypeOf<UserRoleValue>();
+    expectTypeOf<AppUserDto>().toHaveProperty('firstName').toBeString();
+    expectTypeOf<AppUserDto>().toHaveProperty('lastName').toBeString();
+    expectTypeOf<AppUserDto>()
+      .toHaveProperty('phone')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AppUserDto>()
+      .toHaveProperty('preferredContactChannel')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AppUserDto>().toHaveProperty('isActive').toBeBoolean();
+    expectTypeOf<AppUserDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<AppUserDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateAppUserDto should omit server-generated fields', () => {
+    expectTypeOf<CreateAppUserDto>().toHaveProperty('email').toBeString();
+    expectTypeOf<CreateAppUserDto>().toHaveProperty('firstName').toBeString();
+    expectTypeOf<CreateAppUserDto>().toHaveProperty('lastName').toBeString();
+    expectTypeOf<CreateAppUserDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateAppUserDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateAppUserDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateAppUserDto should have all fields optional', () => {
+    expectTypeOf<UpdateAppUserDto>().toMatchTypeOf<Partial<CreateAppUserDto>>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Participant
+// ---------------------------------------------------------------------------
+describe('ParticipantDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<ParticipantDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<ParticipantDto>().toHaveProperty('userId').toBeString();
+    expectTypeOf<ParticipantDto>()
+      .toHaveProperty('lifecycleStatus')
+      .toEqualTypeOf<LifecycleStatusValue>();
+    expectTypeOf<ParticipantDto>()
+      .toHaveProperty('referenceCode')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ParticipantDto>()
+      .toHaveProperty('country')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ParticipantDto>()
+      .toHaveProperty('city')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ParticipantDto>()
+      .toHaveProperty('notes')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ParticipantDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<ParticipantDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateParticipantDto should omit server-generated fields', () => {
+    expectTypeOf<CreateParticipantDto>().toHaveProperty('userId').toBeString();
+    expectTypeOf<CreateParticipantDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateParticipantDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateParticipantDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateParticipantDto should have all fields optional', () => {
+    expectTypeOf<UpdateParticipantDto>().toMatchTypeOf<
+      Partial<CreateParticipantDto>
+    >();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+describe('ProgramDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<ProgramDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<ProgramDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<ProgramDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<ProgramDto>().toHaveProperty('summary').toBeString();
+    expectTypeOf<ProgramDto>().toHaveProperty('description').toBeString();
+    expectTypeOf<ProgramDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<PublicationStatusValue>();
+    expectTypeOf<ProgramDto>()
+      .toHaveProperty('visibility')
+      .toEqualTypeOf<ProgramVisibilityValue>();
+    expectTypeOf<ProgramDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<ProgramDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateProgramDto should omit server-generated fields', () => {
+    expectTypeOf<CreateProgramDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<CreateProgramDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<CreateProgramDto>().toHaveProperty('summary').toBeString();
+    expectTypeOf<CreateProgramDto>().toHaveProperty('description').toBeString();
+    expectTypeOf<CreateProgramDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateProgramDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateProgramDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateProgramDto should have all fields optional', () => {
+    expectTypeOf<UpdateProgramDto>().toMatchTypeOf<Partial<CreateProgramDto>>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cohort
+// ---------------------------------------------------------------------------
+describe('CohortDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<CohortDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<CohortDto>().toHaveProperty('programId').toBeString();
+    expectTypeOf<CohortDto>().toHaveProperty('name').toBeString();
+    expectTypeOf<CohortDto>()
+      .toHaveProperty('code')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<CohortDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<CohortStatusValue>();
+    expectTypeOf<CohortDto>().toHaveProperty('startDate').toBeString();
+    expectTypeOf<CohortDto>()
+      .toHaveProperty('endDate')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<CohortDto>()
+      .toHaveProperty('capacity')
+      .toEqualTypeOf<number | null>();
+    expectTypeOf<CohortDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<CohortDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateCohortDto should omit server-generated fields', () => {
+    expectTypeOf<CreateCohortDto>().toHaveProperty('programId').toBeString();
+    expectTypeOf<CreateCohortDto>().toHaveProperty('name').toBeString();
+    expectTypeOf<CreateCohortDto>().toHaveProperty('startDate').toBeString();
+    expectTypeOf<CreateCohortDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateCohortDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateCohortDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateCohortDto should have all fields optional', () => {
+    expectTypeOf<UpdateCohortDto>().toMatchTypeOf<Partial<CreateCohortDto>>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+describe('SessionDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<SessionDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<SessionDto>().toHaveProperty('cohortId').toBeString();
+    expectTypeOf<SessionDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<SessionDto>()
+      .toHaveProperty('description')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<SessionDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<SessionStatusValue>();
+    expectTypeOf<SessionDto>().toHaveProperty('startsAt').toBeString();
+    expectTypeOf<SessionDto>().toHaveProperty('endsAt').toBeString();
+    expectTypeOf<SessionDto>()
+      .toHaveProperty('locationType')
+      .toEqualTypeOf<LocationTypeValue>();
+    expectTypeOf<SessionDto>()
+      .toHaveProperty('locationLabel')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<SessionDto>()
+      .toHaveProperty('meetingLink')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<SessionDto>()
+      .toHaveProperty('trainerUserId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<SessionDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<SessionDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateSessionDto should omit server-generated fields', () => {
+    expectTypeOf<CreateSessionDto>().toHaveProperty('cohortId').toBeString();
+    expectTypeOf<CreateSessionDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<CreateSessionDto>().toHaveProperty('startsAt').toBeString();
+    expectTypeOf<CreateSessionDto>().toHaveProperty('endsAt').toBeString();
+    expectTypeOf<CreateSessionDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateSessionDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateSessionDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateSessionDto should have all fields optional', () => {
+    expectTypeOf<UpdateSessionDto>().toMatchTypeOf<Partial<CreateSessionDto>>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+describe('ResourceDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<ResourceDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('programId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('cohortId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ResourceDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('description')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('resourceType')
+      .toEqualTypeOf<ResourceTypeValue>();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('url')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('filePath')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<PublicationStatusValue>();
+    expectTypeOf<ResourceDto>()
+      .toHaveProperty('publishedAt')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ResourceDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<ResourceDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateResourceDto should omit server-generated fields', () => {
+    expectTypeOf<CreateResourceDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<CreateResourceDto>()
+      .toHaveProperty('resourceType')
+      .toEqualTypeOf<ResourceTypeValue>();
+    expectTypeOf<CreateResourceDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateResourceDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateResourceDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateResourceDto should have all fields optional', () => {
+    expectTypeOf<UpdateResourceDto>().toMatchTypeOf<
+      Partial<CreateResourceDto>
+    >();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Announcement
+// ---------------------------------------------------------------------------
+describe('AnnouncementDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<AnnouncementDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<AnnouncementDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<AnnouncementDto>().toHaveProperty('body').toBeString();
+    expectTypeOf<AnnouncementDto>()
+      .toHaveProperty('audienceType')
+      .toEqualTypeOf<AudienceTypeValue>();
+    expectTypeOf<AnnouncementDto>()
+      .toHaveProperty('programId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AnnouncementDto>()
+      .toHaveProperty('cohortId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AnnouncementDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<PublicationStatusValue>();
+    expectTypeOf<AnnouncementDto>()
+      .toHaveProperty('publishedAt')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AnnouncementDto>()
+      .toHaveProperty('createdByUserId')
+      .toBeString();
+    expectTypeOf<AnnouncementDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<AnnouncementDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateAnnouncementDto should omit server-generated fields', () => {
+    expectTypeOf<CreateAnnouncementDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<CreateAnnouncementDto>().toHaveProperty('body').toBeString();
+    expectTypeOf<CreateAnnouncementDto>()
+      .toHaveProperty('audienceType')
+      .toEqualTypeOf<AudienceTypeValue>();
+    expectTypeOf<CreateAnnouncementDto>()
+      .toHaveProperty('createdByUserId')
+      .toBeString();
+    expectTypeOf<CreateAnnouncementDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateAnnouncementDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateAnnouncementDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateAnnouncementDto should have all fields optional', () => {
+    expectTypeOf<UpdateAnnouncementDto>().toMatchTypeOf<
+      Partial<CreateAnnouncementDto>
+    >();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enrollment
+// ---------------------------------------------------------------------------
+describe('EnrollmentDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<EnrollmentDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<EnrollmentDto>().toHaveProperty('participantId').toBeString();
+    expectTypeOf<EnrollmentDto>().toHaveProperty('programId').toBeString();
+    expectTypeOf<EnrollmentDto>()
+      .toHaveProperty('cohortId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<EnrollmentDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<EnrollmentStatusValue>();
+    expectTypeOf<EnrollmentDto>().toHaveProperty('enrolledAt').toBeString();
+    expectTypeOf<EnrollmentDto>()
+      .toHaveProperty('completedAt')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<EnrollmentDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<EnrollmentDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateEnrollmentDto should omit server-generated fields', () => {
+    expectTypeOf<CreateEnrollmentDto>()
+      .toHaveProperty('participantId')
+      .toBeString();
+    expectTypeOf<CreateEnrollmentDto>()
+      .toHaveProperty('programId')
+      .toBeString();
+    expectTypeOf<CreateEnrollmentDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateEnrollmentDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateEnrollmentDto>().not.toHaveProperty('updatedAt');
+    expectTypeOf<CreateEnrollmentDto>().not.toHaveProperty('enrolledAt');
+  });
+
+  it('UpdateEnrollmentDto should have all fields optional', () => {
+    expectTypeOf<UpdateEnrollmentDto>().toMatchTypeOf<
+      Partial<CreateEnrollmentDto>
+    >();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification (no UpdateDto — notifications are immutable)
+// ---------------------------------------------------------------------------
+describe('NotificationDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<NotificationDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<NotificationDto>().toHaveProperty('userId').toBeString();
+    expectTypeOf<NotificationDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<NotificationDto>().toHaveProperty('body').toBeString();
+    expectTypeOf<NotificationDto>()
+      .toHaveProperty('notificationType')
+      .toEqualTypeOf<NotificationTypeValue>();
+    expectTypeOf<NotificationDto>()
+      .toHaveProperty('channel')
+      .toEqualTypeOf<NotificationChannelValue>();
+    expectTypeOf<NotificationDto>().toHaveProperty('isRead').toBeBoolean();
+    expectTypeOf<NotificationDto>()
+      .toHaveProperty('readAt')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<NotificationDto>()
+      .toHaveProperty('sourceType')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<NotificationDto>()
+      .toHaveProperty('sourceId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<NotificationDto>().toHaveProperty('createdAt').toBeString();
+  });
+
+  it('should not have updatedAt (notifications are immutable)', () => {
+    expectTypeOf<NotificationDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('CreateNotificationDto should omit server-generated fields', () => {
+    expectTypeOf<CreateNotificationDto>().toHaveProperty('userId').toBeString();
+    expectTypeOf<CreateNotificationDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<CreateNotificationDto>().toHaveProperty('body').toBeString();
+    expectTypeOf<CreateNotificationDto>()
+      .toHaveProperty('notificationType')
+      .toEqualTypeOf<NotificationTypeValue>();
+    expectTypeOf<CreateNotificationDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateNotificationDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateNotificationDto>().not.toHaveProperty('isRead');
+    expectTypeOf<CreateNotificationDto>().not.toHaveProperty('readAt');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupportRequest
+// ---------------------------------------------------------------------------
+describe('SupportRequestDto', () => {
+  it('should have all required fields with correct types', () => {
+    expectTypeOf<SupportRequestDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<SupportRequestDto>().toHaveProperty('userId').toBeString();
+    expectTypeOf<SupportRequestDto>()
+      .toHaveProperty('participantId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<SupportRequestDto>().toHaveProperty('subject').toBeString();
+    expectTypeOf<SupportRequestDto>().toHaveProperty('message').toBeString();
+    expectTypeOf<SupportRequestDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<SupportRequestStatusValue>();
+    expectTypeOf<SupportRequestDto>()
+      .toHaveProperty('category')
+      .toEqualTypeOf<SupportCategoryValue>();
+    expectTypeOf<SupportRequestDto>()
+      .toHaveProperty('assignedToUserId')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<SupportRequestDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<SupportRequestDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('CreateSupportRequestDto should omit server-generated fields', () => {
+    expectTypeOf<CreateSupportRequestDto>()
+      .toHaveProperty('userId')
+      .toBeString();
+    expectTypeOf<CreateSupportRequestDto>()
+      .toHaveProperty('subject')
+      .toBeString();
+    expectTypeOf<CreateSupportRequestDto>()
+      .toHaveProperty('message')
+      .toBeString();
+    expectTypeOf<CreateSupportRequestDto>()
+      .toHaveProperty('category')
+      .toEqualTypeOf<SupportCategoryValue>();
+    expectTypeOf<CreateSupportRequestDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateSupportRequestDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateSupportRequestDto>().not.toHaveProperty('updatedAt');
+  });
+
+  it('UpdateSupportRequestDto should have all fields optional', () => {
+    expectTypeOf<UpdateSupportRequestDto>().toMatchTypeOf<
+      Partial<CreateSupportRequestDto>
+    >();
+  });
+});

--- a/packages/contracts/src/enums.spec.ts
+++ b/packages/contracts/src/enums.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  UserRole,
+  LifecycleStatus,
+  PublicationStatus,
+  ProgramVisibility,
+  CohortStatus,
+  SessionStatus,
+  LocationType,
+  ResourceType,
+  AudienceType,
+  EnrollmentStatus,
+  NotificationType,
+  NotificationChannel,
+  SupportRequestStatus,
+  SupportCategory,
+} from '../enums';
+
+describe('Enums', () => {
+  describe('UserRole', () => {
+    it('devrait contenir les rôles participant, admin, trainer', () => {
+      expect(UserRole.PARTICIPANT).toBe('participant');
+      expect(UserRole.ADMIN).toBe('admin');
+      expect(UserRole.TRAINER).toBe('trainer');
+    });
+
+    it('devrait avoir exactement 3 valeurs', () => {
+      expect(Object.values(UserRole)).toHaveLength(3);
+    });
+  });
+
+  describe('LifecycleStatus', () => {
+    it('devrait contenir les statuts de cycle de vie', () => {
+      expect(LifecycleStatus.INVITED).toBe('invited');
+      expect(LifecycleStatus.REGISTERED).toBe('registered');
+      expect(LifecycleStatus.ACTIVE).toBe('active');
+      expect(LifecycleStatus.COMPLETED).toBe('completed');
+      expect(LifecycleStatus.INACTIVE).toBe('inactive');
+    });
+
+    it('devrait avoir exactement 5 valeurs', () => {
+      expect(Object.values(LifecycleStatus)).toHaveLength(5);
+    });
+  });
+
+  describe('PublicationStatus', () => {
+    it('devrait contenir draft, published, archived', () => {
+      expect(PublicationStatus.DRAFT).toBe('draft');
+      expect(PublicationStatus.PUBLISHED).toBe('published');
+      expect(PublicationStatus.ARCHIVED).toBe('archived');
+    });
+
+    it('devrait avoir exactement 3 valeurs', () => {
+      expect(Object.values(PublicationStatus)).toHaveLength(3);
+    });
+  });
+
+  describe('ProgramVisibility', () => {
+    it('devrait contenir private, participants, public', () => {
+      expect(ProgramVisibility.PRIVATE).toBe('private');
+      expect(ProgramVisibility.PARTICIPANTS).toBe('participants');
+      expect(ProgramVisibility.PUBLIC).toBe('public');
+    });
+
+    it('devrait avoir exactement 3 valeurs', () => {
+      expect(Object.values(ProgramVisibility)).toHaveLength(3);
+    });
+  });
+
+  describe('CohortStatus', () => {
+    it('devrait contenir les statuts de cohorte', () => {
+      expect(CohortStatus.DRAFT).toBe('draft');
+      expect(CohortStatus.OPEN).toBe('open');
+      expect(CohortStatus.ACTIVE).toBe('active');
+      expect(CohortStatus.COMPLETED).toBe('completed');
+      expect(CohortStatus.ARCHIVED).toBe('archived');
+    });
+
+    it('devrait avoir exactement 5 valeurs', () => {
+      expect(Object.values(CohortStatus)).toHaveLength(5);
+    });
+  });
+
+  describe('SessionStatus', () => {
+    it('devrait contenir les statuts de session', () => {
+      expect(SessionStatus.SCHEDULED).toBe('scheduled');
+      expect(SessionStatus.LIVE).toBe('live');
+      expect(SessionStatus.COMPLETED).toBe('completed');
+      expect(SessionStatus.CANCELLED).toBe('cancelled');
+    });
+
+    it('devrait avoir exactement 4 valeurs', () => {
+      expect(Object.values(SessionStatus)).toHaveLength(4);
+    });
+  });
+
+  describe('LocationType', () => {
+    it('devrait contenir online, onsite, hybrid', () => {
+      expect(LocationType.ONLINE).toBe('online');
+      expect(LocationType.ONSITE).toBe('onsite');
+      expect(LocationType.HYBRID).toBe('hybrid');
+    });
+
+    it('devrait avoir exactement 3 valeurs', () => {
+      expect(Object.values(LocationType)).toHaveLength(3);
+    });
+  });
+
+  describe('ResourceType', () => {
+    it('devrait contenir les types de ressource', () => {
+      expect(ResourceType.LINK).toBe('link');
+      expect(ResourceType.FILE).toBe('file');
+      expect(ResourceType.VIDEO).toBe('video');
+      expect(ResourceType.DOCUMENT).toBe('document');
+    });
+
+    it('devrait avoir exactement 4 valeurs', () => {
+      expect(Object.values(ResourceType)).toHaveLength(4);
+    });
+  });
+
+  describe('AudienceType', () => {
+    it("devrait contenir les types d'audience", () => {
+      expect(AudienceType.ALL_PARTICIPANTS).toBe('all_participants');
+      expect(AudienceType.PROGRAM).toBe('program');
+      expect(AudienceType.COHORT).toBe('cohort');
+      expect(AudienceType.CUSTOM).toBe('custom');
+    });
+
+    it('devrait avoir exactement 4 valeurs', () => {
+      expect(Object.values(AudienceType)).toHaveLength(4);
+    });
+  });
+
+  describe('EnrollmentStatus', () => {
+    it("devrait contenir les statuts d'inscription", () => {
+      expect(EnrollmentStatus.PENDING).toBe('pending');
+      expect(EnrollmentStatus.ACTIVE).toBe('active');
+      expect(EnrollmentStatus.COMPLETED).toBe('completed');
+      expect(EnrollmentStatus.CANCELLED).toBe('cancelled');
+    });
+
+    it('devrait avoir exactement 4 valeurs', () => {
+      expect(Object.values(EnrollmentStatus)).toHaveLength(4);
+    });
+  });
+
+  describe('NotificationType', () => {
+    it('devrait contenir les types de notification', () => {
+      expect(NotificationType.ANNOUNCEMENT).toBe('announcement');
+      expect(NotificationType.SESSION_REMINDER).toBe('session_reminder');
+      expect(NotificationType.SYSTEM).toBe('system');
+      expect(NotificationType.SUPPORT_UPDATE).toBe('support_update');
+    });
+
+    it('devrait avoir exactement 4 valeurs', () => {
+      expect(Object.values(NotificationType)).toHaveLength(4);
+    });
+  });
+
+  describe('NotificationChannel', () => {
+    it('devrait contenir in_app, push', () => {
+      expect(NotificationChannel.IN_APP).toBe('in_app');
+      expect(NotificationChannel.PUSH).toBe('push');
+    });
+
+    it('devrait avoir exactement 2 valeurs', () => {
+      expect(Object.values(NotificationChannel)).toHaveLength(2);
+    });
+  });
+
+  describe('SupportRequestStatus', () => {
+    it('devrait contenir les statuts de demande de support', () => {
+      expect(SupportRequestStatus.OPEN).toBe('open');
+      expect(SupportRequestStatus.IN_PROGRESS).toBe('in_progress');
+      expect(SupportRequestStatus.RESOLVED).toBe('resolved');
+      expect(SupportRequestStatus.CLOSED).toBe('closed');
+    });
+
+    it('devrait avoir exactement 4 valeurs', () => {
+      expect(Object.values(SupportRequestStatus)).toHaveLength(4);
+    });
+  });
+
+  describe('SupportCategory', () => {
+    it('devrait contenir les catégories de support', () => {
+      expect(SupportCategory.TECHNICAL).toBe('technical');
+      expect(SupportCategory.PROGRAM).toBe('program');
+      expect(SupportCategory.SESSION).toBe('session');
+      expect(SupportCategory.BILLING).toBe('billing');
+      expect(SupportCategory.OTHER).toBe('other');
+    });
+
+    it('devrait avoir exactement 5 valeurs', () => {
+      expect(Object.values(SupportCategory)).toHaveLength(5);
+    });
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,3 @@
+export * from '../enums';
+export * from '../dto';
+export * from '../schemas';

--- a/packages/contracts/src/schemas.spec.ts
+++ b/packages/contracts/src/schemas.spec.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect } from 'vitest';
+import * as schemasModule from '../schemas';
+import {
+  CreateAppUserSchema,
+  CreateParticipantSchema,
+  CreateProgramSchema,
+  CreateCohortSchema,
+  CreateSessionSchema,
+  CreateResourceSchema,
+  CreateAnnouncementSchema,
+  CreateEnrollmentSchema,
+  CreateNotificationSchema,
+  CreateSupportRequestSchema,
+  UpdateAppUserSchema,
+  UpdateParticipantSchema,
+  UpdateProgramSchema,
+  UpdateCohortSchema,
+  UpdateSessionSchema,
+  UpdateResourceSchema,
+  UpdateAnnouncementSchema,
+  UpdateEnrollmentSchema,
+  UpdateSupportRequestSchema,
+  AppUserSchema,
+  ParticipantSchema,
+  ProgramSchema,
+  CohortSchema,
+  SessionSchema,
+  ResourceSchema,
+  AnnouncementSchema,
+  EnrollmentSchema,
+  NotificationSchema,
+  SupportRequestSchema,
+} from '../schemas';
+
+// ---------------------------------------------------------------------------
+// Module resolution smoke test
+// ---------------------------------------------------------------------------
+describe('schemas module', () => {
+  it('should be importable at runtime', () => {
+    expect(schemasModule).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AppUser
+// ---------------------------------------------------------------------------
+describe('CreateAppUserSchema', () => {
+  const valid = {
+    email: 'alice@example.com',
+    role: 'participant',
+    firstName: 'Alice',
+    lastName: 'Dupont',
+    phone: null,
+    preferredContactChannel: null,
+    isActive: true,
+  };
+
+  it('should accept valid data', () => {
+    const result = CreateAppUserSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing required fields', () => {
+    const result = CreateAppUserSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid role', () => {
+    const result = CreateAppUserSchema.safeParse({
+      ...valid,
+      role: 'superadmin',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid email', () => {
+    const result = CreateAppUserSchema.safeParse({
+      ...valid,
+      email: 'not-an-email',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('UpdateAppUserSchema', () => {
+  it('should accept partial data', () => {
+    const result = UpdateAppUserSchema.safeParse({ firstName: 'Bob' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept empty object', () => {
+    const result = UpdateAppUserSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('AppUserSchema', () => {
+  it('should accept a full entity', () => {
+    const result = AppUserSchema.safeParse({
+      id: 'a1b2c3',
+      email: 'alice@example.com',
+      role: 'admin',
+      firstName: 'Alice',
+      lastName: 'Dupont',
+      phone: '+33612345678',
+      preferredContactChannel: 'email',
+      isActive: true,
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing id', () => {
+    const result = AppUserSchema.safeParse({
+      email: 'alice@example.com',
+      role: 'admin',
+      firstName: 'Alice',
+      lastName: 'Dupont',
+      phone: null,
+      preferredContactChannel: null,
+      isActive: true,
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Participant
+// ---------------------------------------------------------------------------
+describe('CreateParticipantSchema', () => {
+  const valid = {
+    userId: 'user-1',
+    lifecycleStatus: 'invited',
+    referenceCode: null,
+    country: null,
+    city: null,
+    notes: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateParticipantSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid lifecycleStatus', () => {
+    expect(
+      CreateParticipantSchema.safeParse({
+        ...valid,
+        lifecycleStatus: 'unknown',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateParticipantSchema', () => {
+  it('should accept partial data', () => {
+    expect(
+      UpdateParticipantSchema.safeParse({ city: 'Montréal' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('ParticipantSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      ParticipantSchema.safeParse({
+        id: 'p-1',
+        userId: 'user-1',
+        lifecycleStatus: 'active',
+        referenceCode: 'REF-001',
+        country: 'CA',
+        city: 'Montréal',
+        notes: null,
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+describe('CreateProgramSchema', () => {
+  const valid = {
+    slug: 'formation-leadership',
+    title: 'Formation Leadership',
+    summary: 'Résumé du programme',
+    description: 'Description complète',
+    status: 'draft',
+    visibility: 'private',
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateProgramSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid status', () => {
+    expect(
+      CreateProgramSchema.safeParse({ ...valid, status: 'deleted' }).success,
+    ).toBe(false);
+  });
+
+  it('should reject invalid visibility', () => {
+    expect(
+      CreateProgramSchema.safeParse({ ...valid, visibility: 'secret' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateProgramSchema', () => {
+  it('should accept partial data', () => {
+    expect(
+      UpdateProgramSchema.safeParse({ title: 'Nouveau titre' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('ProgramSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      ProgramSchema.safeParse({
+        id: 'prg-1',
+        slug: 'formation-leadership',
+        title: 'Formation Leadership',
+        summary: 'Résumé',
+        description: 'Description',
+        status: 'published',
+        visibility: 'public',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cohort
+// ---------------------------------------------------------------------------
+describe('CreateCohortSchema', () => {
+  const valid = {
+    programId: 'prg-1',
+    name: 'Cohorte A',
+    code: null,
+    status: 'draft',
+    startDate: '2025-06-01',
+    endDate: null,
+    capacity: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateCohortSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid status', () => {
+    expect(
+      CreateCohortSchema.safeParse({ ...valid, status: 'cancelled' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateCohortSchema', () => {
+  it('should accept partial data', () => {
+    expect(UpdateCohortSchema.safeParse({ capacity: 25 }).success).toBe(true);
+  });
+});
+
+describe('CohortSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      CohortSchema.safeParse({
+        id: 'coh-1',
+        programId: 'prg-1',
+        name: 'Cohorte A',
+        code: 'COH-A',
+        status: 'open',
+        startDate: '2025-06-01',
+        endDate: '2025-12-01',
+        capacity: 30,
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+describe('CreateSessionSchema', () => {
+  const valid = {
+    cohortId: 'coh-1',
+    title: 'Session 1',
+    description: null,
+    status: 'scheduled',
+    startsAt: '2025-06-15T09:00:00Z',
+    endsAt: '2025-06-15T12:00:00Z',
+    locationType: 'online',
+    locationLabel: null,
+    meetingLink: null,
+    trainerUserId: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateSessionSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid status', () => {
+    expect(
+      CreateSessionSchema.safeParse({ ...valid, status: 'pending' }).success,
+    ).toBe(false);
+  });
+
+  it('should reject invalid locationType', () => {
+    expect(
+      CreateSessionSchema.safeParse({ ...valid, locationType: 'remote' })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateSessionSchema', () => {
+  it('should accept partial data', () => {
+    expect(
+      UpdateSessionSchema.safeParse({ title: 'Session modifiée' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('SessionSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      SessionSchema.safeParse({
+        id: 'ses-1',
+        cohortId: 'coh-1',
+        title: 'Session 1',
+        description: 'Intro',
+        status: 'live',
+        startsAt: '2025-06-15T09:00:00Z',
+        endsAt: '2025-06-15T12:00:00Z',
+        locationType: 'hybrid',
+        locationLabel: 'Salle A',
+        meetingLink: 'https://meet.example.com/abc',
+        trainerUserId: 'user-42',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+describe('CreateResourceSchema', () => {
+  const valid = {
+    programId: null,
+    cohortId: null,
+    title: 'Guide PDF',
+    description: null,
+    resourceType: 'document',
+    url: null,
+    filePath: '/uploads/guide.pdf',
+    status: 'draft',
+    publishedAt: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateResourceSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid resourceType', () => {
+    expect(
+      CreateResourceSchema.safeParse({ ...valid, resourceType: 'audio' })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateResourceSchema', () => {
+  it('should accept partial data', () => {
+    expect(UpdateResourceSchema.safeParse({ title: 'Guide v2' }).success).toBe(
+      true,
+    );
+  });
+});
+
+describe('ResourceSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      ResourceSchema.safeParse({
+        id: 'res-1',
+        programId: 'prg-1',
+        cohortId: null,
+        title: 'Guide PDF',
+        description: 'Un guide utile',
+        resourceType: 'file',
+        url: null,
+        filePath: '/uploads/guide.pdf',
+        status: 'published',
+        publishedAt: '2025-03-01T00:00:00Z',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Announcement
+// ---------------------------------------------------------------------------
+describe('CreateAnnouncementSchema', () => {
+  const valid = {
+    title: 'Bienvenue',
+    body: "Contenu de l'annonce",
+    audienceType: 'all_participants',
+    programId: null,
+    cohortId: null,
+    status: 'draft',
+    publishedAt: null,
+    createdByUserId: 'user-1',
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateAnnouncementSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid audienceType', () => {
+    expect(
+      CreateAnnouncementSchema.safeParse({ ...valid, audienceType: 'everyone' })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateAnnouncementSchema', () => {
+  it('should accept partial data', () => {
+    expect(
+      UpdateAnnouncementSchema.safeParse({ title: 'Mise à jour' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('AnnouncementSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      AnnouncementSchema.safeParse({
+        id: 'ann-1',
+        title: 'Bienvenue',
+        body: 'Contenu',
+        audienceType: 'program',
+        programId: 'prg-1',
+        cohortId: null,
+        status: 'published',
+        publishedAt: '2025-03-01T00:00:00Z',
+        createdByUserId: 'user-1',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enrollment
+// ---------------------------------------------------------------------------
+describe('CreateEnrollmentSchema', () => {
+  const valid = {
+    participantId: 'p-1',
+    programId: 'prg-1',
+    cohortId: null,
+    status: 'pending',
+    completedAt: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateEnrollmentSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid status', () => {
+    expect(
+      CreateEnrollmentSchema.safeParse({ ...valid, status: 'dropped' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateEnrollmentSchema', () => {
+  it('should accept partial data', () => {
+    expect(UpdateEnrollmentSchema.safeParse({ status: 'active' }).success).toBe(
+      true,
+    );
+  });
+});
+
+describe('EnrollmentSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      EnrollmentSchema.safeParse({
+        id: 'enr-1',
+        participantId: 'p-1',
+        programId: 'prg-1',
+        cohortId: 'coh-1',
+        status: 'active',
+        enrolledAt: '2025-02-01T00:00:00Z',
+        completedAt: null,
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification (immutable — no UpdateSchema)
+// ---------------------------------------------------------------------------
+describe('CreateNotificationSchema', () => {
+  const valid = {
+    userId: 'user-1',
+    title: 'Nouvelle session',
+    body: 'Votre session commence bientôt',
+    notificationType: 'session_reminder',
+    channel: 'in_app',
+    sourceType: null,
+    sourceId: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateNotificationSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid notificationType', () => {
+    expect(
+      CreateNotificationSchema.safeParse({
+        ...valid,
+        notificationType: 'email',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('should reject invalid channel', () => {
+    expect(
+      CreateNotificationSchema.safeParse({ ...valid, channel: 'sms' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('NotificationSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      NotificationSchema.safeParse({
+        id: 'ntf-1',
+        userId: 'user-1',
+        title: 'Rappel',
+        body: 'Session demain',
+        notificationType: 'session_reminder',
+        channel: 'push',
+        isRead: false,
+        readAt: null,
+        sourceType: 'session',
+        sourceId: 'ses-1',
+        createdAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('should reject entity with updatedAt (immutable)', () => {
+    const result = NotificationSchema.safeParse({
+      id: 'ntf-1',
+      userId: 'user-1',
+      title: 'Rappel',
+      body: 'Session demain',
+      notificationType: 'session_reminder',
+      channel: 'push',
+      isRead: false,
+      readAt: null,
+      sourceType: null,
+      sourceId: null,
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    });
+    // Schema should use .strict() or not define updatedAt — extra keys rejected
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupportRequest
+// ---------------------------------------------------------------------------
+describe('CreateSupportRequestSchema', () => {
+  const valid = {
+    userId: 'user-1',
+    participantId: null,
+    subject: 'Problème technique',
+    message: 'Je ne peux pas accéder au cours',
+    status: 'open',
+    category: 'technical',
+    assignedToUserId: null,
+  };
+
+  it('should accept valid data', () => {
+    expect(CreateSupportRequestSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('should reject invalid status', () => {
+    expect(
+      CreateSupportRequestSchema.safeParse({ ...valid, status: 'deleted' })
+        .success,
+    ).toBe(false);
+  });
+
+  it('should reject invalid category', () => {
+    expect(
+      CreateSupportRequestSchema.safeParse({ ...valid, category: 'finance' })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('UpdateSupportRequestSchema', () => {
+  it('should accept partial data', () => {
+    expect(
+      UpdateSupportRequestSchema.safeParse({ status: 'resolved' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('SupportRequestSchema', () => {
+  it('should accept a full entity', () => {
+    expect(
+      SupportRequestSchema.safeParse({
+        id: 'sr-1',
+        userId: 'user-1',
+        participantId: 'p-1',
+        subject: 'Problème',
+        message: 'Détails',
+        status: 'in_progress',
+        category: 'program',
+        assignedToUserId: 'user-42',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.5.0
         version: 20.5.0
+      commitizen:
+        specifier: ^4.3.1
+        version: 4.3.1(@types/node@20.19.39)(typescript@5.9.3)
+      cz-git:
+        specifier: ^1.12.0
+        version: 1.12.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -214,6 +220,19 @@ importers:
       typescript-eslint:
         specifier: ^8.58.1
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.8
+        version: 4.1.4(@types/node@20.19.39)(jsdom@28.1.0)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+
+  packages/contracts:
+    dependencies:
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
       vitest:
         specifier: ^4.0.8
         version: 4.1.4(@types/node@20.19.39)(jsdom@28.1.0)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
@@ -2656,6 +2675,10 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -2830,6 +2853,10 @@ packages:
     resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  cachedir@2.3.0:
+    resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
+    engines: {node: '>=6'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2857,6 +2884,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2868,6 +2899,9 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -2919,6 +2953,10 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -2942,9 +2980,15 @@ packages:
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -2970,6 +3014,11 @@ packages:
   comment-json@4.6.2:
     resolution: {integrity: sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==}
     engines: {node: '>= 6'}
+
+  commitizen@4.3.1:
+    resolution: {integrity: sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==}
+    engines: {node: '>= 12'}
+    hasBin: true
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -3000,6 +3049,9 @@ packages:
   conventional-changelog-conventionalcommits@9.3.1:
     resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
     engines: {node: '>=18'}
+
+  conventional-commit-types@3.0.0:
+    resolution: {integrity: sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==}
 
   conventional-commits-parser@6.4.0:
     resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
@@ -3077,6 +3129,14 @@ packages:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
     engines: {node: '>=20'}
 
+  cz-conventional-changelog@3.3.0:
+    resolution: {integrity: sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==}
+    engines: {node: '>= 10'}
+
+  cz-git@1.12.0:
+    resolution: {integrity: sha512-LaZ+8whPPUOo6Y0Zy4nIbf6JOleV3ejp41sT6N4RPKiKKA+ICWf4ueeIlxIO8b6JtdlDxRzHH/EcRji07nDxcg==}
+    engines: {node: '>=v12.20.0'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3092,6 +3152,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dedent@0.7.0:
+    resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -3118,6 +3181,14 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  detect-file@1.0.0:
+    resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
+    engines: {node: '>=0.10.0'}
+
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -3237,6 +3308,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -3352,6 +3427,10 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  expand-tilde@2.0.2:
+    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
+    engines: {node: '>=0.10.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3372,6 +3451,10 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3403,6 +3486,10 @@ packages:
       picomatch:
         optional: true
 
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3419,6 +3506,12 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-node-modules@2.1.3:
+    resolution: {integrity: sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==}
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3426,6 +3519,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  findup-sync@4.0.0:
+    resolution: {integrity: sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==}
+    engines: {node: '>= 8'}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -3543,6 +3640,14 @@ packages:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
 
+  global-modules@1.0.0:
+    resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
+    engines: {node: '>=0.10.0'}
+
+  global-prefix@1.0.2:
+    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
+    engines: {node: '>=0.10.0'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -3559,6 +3664,10 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -3570,6 +3679,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
 
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
@@ -3612,6 +3725,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3672,6 +3789,10 @@ packages:
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  inquirer@8.2.5:
+    resolution: {integrity: sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==}
+    engines: {node: '>=12.0.0'}
 
   ionicons@7.4.0:
     resolution: {integrity: sha512-ZK94MMqgzMCPPMhmk8Ouu6goyVHFIlw/ACP6oe3FrikcI0N7CX0xcwVaEbUc0G/v3W0shI93vo+9ve/KpvcNhQ==}
@@ -3760,6 +3881,13 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-utf8@0.2.1:
+    resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -4124,6 +4252,9 @@ packages:
   lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
 
+  lodash.map@4.6.0:
+    resolution: {integrity: sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
@@ -4141,6 +4272,9 @@ packages:
 
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -4160,6 +4294,10 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  longest@2.0.1:
+    resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
+    engines: {node: '>=0.10.0'}
 
   lru-cache@11.3.3:
     resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
@@ -4218,6 +4356,9 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  merge@2.1.1:
+    resolution: {integrity: sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -4252,6 +4393,9 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.7:
+    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -4305,6 +4449,9 @@ packages:
   multer@2.1.1:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
+
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -4450,6 +4597,10 @@ packages:
   ordered-binary@1.6.1:
     resolution: {integrity: sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==}
 
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4489,6 +4640,10 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
 
   parse5-html-rewriting-stream@8.0.0:
     resolution: {integrity: sha512-wzh11mj8KKkno1pZEu+l2EVeWsuKDfR5KNWZOTsslfUX8lPDZx77m9T0kIoAVkFtD1nx6YF8oh4BnPHvxMtNMw==}
@@ -4685,6 +4840,10 @@ packages:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
 
+  resolve-dir@1.0.1:
+    resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4735,6 +4894,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -4976,6 +5139,10 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5034,6 +5201,9 @@ packages:
   through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
 
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5059,6 +5229,10 @@ packages:
   tldts@7.0.28:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -5388,6 +5562,10 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -5505,6 +5683,9 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -8257,6 +8438,10 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -8469,6 +8654,8 @@ snapshots:
       p-map: 7.0.4
       ssri: 13.0.1
 
+  cachedir@2.3.0: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -8489,6 +8676,12 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -8497,6 +8690,8 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  chardet@0.7.0: {}
 
   chardet@2.1.1: {}
 
@@ -8539,6 +8734,8 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.0
 
+  cli-width@3.0.0: {}
+
   cli-width@4.1.0: {}
 
   cliui@8.0.1:
@@ -8559,9 +8756,15 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+
+  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -8579,6 +8782,26 @@ snapshots:
     dependencies:
       array-timsort: 1.0.3
       esprima: 4.0.1
+
+  commitizen@4.3.1(@types/node@20.19.39)(typescript@5.9.3):
+    dependencies:
+      cachedir: 2.3.0
+      cz-conventional-changelog: 3.3.0(@types/node@20.19.39)(typescript@5.9.3)
+      dedent: 0.7.0
+      detect-indent: 6.1.0
+      find-node-modules: 2.1.3
+      find-root: 1.1.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      inquirer: 8.2.5
+      is-utf8: 0.2.1
+      lodash: 4.17.21
+      minimist: 1.2.7
+      strip-bom: 4.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
 
   compare-func@2.0.0:
     dependencies:
@@ -8607,6 +8830,8 @@ snapshots:
   conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
       compare-func: 2.0.0
+
+  conventional-commit-types@3.0.0: {}
 
   conventional-commits-parser@6.4.0:
     dependencies:
@@ -8696,6 +8921,22 @@ snapshots:
       css-tree: 3.2.1
       lru-cache: 11.3.3
 
+  cz-conventional-changelog@3.3.0(@types/node@20.19.39)(typescript@5.9.3):
+    dependencies:
+      chalk: 2.4.2
+      commitizen: 4.3.1(@types/node@20.19.39)(typescript@5.9.3)
+      conventional-commit-types: 3.0.0
+      lodash.map: 4.6.0
+      longest: 2.0.1
+      word-wrap: 1.2.5
+    optionalDependencies:
+      '@commitlint/load': 20.5.0(@types/node@20.19.39)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  cz-git@1.12.0: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -8708,6 +8949,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  dedent@0.7.0: {}
 
   dedent@1.7.2: {}
 
@@ -8722,6 +8965,10 @@ snapshots:
   define-lazy-prop@2.0.0: {}
 
   depd@2.0.0: {}
+
+  detect-file@1.0.0: {}
+
+  detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -8838,6 +9085,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -9002,6 +9251,10 @@ snapshots:
 
   exit@0.1.2: {}
 
+  expand-tilde@2.0.2:
+    dependencies:
+      homedir-polyfill: 1.0.3
+
   expect-type@1.3.0: {}
 
   expect@29.7.0:
@@ -9052,6 +9305,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -9073,6 +9332,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9102,6 +9365,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-node-modules@2.1.3:
+    dependencies:
+      findup-sync: 4.0.0
+      merge: 2.1.1
+
+  find-root@1.1.0: {}
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -9111,6 +9381,13 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  findup-sync@4.0.0:
+    dependencies:
+      detect-file: 1.0.0
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      resolve-dir: 1.0.1
 
   flat-cache@4.0.1:
     dependencies:
@@ -9242,6 +9519,20 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
+  global-modules@1.0.0:
+    dependencies:
+      global-prefix: 1.0.2
+      is-windows: 1.0.2
+      resolve-dir: 1.0.1
+
+  global-prefix@1.0.2:
+    dependencies:
+      expand-tilde: 2.0.2
+      homedir-polyfill: 1.0.3
+      ini: 1.3.8
+      is-windows: 1.0.2
+      which: 1.3.1
+
   globals@14.0.0: {}
 
   gopd@1.2.0: {}
@@ -9257,6 +9548,8 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  has-flag@3.0.0: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -9264,6 +9557,10 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  homedir-polyfill@1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
 
   hono@4.12.12: {}
 
@@ -9314,6 +9611,10 @@ snapshots:
 
   husky@9.1.7: {}
 
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -9358,6 +9659,24 @@ snapshots:
   ini@4.1.3: {}
 
   ini@6.0.0: {}
+
+  inquirer@8.2.5:
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.18.1
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 7.0.0
 
   ionicons@7.4.0:
     dependencies:
@@ -9414,6 +9733,10 @@ snapshots:
   is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-utf8@0.2.1: {}
+
+  is-windows@1.0.2: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -9960,6 +10283,8 @@ snapshots:
 
   lodash.kebabcase@4.1.1: {}
 
+  lodash.map@4.6.0: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
@@ -9971,6 +10296,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash.upperfirst@4.3.1: {}
+
+  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 
@@ -9996,6 +10323,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  longest@2.0.1: {}
 
   lru-cache@11.3.3: {}
 
@@ -10056,6 +10385,8 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
+  merge@2.1.1: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -10084,6 +10415,8 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
+
+  minimist@1.2.7: {}
 
   minimist@1.2.8: {}
 
@@ -10148,6 +10481,8 @@ snapshots:
       busboy: 1.6.0
       concat-stream: 2.0.0
       type-is: 1.6.18
+
+  mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
 
@@ -10342,6 +10677,8 @@ snapshots:
   ordered-binary@1.6.1:
     optional: true
 
+  os-tmpdir@1.0.2: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -10396,6 +10733,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-passwd@1.0.0: {}
 
   parse5-html-rewriting-stream@8.0.0:
     dependencies:
@@ -10563,6 +10902,11 @@ snapshots:
     dependencies:
       resolve-from: 5.0.0
 
+  resolve-dir@1.0.1:
+    dependencies:
+      expand-tilde: 2.0.2
+      global-modules: 1.0.0
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -10656,6 +11000,8 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  run-async@2.4.1: {}
 
   rxjs@7.8.1:
     dependencies:
@@ -10912,6 +11258,10 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10963,6 +11313,8 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
+  through@2.3.8: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -10984,6 +11336,10 @@ snapshots:
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
 
   tmpl@1.0.5: {}
 
@@ -11292,6 +11648,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -11396,6 +11756,8 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Résumé

Implémente le package `@kraak/contracts` avec les contrats partagés typés pour les 10 entités du MVP KRAAK.

### Contenu

- **14 enums** (`as const` + types) : `UserRole`, `LifecycleStatus`, `PublicationStatus`, `ProgramVisibility`, `CohortStatus`, `SessionStatus`, `LocationType`, `ResourceType`, `AudienceType`, `EnrollmentStatus`, `NotificationType`, `NotificationChannel`, `SupportRequestStatus`, `SupportCategory`
- **29 DTOs** (10 interfaces full + 9 Create + 9 Update + 1 `CreateNotificationDto` spécial)
- **30 schemas Zod** (10 full + 9 Create + 9 Update + 2 spéciaux Enrollment/Notification)
- **108 tests unitaires** (28 enum + 31 DTO + 49 schema) — tous verts ✅

### Architecture

```
packages/contracts/
├── enums.ts          # Enums as const + types
├── dto.ts            # Interfaces TypeScript
├── schemas.ts        # Schemas Zod avec validation runtime
├── src/
│   ├── index.ts      # Barrel exports
│   ├── enums.spec.ts
│   ├── dto.spec.ts
│   └── schemas.spec.ts
├── package.json
├── tsconfig.json
└── vitest.config.ts
```

### Validation

- `pnpm --filter @kraak/contracts test` → 108/108 ✅
- TDD : RED → GREEN → REFACTOR suivi pour chaque module
- Prettier + ESLint conformes

Closes #71