### PR TITLE
[codex] Document active Vercel domain

### DIFF
--- a/docs/runbooks/ENVIRONMENT_VARIABLES.md
+++ b/docs/runbooks/ENVIRONMENT_VARIABLES.md
@@ -9,6 +9,12 @@ Ne jamais commiter de secrets dans le depot.
 - `PUBLIC_GA4_ID`: identifiant Google Analytics 4
 - `PUBLIC_API_BASE_URL`: URL de base de l'API backend
 
+## Domaines publics documentes
+
+- Domaine Vercel actuellement aligne sur le depot : `https://kraak-group.vercel.app`
+- Tant qu'aucun domaine custom n'est branche, garder `PUBLIC_SITE_URL` alignee
+  sur cette URL pour les environnements web publics heberges sur Vercel.
+
 ## Backend (apps/api)
 
 - `NODE_ENV`: `development` | `test` | `production`


### PR DESCRIPTION
## Resume
- documente le domaine public Vercel actuellement actif dans le runbook d'environnement
- garde une trace repo du renommage du projet Vercel vers kraak-group
- formalise l'URL a conserver dans PUBLIC_SITE_URL tant qu'aucun domaine custom n'est branche

## Pourquoi
- le changement principal a ete realise cote Vercel et devait laisser une trace versionnee dans le depot
- le workflow Git demande un item de suivi, une branche isolee, une PR et une fusion propre sur main

## Validation
- verification CLI Vercel des alias actifs, y compris kraak-group.vercel.app
- pnpm typecheck
- pnpm test:api

Closes #159