### PR TITLE
feat(api-client): implement typed HTTP client for web and mobile

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@kraak/api-client",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@kraak/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "vitest": "^4.0.8"
+  }
+}

--- a/packages/api-client/src/client.spec.ts
+++ b/packages/api-client/src/client.spec.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createApiClient, ApiError } from './client';
+import type { ApiClient, ApiClientConfig } from './client';
+import type { CreateAppUserDto, CreateNotificationDto } from '@kraak/contracts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(status: number, body: unknown = null, statusText = 'OK') {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } satisfies Partial<Response> as unknown as Response);
+}
+
+function baseConfig(overrides?: Partial<ApiClientConfig>): ApiClientConfig {
+  return { baseUrl: 'https://api.test', ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Structure tests
+// ---------------------------------------------------------------------------
+
+describe('createApiClient', () => {
+  it('retourne un objet avec les 10 groupes de ressources', () => {
+    const client = createApiClient(baseConfig());
+    const keys = Object.keys(client).sort();
+    expect(keys).toEqual([
+      'announcements',
+      'cohorts',
+      'enrollments',
+      'notifications',
+      'participants',
+      'programs',
+      'resources',
+      'sessions',
+      'supportRequests',
+      'users',
+    ]);
+  });
+
+  it.each([
+    'users',
+    'participants',
+    'programs',
+    'cohorts',
+    'sessions',
+    'resources',
+    'announcements',
+    'enrollments',
+    'supportRequests',
+  ] as const)('%s expose getById, list, create, update, remove', (resource) => {
+    const client = createApiClient(baseConfig()) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(typeof client[resource].getById).toBe('function');
+    expect(typeof client[resource].list).toBe('function');
+    expect(typeof client[resource].create).toBe('function');
+    expect(typeof client[resource].update).toBe('function');
+    expect(typeof client[resource].remove).toBe('function');
+  });
+
+  it('notifications expose getById, list, create mais PAS update ni remove', () => {
+    const client = createApiClient(baseConfig());
+    expect(typeof client.notifications.getById).toBe('function');
+    expect(typeof client.notifications.list).toBe('function');
+    expect(typeof client.notifications.create).toBe('function');
+    expect(
+      (client.notifications as Record<string, unknown>)['update'],
+    ).toBeUndefined();
+    expect(
+      (client.notifications as Record<string, unknown>)['remove'],
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP behaviour tests
+// ---------------------------------------------------------------------------
+
+describe('HTTP behaviour', () => {
+  let fetchSpy: ReturnType<typeof mockFetch>;
+
+  beforeEach(() => {
+    fetchSpy = mockFetch(200, { id: '1' });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  it('GET /users/42 appelle fetch avec la bonne URL et méthode', async () => {
+    const client = createApiClient(baseConfig());
+    await client.users.getById('42');
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.test/users/42');
+    expect(init.method).toBe('GET');
+  });
+
+  it('GET /programs liste sans body', async () => {
+    fetchSpy = mockFetch(200, []);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    await client.programs.list();
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.test/programs');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('POST /users envoie le body JSON et retourne le DTO', async () => {
+    const created = { id: 'u1', email: 'a@b.c' };
+    fetchSpy = mockFetch(201, created);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    const body: CreateAppUserDto = {
+      email: 'a@b.c',
+      role: 'admin',
+      firstName: 'A',
+      lastName: 'B',
+    };
+    const result = await client.users.create(body);
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(body);
+    expect(result).toEqual(created);
+  });
+
+  it('PATCH /cohorts/:id envoie le body de mise à jour', async () => {
+    fetchSpy = mockFetch(200, { id: 'c1', name: 'updated' });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    await client.cohorts.update('c1', { name: 'updated' });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.test/cohorts/c1');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'updated' });
+  });
+
+  it('DELETE /sessions/:id envoie sans body', async () => {
+    fetchSpy = mockFetch(204);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    await client.sessions.remove('s1');
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.test/sessions/s1');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('POST /notifications crée une notification (immutable)', async () => {
+    const dto = { id: 'n1', title: 'Hello' };
+    fetchSpy = mockFetch(201, dto);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    const body: CreateNotificationDto = {
+      userId: 'u1',
+      title: 'Hello',
+      body: 'World',
+      notificationType: 'system',
+      channel: 'in_app',
+    };
+    const result = await client.notifications.create(body);
+
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://api.test/notifications');
+    expect(result).toEqual(dto);
+  });
+
+  it('support-requests utilise le bon chemin avec tiret', async () => {
+    fetchSpy = mockFetch(200, []);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    await client.supportRequests.list();
+
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://api.test/support-requests');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Headers & auth tests
+// ---------------------------------------------------------------------------
+
+describe('en-têtes et authentification', () => {
+  let fetchSpy: ReturnType<typeof mockFetch>;
+
+  beforeEach(() => {
+    fetchSpy = mockFetch(200, {});
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  it('envoie Content-Type et Accept par défaut', async () => {
+    const client = createApiClient(baseConfig());
+    await client.users.list();
+
+    const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['Accept']).toBe('application/json');
+  });
+
+  it('injecte le token Authorization quand getAuthToken est fourni', async () => {
+    const client = createApiClient(
+      baseConfig({ getAuthToken: () => 'tok_123' }),
+    );
+    await client.users.list();
+
+    const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer tok_123');
+  });
+
+  it('supporte getAuthToken asynchrone', async () => {
+    const client = createApiClient(
+      baseConfig({ getAuthToken: async () => 'async_tok' }),
+    );
+    await client.users.list();
+
+    const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer async_tok');
+  });
+
+  it("n'envoie pas Authorization quand getAuthToken retourne null", async () => {
+    const client = createApiClient(baseConfig({ getAuthToken: () => null }));
+    await client.users.list();
+
+    const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('fusionne defaultHeaders et requestOptions.headers', async () => {
+    const client = createApiClient(
+      baseConfig({ defaultHeaders: { 'X-Custom': 'default' } }),
+    );
+    await client.users.list({ headers: { 'X-Request': 'override' } });
+
+    const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['X-Custom']).toBe('default');
+    expect(headers['X-Request']).toBe('override');
+  });
+
+  it('transmet le signal AbortSignal', async () => {
+    const controller = new AbortController();
+    const client = createApiClient(baseConfig());
+    await client.users.list({ signal: controller.signal });
+
+    expect(fetchSpy.mock.calls[0][1].signal).toBe(controller.signal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling tests
+// ---------------------------------------------------------------------------
+
+describe('gestion des erreurs', () => {
+  it('lance ApiError pour une réponse non-ok avec body JSON', async () => {
+    const errorBody = { message: 'Non trouvé' };
+    vi.stubGlobal('fetch', mockFetch(404, errorBody, 'Not Found'));
+
+    const client = createApiClient(baseConfig());
+
+    await expect(client.users.getById('999')).rejects.toThrow(ApiError);
+
+    try {
+      await client.users.getById('999');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(404);
+      expect(apiErr.statusText).toBe('Not Found');
+      expect(apiErr.body).toEqual(errorBody);
+    }
+  });
+
+  it("lance ApiError même quand le body n'est pas du JSON", async () => {
+    const badFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.reject(new Error('invalid json')),
+      text: () => Promise.resolve('crash'),
+    });
+    vi.stubGlobal('fetch', badFetch);
+
+    const client = createApiClient(baseConfig());
+    await expect(client.programs.list()).rejects.toThrow(ApiError);
+  });
+
+  it('ApiError.message contient status et statusText', () => {
+    const err = new ApiError(403, 'Forbidden', null);
+    expect(err.message).toBe('403 Forbidden');
+    expect(err.name).toBe('ApiError');
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,0 +1,244 @@
+import type {
+  AppUserDto,
+  CreateAppUserDto,
+  UpdateAppUserDto,
+  ParticipantDto,
+  CreateParticipantDto,
+  UpdateParticipantDto,
+  ProgramDto,
+  CreateProgramDto,
+  UpdateProgramDto,
+  CohortDto,
+  CreateCohortDto,
+  UpdateCohortDto,
+  SessionDto,
+  CreateSessionDto,
+  UpdateSessionDto,
+  ResourceDto,
+  CreateResourceDto,
+  UpdateResourceDto,
+  AnnouncementDto,
+  CreateAnnouncementDto,
+  UpdateAnnouncementDto,
+  EnrollmentDto,
+  CreateEnrollmentDto,
+  UpdateEnrollmentDto,
+  NotificationDto,
+  CreateNotificationDto,
+  SupportRequestDto,
+  CreateSupportRequestDto,
+  UpdateSupportRequestDto,
+} from '@kraak/contracts';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface ApiClientConfig {
+  baseUrl: string;
+  getAuthToken?: () => string | null | Promise<string | null>;
+  defaultHeaders?: Record<string, string>;
+}
+
+export interface RequestOptions {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+// ---------------------------------------------------------------------------
+// Generic resource client types
+// ---------------------------------------------------------------------------
+
+export interface ReadonlyResourceClient<TDto> {
+  getById(id: string, options?: RequestOptions): Promise<TDto>;
+  list(options?: RequestOptions): Promise<TDto[]>;
+}
+
+export interface CreatableResourceClient<
+  TDto,
+  TCreate,
+> extends ReadonlyResourceClient<TDto> {
+  create(body: TCreate, options?: RequestOptions): Promise<TDto>;
+}
+
+export interface FullResourceClient<
+  TDto,
+  TCreate,
+  TUpdate,
+> extends CreatableResourceClient<TDto, TCreate> {
+  update(id: string, body: TUpdate, options?: RequestOptions): Promise<TDto>;
+  remove(id: string, options?: RequestOptions): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// ApiClient interface
+// ---------------------------------------------------------------------------
+
+export interface ApiClient {
+  users: FullResourceClient<AppUserDto, CreateAppUserDto, UpdateAppUserDto>;
+  participants: FullResourceClient<
+    ParticipantDto,
+    CreateParticipantDto,
+    UpdateParticipantDto
+  >;
+  programs: FullResourceClient<ProgramDto, CreateProgramDto, UpdateProgramDto>;
+  cohorts: FullResourceClient<CohortDto, CreateCohortDto, UpdateCohortDto>;
+  sessions: FullResourceClient<SessionDto, CreateSessionDto, UpdateSessionDto>;
+  resources: FullResourceClient<
+    ResourceDto,
+    CreateResourceDto,
+    UpdateResourceDto
+  >;
+  announcements: FullResourceClient<
+    AnnouncementDto,
+    CreateAnnouncementDto,
+    UpdateAnnouncementDto
+  >;
+  enrollments: FullResourceClient<
+    EnrollmentDto,
+    CreateEnrollmentDto,
+    UpdateEnrollmentDto
+  >;
+  notifications: CreatableResourceClient<
+    NotificationDto,
+    CreateNotificationDto
+  >;
+  supportRequests: FullResourceClient<
+    SupportRequestDto,
+    CreateSupportRequestDto,
+    UpdateSupportRequestDto
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: unknown,
+  ) {
+    super(`${status} ${statusText}`);
+    this.name = 'ApiError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function buildHeaders(
+  config: ApiClientConfig,
+  options?: RequestOptions,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...config.defaultHeaders,
+    ...options?.headers,
+  };
+
+  if (config.getAuthToken) {
+    const token = await config.getAuthToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  return headers;
+}
+
+async function request<T>(
+  config: ApiClientConfig,
+  method: string,
+  path: string,
+  body?: unknown,
+  options?: RequestOptions,
+): Promise<T> {
+  const url = `${config.baseUrl}${path}`;
+  const headers = await buildHeaders(config, options);
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    let errorBody: unknown;
+    try {
+      errorBody = await response.json();
+    } catch {
+      errorBody = await response.text().catch(() => null);
+    }
+    throw new ApiError(response.status, response.statusText, errorBody);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Resource client factories (composed to avoid duplication)
+// ---------------------------------------------------------------------------
+
+function createReadonlyResourceClient<TDto>(
+  config: ApiClientConfig,
+  basePath: string,
+): ReadonlyResourceClient<TDto> {
+  return {
+    getById: (id, options?) =>
+      request<TDto>(config, 'GET', `${basePath}/${id}`, undefined, options),
+    list: (options?) =>
+      request<TDto[]>(config, 'GET', basePath, undefined, options),
+  };
+}
+
+function createCreatableResourceClient<TDto, TCreate>(
+  config: ApiClientConfig,
+  basePath: string,
+): CreatableResourceClient<TDto, TCreate> {
+  return {
+    ...createReadonlyResourceClient<TDto>(config, basePath),
+    create: (body, options?) =>
+      request<TDto>(config, 'POST', basePath, body, options),
+  };
+}
+
+function createFullResourceClient<TDto, TCreate, TUpdate>(
+  config: ApiClientConfig,
+  basePath: string,
+): FullResourceClient<TDto, TCreate, TUpdate> {
+  return {
+    ...createCreatableResourceClient<TDto, TCreate>(config, basePath),
+    update: (id, body, options?) =>
+      request<TDto>(config, 'PATCH', `${basePath}/${id}`, body, options),
+    remove: (id, options?) =>
+      request<void>(config, 'DELETE', `${basePath}/${id}`, undefined, options),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createApiClient(config: ApiClientConfig): ApiClient {
+  return {
+    users: createFullResourceClient(config, '/users'),
+    participants: createFullResourceClient(config, '/participants'),
+    programs: createFullResourceClient(config, '/programs'),
+    cohorts: createFullResourceClient(config, '/cohorts'),
+    sessions: createFullResourceClient(config, '/sessions'),
+    resources: createFullResourceClient(config, '/resources'),
+    announcements: createFullResourceClient(config, '/announcements'),
+    enrollments: createFullResourceClient(config, '/enrollments'),
+    notifications: createCreatableResourceClient(config, '/notifications'),
+    supportRequests: createFullResourceClient(config, '/support-requests'),
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,9 @@
+export { createApiClient, ApiError } from './client';
+export type {
+  ApiClient,
+  ApiClientConfig,
+  RequestOptions,
+  ReadonlyResourceClient,
+  CreatableResourceClient,
+  FullResourceClient,
+} from './client';

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/packages/domain/src/permissions.spec.ts
+++ b/packages/domain/src/permissions.spec.ts
@@ -13,21 +13,15 @@ const allEntities = Object.values(Entity) as EntityValue[];
 
 describe('getViewPermission', () => {
   describe('Given an admin role', () => {
-    it.each(allEntities)(
-      'When checking %s / Then returns "all"',
-      (entity) => {
-        expect(getViewPermission(UserRole.ADMIN, entity)).toBe('all');
-      },
-    );
+    it.each(allEntities)('When checking %s / Then returns "all"', (entity) => {
+      expect(getViewPermission(UserRole.ADMIN, entity)).toBe('all');
+    });
   });
 
   describe('Given a participant role', () => {
-    it.each(allEntities)(
-      'When checking %s / Then returns "own"',
-      (entity) => {
-        expect(getViewPermission(UserRole.PARTICIPANT, entity)).toBe('own');
-      },
-    );
+    it.each(allEntities)('When checking %s / Then returns "own"', (entity) => {
+      expect(getViewPermission(UserRole.PARTICIPANT, entity)).toBe('own');
+    });
   });
 
   describe('Given a trainer role', () => {
@@ -43,17 +37,14 @@ describe('getViewPermission', () => {
       Entity.SUPPORT_REQUEST,
     ];
 
-    it.each(ownEntities)(
-      'When checking %s / Then returns "own"',
-      (entity) => {
-        expect(getViewPermission(UserRole.TRAINER, entity)).toBe('own');
-      },
-    );
+    it.each(ownEntities)('When checking %s / Then returns "own"', (entity) => {
+      expect(getViewPermission(UserRole.TRAINER, entity)).toBe('own');
+    });
 
     it('When checking Enrollment / Then returns "none"', () => {
-      expect(
-        getViewPermission(UserRole.TRAINER, Entity.ENROLLMENT),
-      ).toBe('none');
+      expect(getViewPermission(UserRole.TRAINER, Entity.ENROLLMENT)).toBe(
+        'none',
+      );
     });
   });
 });
@@ -62,12 +53,9 @@ describe('getViewPermission', () => {
 
 describe('getEditPermission', () => {
   describe('Given an admin role', () => {
-    it.each(allEntities)(
-      'When checking %s / Then returns "all"',
-      (entity) => {
-        expect(getEditPermission(UserRole.ADMIN, entity)).toBe('all');
-      },
-    );
+    it.each(allEntities)('When checking %s / Then returns "all"', (entity) => {
+      expect(getEditPermission(UserRole.ADMIN, entity)).toBe('all');
+    });
   });
 
   describe('Given a participant role', () => {
@@ -86,12 +74,9 @@ describe('getEditPermission', () => {
       Entity.NOTIFICATION,
     ];
 
-    it.each(ownEntities)(
-      'When checking %s / Then returns "own"',
-      (entity) => {
-        expect(getEditPermission(UserRole.PARTICIPANT, entity)).toBe('own');
-      },
-    );
+    it.each(ownEntities)('When checking %s / Then returns "own"', (entity) => {
+      expect(getEditPermission(UserRole.PARTICIPANT, entity)).toBe('own');
+    });
 
     it.each(noneEntities)(
       'When checking %s / Then returns "none"',
@@ -117,12 +102,9 @@ describe('getEditPermission', () => {
       Entity.NOTIFICATION,
     ];
 
-    it.each(ownEntities)(
-      'When checking %s / Then returns "own"',
-      (entity) => {
-        expect(getEditPermission(UserRole.TRAINER, entity)).toBe('own');
-      },
-    );
+    it.each(ownEntities)('When checking %s / Then returns "own"', (entity) => {
+      expect(getEditPermission(UserRole.TRAINER, entity)).toBe('own');
+    });
 
     it.each(noneEntities)(
       'When checking %s / Then returns "none"',

--- a/packages/domain/src/permissions.ts
+++ b/packages/domain/src/permissions.ts
@@ -24,7 +24,10 @@ export type PermissionLevel = 'all' | 'own' | 'none';
 
 // ── Matrices de permission ──────────────────────────────────────────
 
-type PermissionMatrix = Record<UserRoleValue, Record<EntityValue, PermissionLevel>>;
+type PermissionMatrix = Record<
+  UserRoleValue,
+  Record<EntityValue, PermissionLevel>
+>;
 
 const allEntities = Object.values(Entity) as EntityValue[];
 

--- a/packages/domain/src/transitions.spec.ts
+++ b/packages/domain/src/transitions.spec.ts
@@ -310,9 +310,9 @@ describe('canTransitionSupportRequestStatus', () => {
 
 describe('getNextSupportRequestStatuses', () => {
   it('returns [in_progress] from open', () => {
-    expect(
-      getNextSupportRequestStatuses(SupportRequestStatus.OPEN),
-    ).toEqual([SupportRequestStatus.IN_PROGRESS]);
+    expect(getNextSupportRequestStatuses(SupportRequestStatus.OPEN)).toEqual([
+      SupportRequestStatus.IN_PROGRESS,
+    ]);
   });
 
   it('returns [resolved] from in_progress', () => {
@@ -328,9 +328,9 @@ describe('getNextSupportRequestStatuses', () => {
   });
 
   it('returns [] from closed', () => {
-    expect(
-      getNextSupportRequestStatuses(SupportRequestStatus.CLOSED),
-    ).toEqual([]);
+    expect(getNextSupportRequestStatuses(SupportRequestStatus.CLOSED)).toEqual(
+      [],
+    );
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,19 @@ importers:
         specifier: ^4.0.8
         version: 4.1.4(@types/node@20.19.39)(jsdom@28.1.0)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
 
+  packages/api-client:
+    dependencies:
+      '@kraak/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^4.0.8
+        version: 4.1.4(@types/node@20.19.39)(jsdom@28.1.0)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+
   packages/contracts:
     dependencies:
       zod:


### PR DESCRIPTION
## Résumé

Client API typé générique pour les projets web et mobile, consommant les DTOs de `@kraak/contracts`.

### Ajouts

- **`createApiClient(config)`** : factory principale retournant un objet typé avec 10 ressources
- **3 niveaux de clients** : `ReadonlyResourceClient`, `CreatableResourceClient`, `FullResourceClient`
- **`ApiError`** : classe d'erreur enrichie (status, statusText, body)
- **Gestion d'authentification** : injection Bearer token (sync/async), merging d'en-têtes, AbortSignal
- **27 tests unitaires** couvrant structure, HTTP, auth, erreurs

### Ressources exposées

| Ressource | Type de client |
|---|---|
| users, participants, programs, cohorts, sessions, resources, announcements, enrollments, supportRequests | FullResourceClient |
| notifications | CreatableResourceClient (pas d'update/remove) |

### TDD

- RED → GREEN → REFACTOR (composition 3 niveaux de factories)
- 27/27 tests verts

### Corrections incluses

- Formatage Prettier de 3 fichiers `packages/domain` (pre-commit hook)

Closes #73