### PR TITLE
feat(domain): implement state transitions and role-based permissions (#72)

### DIFF
--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@kraak/domain",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@kraak/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.8",
+    "typescript": "~5.8.3"
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,2 @@
+export * from './transitions';
+export * from './permissions';

--- a/packages/domain/src/permissions.spec.ts
+++ b/packages/domain/src/permissions.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { UserRole } from '@kraak/contracts';
+import {
+  getViewPermission,
+  getEditPermission,
+  Entity,
+  type EntityValue,
+} from './permissions';
+
+const allEntities = Object.values(Entity) as EntityValue[];
+
+// ── getViewPermission ───────────────────────────────────────────────
+
+describe('getViewPermission', () => {
+  describe('Given an admin role', () => {
+    it.each(allEntities)(
+      'When checking %s / Then returns "all"',
+      (entity) => {
+        expect(getViewPermission(UserRole.ADMIN, entity)).toBe('all');
+      },
+    );
+  });
+
+  describe('Given a participant role', () => {
+    it.each(allEntities)(
+      'When checking %s / Then returns "own"',
+      (entity) => {
+        expect(getViewPermission(UserRole.PARTICIPANT, entity)).toBe('own');
+      },
+    );
+  });
+
+  describe('Given a trainer role', () => {
+    const ownEntities: EntityValue[] = [
+      Entity.APP_USER,
+      Entity.PARTICIPANT,
+      Entity.PROGRAM,
+      Entity.COHORT,
+      Entity.SESSION,
+      Entity.RESOURCE,
+      Entity.ANNOUNCEMENT,
+      Entity.NOTIFICATION,
+      Entity.SUPPORT_REQUEST,
+    ];
+
+    it.each(ownEntities)(
+      'When checking %s / Then returns "own"',
+      (entity) => {
+        expect(getViewPermission(UserRole.TRAINER, entity)).toBe('own');
+      },
+    );
+
+    it('When checking Enrollment / Then returns "none"', () => {
+      expect(
+        getViewPermission(UserRole.TRAINER, Entity.ENROLLMENT),
+      ).toBe('none');
+    });
+  });
+});
+
+// ── getEditPermission ───────────────────────────────────────────────
+
+describe('getEditPermission', () => {
+  describe('Given an admin role', () => {
+    it.each(allEntities)(
+      'When checking %s / Then returns "all"',
+      (entity) => {
+        expect(getEditPermission(UserRole.ADMIN, entity)).toBe('all');
+      },
+    );
+  });
+
+  describe('Given a participant role', () => {
+    const ownEntities: EntityValue[] = [
+      Entity.APP_USER,
+      Entity.PARTICIPANT,
+      Entity.SUPPORT_REQUEST,
+    ];
+    const noneEntities: EntityValue[] = [
+      Entity.PROGRAM,
+      Entity.COHORT,
+      Entity.SESSION,
+      Entity.RESOURCE,
+      Entity.ANNOUNCEMENT,
+      Entity.ENROLLMENT,
+      Entity.NOTIFICATION,
+    ];
+
+    it.each(ownEntities)(
+      'When checking %s / Then returns "own"',
+      (entity) => {
+        expect(getEditPermission(UserRole.PARTICIPANT, entity)).toBe('own');
+      },
+    );
+
+    it.each(noneEntities)(
+      'When checking %s / Then returns "none"',
+      (entity) => {
+        expect(getEditPermission(UserRole.PARTICIPANT, entity)).toBe('none');
+      },
+    );
+  });
+
+  describe('Given a trainer role', () => {
+    const ownEntities: EntityValue[] = [
+      Entity.APP_USER,
+      Entity.SESSION,
+      Entity.RESOURCE,
+      Entity.ANNOUNCEMENT,
+      Entity.SUPPORT_REQUEST,
+    ];
+    const noneEntities: EntityValue[] = [
+      Entity.PARTICIPANT,
+      Entity.PROGRAM,
+      Entity.COHORT,
+      Entity.ENROLLMENT,
+      Entity.NOTIFICATION,
+    ];
+
+    it.each(ownEntities)(
+      'When checking %s / Then returns "own"',
+      (entity) => {
+        expect(getEditPermission(UserRole.TRAINER, entity)).toBe('own');
+      },
+    );
+
+    it.each(noneEntities)(
+      'When checking %s / Then returns "none"',
+      (entity) => {
+        expect(getEditPermission(UserRole.TRAINER, entity)).toBe('none');
+      },
+    );
+  });
+});

--- a/packages/domain/src/permissions.ts
+++ b/packages/domain/src/permissions.ts
@@ -1,0 +1,77 @@
+import type { UserRoleValue } from '@kraak/contracts';
+import { UserRole } from '@kraak/contracts';
+
+// ── Entités du domaine ──────────────────────────────────────────────
+
+export const Entity = {
+  APP_USER: 'AppUser',
+  PARTICIPANT: 'Participant',
+  PROGRAM: 'Program',
+  COHORT: 'Cohort',
+  SESSION: 'Session',
+  RESOURCE: 'Resource',
+  ANNOUNCEMENT: 'Announcement',
+  ENROLLMENT: 'Enrollment',
+  NOTIFICATION: 'Notification',
+  SUPPORT_REQUEST: 'SupportRequest',
+} as const;
+
+export type EntityValue = (typeof Entity)[keyof typeof Entity];
+
+// ── Niveaux de permission ───────────────────────────────────────────
+
+export type PermissionLevel = 'all' | 'own' | 'none';
+
+// ── Matrices de permission ──────────────────────────────────────────
+
+type PermissionMatrix = Record<UserRoleValue, Record<EntityValue, PermissionLevel>>;
+
+const allEntities = Object.values(Entity) as EntityValue[];
+
+/** Construit une ligne de permissions : remplit avec `defaultLevel` puis applique les surcharges. */
+function buildRow(
+  defaultLevel: PermissionLevel,
+  overrides: Partial<Record<EntityValue, PermissionLevel>> = {},
+): Record<EntityValue, PermissionLevel> {
+  const row = {} as Record<EntityValue, PermissionLevel>;
+  for (const e of allEntities) row[e] = overrides[e] ?? defaultLevel;
+  return row;
+}
+
+const viewMatrix: PermissionMatrix = {
+  [UserRole.ADMIN]: buildRow('all'),
+  [UserRole.PARTICIPANT]: buildRow('own'),
+  [UserRole.TRAINER]: buildRow('own', { [Entity.ENROLLMENT]: 'none' }),
+};
+
+const editMatrix: PermissionMatrix = {
+  [UserRole.ADMIN]: buildRow('all'),
+  [UserRole.PARTICIPANT]: buildRow('none', {
+    [Entity.APP_USER]: 'own',
+    [Entity.PARTICIPANT]: 'own',
+    [Entity.SUPPORT_REQUEST]: 'own',
+  }),
+  [UserRole.TRAINER]: buildRow('none', {
+    [Entity.APP_USER]: 'own',
+    [Entity.SESSION]: 'own',
+    [Entity.RESOURCE]: 'own',
+    [Entity.ANNOUNCEMENT]: 'own',
+    [Entity.SUPPORT_REQUEST]: 'own',
+  }),
+};
+
+// ── Fonctions publiques ─────────────────────────────────────────────
+
+export function getViewPermission(
+  role: UserRoleValue,
+  entity: EntityValue,
+): PermissionLevel {
+  return viewMatrix[role][entity];
+}
+
+export function getEditPermission(
+  role: UserRoleValue,
+  entity: EntityValue,
+): PermissionLevel {
+  return editMatrix[role][entity];
+}

--- a/packages/domain/src/transitions.spec.ts
+++ b/packages/domain/src/transitions.spec.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LifecycleStatus,
+  CohortStatus,
+  SessionStatus,
+  EnrollmentStatus,
+  SupportRequestStatus,
+  PublicationStatus,
+} from '@kraak/contracts';
+import {
+  canTransitionLifecycle,
+  getNextLifecycleStatuses,
+  canTransitionCohortStatus,
+  getNextCohortStatuses,
+  canTransitionSessionStatus,
+  getNextSessionStatuses,
+  canTransitionEnrollmentStatus,
+  getNextEnrollmentStatuses,
+  canTransitionSupportRequestStatus,
+  getNextSupportRequestStatuses,
+  canTransitionPublicationStatus,
+  getNextPublicationStatuses,
+} from './transitions';
+
+// ---------------------------------------------------------------------------
+// LifecycleStatus transitions
+// invited → registered → active → completed
+//                         active → inactive
+//                         inactive → active
+// ---------------------------------------------------------------------------
+describe('canTransitionLifecycle', () => {
+  const valid: [string, string][] = [
+    [LifecycleStatus.INVITED, LifecycleStatus.REGISTERED],
+    [LifecycleStatus.REGISTERED, LifecycleStatus.ACTIVE],
+    [LifecycleStatus.ACTIVE, LifecycleStatus.COMPLETED],
+    [LifecycleStatus.ACTIVE, LifecycleStatus.INACTIVE],
+    [LifecycleStatus.INACTIVE, LifecycleStatus.ACTIVE],
+  ];
+
+  it.each(valid)('allows %s → %s', (from, to) => {
+    expect(canTransitionLifecycle(from, to)).toBe(true);
+  });
+
+  const invalid: [string, string][] = [
+    [LifecycleStatus.INVITED, LifecycleStatus.ACTIVE],
+    [LifecycleStatus.INVITED, LifecycleStatus.COMPLETED],
+    [LifecycleStatus.REGISTERED, LifecycleStatus.COMPLETED],
+    [LifecycleStatus.COMPLETED, LifecycleStatus.ACTIVE],
+    [LifecycleStatus.COMPLETED, LifecycleStatus.INVITED],
+    [LifecycleStatus.INACTIVE, LifecycleStatus.COMPLETED],
+  ];
+
+  it.each(invalid)('rejects %s → %s', (from, to) => {
+    expect(canTransitionLifecycle(from, to)).toBe(false);
+  });
+
+  it('rejects self-transitions', () => {
+    for (const s of Object.values(LifecycleStatus)) {
+      expect(canTransitionLifecycle(s, s)).toBe(false);
+    }
+  });
+});
+
+describe('getNextLifecycleStatuses', () => {
+  it('returns [registered] from invited', () => {
+    expect(getNextLifecycleStatuses(LifecycleStatus.INVITED)).toEqual([
+      LifecycleStatus.REGISTERED,
+    ]);
+  });
+
+  it('returns [active] from registered', () => {
+    expect(getNextLifecycleStatuses(LifecycleStatus.REGISTERED)).toEqual([
+      LifecycleStatus.ACTIVE,
+    ]);
+  });
+
+  it('returns [completed, inactive] from active', () => {
+    expect(getNextLifecycleStatuses(LifecycleStatus.ACTIVE)).toEqual(
+      expect.arrayContaining([
+        LifecycleStatus.COMPLETED,
+        LifecycleStatus.INACTIVE,
+      ]),
+    );
+  });
+
+  it('returns [active] from inactive', () => {
+    expect(getNextLifecycleStatuses(LifecycleStatus.INACTIVE)).toEqual([
+      LifecycleStatus.ACTIVE,
+    ]);
+  });
+
+  it('returns [] from completed', () => {
+    expect(getNextLifecycleStatuses(LifecycleStatus.COMPLETED)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CohortStatus transitions
+// draft → open → active → completed → archived
+// ---------------------------------------------------------------------------
+describe('canTransitionCohortStatus', () => {
+  const valid: [string, string][] = [
+    [CohortStatus.DRAFT, CohortStatus.OPEN],
+    [CohortStatus.OPEN, CohortStatus.ACTIVE],
+    [CohortStatus.ACTIVE, CohortStatus.COMPLETED],
+    [CohortStatus.COMPLETED, CohortStatus.ARCHIVED],
+  ];
+
+  it.each(valid)('allows %s → %s', (from, to) => {
+    expect(canTransitionCohortStatus(from, to)).toBe(true);
+  });
+
+  const invalid: [string, string][] = [
+    [CohortStatus.DRAFT, CohortStatus.ACTIVE],
+    [CohortStatus.OPEN, CohortStatus.ARCHIVED],
+    [CohortStatus.ACTIVE, CohortStatus.DRAFT],
+    [CohortStatus.ARCHIVED, CohortStatus.DRAFT],
+    [CohortStatus.COMPLETED, CohortStatus.ACTIVE],
+  ];
+
+  it.each(invalid)('rejects %s → %s', (from, to) => {
+    expect(canTransitionCohortStatus(from, to)).toBe(false);
+  });
+
+  it('rejects self-transitions', () => {
+    for (const s of Object.values(CohortStatus)) {
+      expect(canTransitionCohortStatus(s, s)).toBe(false);
+    }
+  });
+});
+
+describe('getNextCohortStatuses', () => {
+  it('returns [open] from draft', () => {
+    expect(getNextCohortStatuses(CohortStatus.DRAFT)).toEqual([
+      CohortStatus.OPEN,
+    ]);
+  });
+
+  it('returns [active] from open', () => {
+    expect(getNextCohortStatuses(CohortStatus.OPEN)).toEqual([
+      CohortStatus.ACTIVE,
+    ]);
+  });
+
+  it('returns [completed] from active', () => {
+    expect(getNextCohortStatuses(CohortStatus.ACTIVE)).toEqual([
+      CohortStatus.COMPLETED,
+    ]);
+  });
+
+  it('returns [archived] from completed', () => {
+    expect(getNextCohortStatuses(CohortStatus.COMPLETED)).toEqual([
+      CohortStatus.ARCHIVED,
+    ]);
+  });
+
+  it('returns [] from archived', () => {
+    expect(getNextCohortStatuses(CohortStatus.ARCHIVED)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionStatus transitions
+// scheduled → live → completed
+// scheduled → cancelled
+// ---------------------------------------------------------------------------
+describe('canTransitionSessionStatus', () => {
+  const valid: [string, string][] = [
+    [SessionStatus.SCHEDULED, SessionStatus.LIVE],
+    [SessionStatus.LIVE, SessionStatus.COMPLETED],
+    [SessionStatus.SCHEDULED, SessionStatus.CANCELLED],
+  ];
+
+  it.each(valid)('allows %s → %s', (from, to) => {
+    expect(canTransitionSessionStatus(from, to)).toBe(true);
+  });
+
+  const invalid: [string, string][] = [
+    [SessionStatus.LIVE, SessionStatus.SCHEDULED],
+    [SessionStatus.COMPLETED, SessionStatus.LIVE],
+    [SessionStatus.CANCELLED, SessionStatus.SCHEDULED],
+    [SessionStatus.LIVE, SessionStatus.CANCELLED],
+  ];
+
+  it.each(invalid)('rejects %s → %s', (from, to) => {
+    expect(canTransitionSessionStatus(from, to)).toBe(false);
+  });
+
+  it('rejects self-transitions', () => {
+    for (const s of Object.values(SessionStatus)) {
+      expect(canTransitionSessionStatus(s, s)).toBe(false);
+    }
+  });
+});
+
+describe('getNextSessionStatuses', () => {
+  it('returns [live, cancelled] from scheduled', () => {
+    expect(getNextSessionStatuses(SessionStatus.SCHEDULED)).toEqual(
+      expect.arrayContaining([SessionStatus.LIVE, SessionStatus.CANCELLED]),
+    );
+  });
+
+  it('returns [completed] from live', () => {
+    expect(getNextSessionStatuses(SessionStatus.LIVE)).toEqual([
+      SessionStatus.COMPLETED,
+    ]);
+  });
+
+  it('returns [] from completed', () => {
+    expect(getNextSessionStatuses(SessionStatus.COMPLETED)).toEqual([]);
+  });
+
+  it('returns [] from cancelled', () => {
+    expect(getNextSessionStatuses(SessionStatus.CANCELLED)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EnrollmentStatus transitions
+// pending → active → completed
+// pending → cancelled
+// ---------------------------------------------------------------------------
+describe('canTransitionEnrollmentStatus', () => {
+  const valid: [string, string][] = [
+    [EnrollmentStatus.PENDING, EnrollmentStatus.ACTIVE],
+    [EnrollmentStatus.ACTIVE, EnrollmentStatus.COMPLETED],
+    [EnrollmentStatus.PENDING, EnrollmentStatus.CANCELLED],
+  ];
+
+  it.each(valid)('allows %s → %s', (from, to) => {
+    expect(canTransitionEnrollmentStatus(from, to)).toBe(true);
+  });
+
+  const invalid: [string, string][] = [
+    [EnrollmentStatus.ACTIVE, EnrollmentStatus.PENDING],
+    [EnrollmentStatus.COMPLETED, EnrollmentStatus.ACTIVE],
+    [EnrollmentStatus.CANCELLED, EnrollmentStatus.PENDING],
+    [EnrollmentStatus.ACTIVE, EnrollmentStatus.CANCELLED],
+  ];
+
+  it.each(invalid)('rejects %s → %s', (from, to) => {
+    expect(canTransitionEnrollmentStatus(from, to)).toBe(false);
+  });
+
+  it('rejects self-transitions', () => {
+    for (const s of Object.values(EnrollmentStatus)) {
+      expect(canTransitionEnrollmentStatus(s, s)).toBe(false);
+    }
+  });
+});
+
+describe('getNextEnrollmentStatuses', () => {
+  it('returns [active, cancelled] from pending', () => {
+    expect(getNextEnrollmentStatuses(EnrollmentStatus.PENDING)).toEqual(
+      expect.arrayContaining([
+        EnrollmentStatus.ACTIVE,
+        EnrollmentStatus.CANCELLED,
+      ]),
+    );
+  });
+
+  it('returns [completed] from active', () => {
+    expect(getNextEnrollmentStatuses(EnrollmentStatus.ACTIVE)).toEqual([
+      EnrollmentStatus.COMPLETED,
+    ]);
+  });
+
+  it('returns [] from completed', () => {
+    expect(getNextEnrollmentStatuses(EnrollmentStatus.COMPLETED)).toEqual([]);
+  });
+
+  it('returns [] from cancelled', () => {
+    expect(getNextEnrollmentStatuses(EnrollmentStatus.CANCELLED)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupportRequestStatus transitions
+// open → in_progress → resolved → closed
+// ---------------------------------------------------------------------------
+describe('canTransitionSupportRequestStatus', () => {
+  const valid: [string, string][] = [
+    [SupportRequestStatus.OPEN, SupportRequestStatus.IN_PROGRESS],
+    [SupportRequestStatus.IN_PROGRESS, SupportRequestStatus.RESOLVED],
+    [SupportRequestStatus.RESOLVED, SupportRequestStatus.CLOSED],
+  ];
+
+  it.each(valid)('allows %s → %s', (from, to) => {
+    expect(canTransitionSupportRequestStatus(from, to)).toBe(true);
+  });
+
+  const invalid: [string, string][] = [
+    [SupportRequestStatus.OPEN, SupportRequestStatus.RESOLVED],
+    [SupportRequestStatus.OPEN, SupportRequestStatus.CLOSED],
+    [SupportRequestStatus.IN_PROGRESS, SupportRequestStatus.OPEN],
+    [SupportRequestStatus.RESOLVED, SupportRequestStatus.IN_PROGRESS],
+    [SupportRequestStatus.CLOSED, SupportRequestStatus.OPEN],
+  ];
+
+  it.each(invalid)('rejects %s → %s', (from, to) => {
+    expect(canTransitionSupportRequestStatus(from, to)).toBe(false);
+  });
+
+  it('rejects self-transitions', () => {
+    for (const s of Object.values(SupportRequestStatus)) {
+      expect(canTransitionSupportRequestStatus(s, s)).toBe(false);
+    }
+  });
+});
+
+describe('getNextSupportRequestStatuses', () => {
+  it('returns [in_progress] from open', () => {
+    expect(
+      getNextSupportRequestStatuses(SupportRequestStatus.OPEN),
+    ).toEqual([SupportRequestStatus.IN_PROGRESS]);
+  });
+
+  it('returns [resolved] from in_progress', () => {
+    expect(
+      getNextSupportRequestStatuses(SupportRequestStatus.IN_PROGRESS),
+    ).toEqual([SupportRequestStatus.RESOLVED]);
+  });
+
+  it('returns [closed] from resolved', () => {
+    expect(
+      getNextSupportRequestStatuses(SupportRequestStatus.RESOLVED),
+    ).toEqual([SupportRequestStatus.CLOSED]);
+  });
+
+  it('returns [] from closed', () => {
+    expect(
+      getNextSupportRequestStatuses(SupportRequestStatus.CLOSED),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PublicationStatus transitions
+// draft → published → archived
+// ---------------------------------------------------------------------------
+describe('canTransitionPublicationStatus', () => {
+  const valid: [string, string][] = [
+    [PublicationStatus.DRAFT, PublicationStatus.PUBLISHED],
+    [PublicationStatus.PUBLISHED, PublicationStatus.ARCHIVED],
+  ];
+
+  it.each(valid)('allows %s → %s', (from, to) => {
+    expect(canTransitionPublicationStatus(from, to)).toBe(true);
+  });
+
+  const invalid: [string, string][] = [
+    [PublicationStatus.DRAFT, PublicationStatus.ARCHIVED],
+    [PublicationStatus.PUBLISHED, PublicationStatus.DRAFT],
+    [PublicationStatus.ARCHIVED, PublicationStatus.DRAFT],
+    [PublicationStatus.ARCHIVED, PublicationStatus.PUBLISHED],
+  ];
+
+  it.each(invalid)('rejects %s → %s', (from, to) => {
+    expect(canTransitionPublicationStatus(from, to)).toBe(false);
+  });
+
+  it('rejects self-transitions', () => {
+    for (const s of Object.values(PublicationStatus)) {
+      expect(canTransitionPublicationStatus(s, s)).toBe(false);
+    }
+  });
+});
+
+describe('getNextPublicationStatuses', () => {
+  it('returns [published] from draft', () => {
+    expect(getNextPublicationStatuses(PublicationStatus.DRAFT)).toEqual([
+      PublicationStatus.PUBLISHED,
+    ]);
+  });
+
+  it('returns [archived] from published', () => {
+    expect(getNextPublicationStatuses(PublicationStatus.PUBLISHED)).toEqual([
+      PublicationStatus.ARCHIVED,
+    ]);
+  });
+
+  it('returns [] from archived', () => {
+    expect(getNextPublicationStatuses(PublicationStatus.ARCHIVED)).toEqual([]);
+  });
+});

--- a/packages/domain/src/transitions.ts
+++ b/packages/domain/src/transitions.ts
@@ -1,0 +1,106 @@
+import {
+  LifecycleStatus,
+  type LifecycleStatusValue,
+  CohortStatus,
+  type CohortStatusValue,
+  SessionStatus,
+  type SessionStatusValue,
+  EnrollmentStatus,
+  type EnrollmentStatusValue,
+  SupportRequestStatus,
+  type SupportRequestStatusValue,
+  PublicationStatus,
+  type PublicationStatusValue,
+} from '@kraak/contracts';
+
+// ---------------------------------------------------------------------------
+// Generic helpers
+// ---------------------------------------------------------------------------
+
+function createTransitionHelpers<T extends string>(
+  map: Record<string, readonly T[]>,
+) {
+  return {
+    canTransition(from: string, to: string): boolean {
+      return (map[from] ?? []).includes(to as T);
+    },
+    getNext(from: string): readonly T[] {
+      return map[from] ?? [];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transition maps
+// ---------------------------------------------------------------------------
+
+const lifecycle = createTransitionHelpers<LifecycleStatusValue>({
+  [LifecycleStatus.INVITED]: [LifecycleStatus.REGISTERED],
+  [LifecycleStatus.REGISTERED]: [LifecycleStatus.ACTIVE],
+  [LifecycleStatus.ACTIVE]: [
+    LifecycleStatus.COMPLETED,
+    LifecycleStatus.INACTIVE,
+  ],
+  [LifecycleStatus.INACTIVE]: [LifecycleStatus.ACTIVE],
+  [LifecycleStatus.COMPLETED]: [],
+});
+
+const cohort = createTransitionHelpers<CohortStatusValue>({
+  [CohortStatus.DRAFT]: [CohortStatus.OPEN],
+  [CohortStatus.OPEN]: [CohortStatus.ACTIVE],
+  [CohortStatus.ACTIVE]: [CohortStatus.COMPLETED],
+  [CohortStatus.COMPLETED]: [CohortStatus.ARCHIVED],
+  [CohortStatus.ARCHIVED]: [],
+});
+
+const session = createTransitionHelpers<SessionStatusValue>({
+  [SessionStatus.SCHEDULED]: [SessionStatus.LIVE, SessionStatus.CANCELLED],
+  [SessionStatus.LIVE]: [SessionStatus.COMPLETED],
+  [SessionStatus.COMPLETED]: [],
+  [SessionStatus.CANCELLED]: [],
+});
+
+const enrollment = createTransitionHelpers<EnrollmentStatusValue>({
+  [EnrollmentStatus.PENDING]: [
+    EnrollmentStatus.ACTIVE,
+    EnrollmentStatus.CANCELLED,
+  ],
+  [EnrollmentStatus.ACTIVE]: [EnrollmentStatus.COMPLETED],
+  [EnrollmentStatus.COMPLETED]: [],
+  [EnrollmentStatus.CANCELLED]: [],
+});
+
+const supportRequest = createTransitionHelpers<SupportRequestStatusValue>({
+  [SupportRequestStatus.OPEN]: [SupportRequestStatus.IN_PROGRESS],
+  [SupportRequestStatus.IN_PROGRESS]: [SupportRequestStatus.RESOLVED],
+  [SupportRequestStatus.RESOLVED]: [SupportRequestStatus.CLOSED],
+  [SupportRequestStatus.CLOSED]: [],
+});
+
+const publication = createTransitionHelpers<PublicationStatusValue>({
+  [PublicationStatus.DRAFT]: [PublicationStatus.PUBLISHED],
+  [PublicationStatus.PUBLISHED]: [PublicationStatus.ARCHIVED],
+  [PublicationStatus.ARCHIVED]: [],
+});
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const canTransitionLifecycle = lifecycle.canTransition;
+export const getNextLifecycleStatuses = lifecycle.getNext;
+
+export const canTransitionCohortStatus = cohort.canTransition;
+export const getNextCohortStatuses = cohort.getNext;
+
+export const canTransitionSessionStatus = session.canTransition;
+export const getNextSessionStatuses = session.getNext;
+
+export const canTransitionEnrollmentStatus = enrollment.canTransition;
+export const getNextEnrollmentStatuses = enrollment.getNext;
+
+export const canTransitionSupportRequestStatus = supportRequest.canTransition;
+export const getNextSupportRequestStatuses = supportRequest.getNext;
+
+export const canTransitionPublicationStatus = publication.canTransition;
+export const getNextPublicationStatuses = publication.getNext;

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/domain/vitest.config.ts
+++ b/packages/domain/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,19 @@ importers:
         specifier: ^4.0.8
         version: 4.1.4(@types/node@20.19.39)(jsdom@28.1.0)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
 
+  packages/domain:
+    dependencies:
+      '@kraak/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^4.0.8
+        version: 4.1.4(@types/node@20.19.39)(jsdom@28.1.0)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+
   packages/tokens: {}
 
 packages:


### PR DESCRIPTION
## LIB-02 — Couche domain (`@kraak/domain`)

Implémente le package `packages/domain` avec deux modules métier sans dépendance de framework.

### Transitions (`transitions.ts`)
- Factory générique `createTransitionHelpers<T>()` retournant `{ canTransition, getNext }`
- 6 machines d'état : lifecycle, cohort, session, enrollment, support-request, publication
- 12 fonctions exportées (2 par domaine)
- **79 tests**

### Permissions (`permissions.ts`)
- Matrices vue/édition pour les 3 rôles (`admin`, `participant`, `trainer`) sur 10 entités
- Helper `buildRow()` pour construction concise des lignes
- `getViewPermission(role, entity)` et `getEditPermission(role, entity)`
- **60 tests**

### Barrel (`index.ts`)
- Réexporte les deux modules

### Validation
- **139/139 tests passants** (vitest)
- TDD RED → GREEN → REFACTOR appliqué sur les deux modules
- Prettier ✅, ESLint ✅, typecheck ✅

Closes #72