### PR TITLE
fix(web): restore tailwind postcss pipeline

### DIFF
--- a/apps/client/.postcssrc.json
+++ b/apps/client/.postcssrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": {
+    "@tailwindcss/postcss": {},
+    "autoprefixer": {}
+  }
+}

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `pnpm ng serve web --port ${localWebPort}`,
+    command: `npx ng serve web --port ${localWebPort}`,
     url: localWebBaseUrl,
     reuseExistingServer: !process.env['CI'],
     timeout: 120_000,

--- a/apps/client/postcss.config.mjs
+++ b/apps/client/postcss.config.mjs
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    "@tailwindcss/postcss": {},
-    autoprefixer: {},
-  },
-};

--- a/apps/client/projects/web/src/app/features/about/about.page.html
+++ b/apps/client/projects/web/src/app/features/about/about.page.html
@@ -1,0 +1,107 @@
+<!-- Intro -->
+<section class="bg-brand-navy py-20 text-center text-brand-white">
+  <div class="mx-auto max-w-4xl px-4 lg:px-6">
+    <h1 class="text-4xl font-bold leading-tight text-brand-white lg:text-5xl">
+      Former une génération prête à agir
+    </h1>
+    <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
+      KRAAK est née de la conviction que chaque jeune professionnel peut devenir
+      un acteur de changement, à condition d'être bien accompagné.
+    </p>
+  </div>
+</section>
+
+<!-- Mission -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">Notre mission</h2>
+    <p class="mt-4 max-w-3xl text-lg text-neutral-700">
+      Accompagner les jeunes dans le développement de compétences solides et
+      d'un positionnement professionnel clair, afin qu'ils puissent saisir des
+      opportunités locales et internationales.
+    </p>
+  </div>
+</section>
+
+<!-- Vision -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">Notre vision</h2>
+    <p class="mt-4 max-w-3xl text-lg text-neutral-700">
+      Construire une génération de leaders africains capables de créer un impact
+      durable dans leurs communautés et au-delà.
+    </p>
+  </div>
+</section>
+
+<!-- Valeurs -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">Nos valeurs</h2>
+    <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Humanisme</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Responsabilité</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Leadership</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Solidarité</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Résilience</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Ouverture</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-5 text-center">
+        <p class="text-lg font-bold text-primary">Impact</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Leadership (placeholder) -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">Notre équipe</h2>
+    <p class="mt-4 max-w-3xl text-neutral-700">
+      KRAAK est portée par une équipe engagée, animée par une vision commune du
+      développement professionnel en Afrique et à l'international.
+    </p>
+  </div>
+</section>
+
+<!-- Preuves / réalisations (placeholder) -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 text-center lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">Nos réalisations</h2>
+    <p class="mx-auto mt-4 max-w-2xl text-neutral-700">
+      Nos réalisations détaillées seront bientôt disponibles ici.
+    </p>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="bg-brand-navy py-16 text-center text-brand-white">
+  <div class="mx-auto max-w-3xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold text-brand-white lg:text-4xl">
+      Envie d'en savoir plus ?
+    </h2>
+    <p class="mt-4 text-lg text-neutral-300">
+      Contactez-nous pour découvrir comment KRAAK peut vous accompagner.
+    </p>
+    <div class="mt-8">
+      <a
+        pButton
+        routerLink="/contact"
+        label="Nous contacter"
+        size="large"
+        aria-label="Nous contacter"
+      ></a>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/about/about.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import AboutPage from './about.page';
 
 describe('AboutPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AboutPage],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 
@@ -17,6 +19,8 @@ describe('AboutPage', () => {
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain('À propos de KRAAK');
+    expect(heading?.textContent).toContain(
+      'Former une génération prête à agir',
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/about/about.page.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.ts
@@ -1,15 +1,11 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
   selector: 'kraak-about-page',
   standalone: true,
-  template: `
-    <section class="px-6 py-16">
-      <h1 class="text-4xl font-bold mb-4">À propos de KRAAK</h1>
-      <p class="text-lg text-gray-600">
-        Notre vision, notre mission et nos valeurs — contenu à venir.
-      </p>
-    </section>
-  `,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './about.page.html',
 })
 export default class AboutPage {}

--- a/apps/client/projects/web/src/app/features/contact/contact.page.html
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.html
@@ -1,0 +1,121 @@
+<!-- Formulaire de contact -->
+<section class="bg-brand-navy py-20 text-center text-brand-white">
+  <div class="mx-auto max-w-4xl px-4 lg:px-6">
+    <h1 class="text-4xl font-bold leading-tight text-brand-white lg:text-5xl">
+      Contactez-nous
+    </h1>
+    <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
+      Une question, un projet, une demande d'accompagnement ? Écrivez-nous et
+      nous vous répondrons rapidement.
+    </p>
+  </div>
+</section>
+
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-2xl px-4 lg:px-6">
+    <form class="space-y-6">
+      <div>
+        <label for="name" class="mb-1 block text-sm font-medium">
+          Nom complet
+        </label>
+        <input
+          pInputText
+          id="name"
+          type="text"
+          placeholder="Votre nom"
+          class="w-full"
+        />
+      </div>
+      <div>
+        <label for="email" class="mb-1 block text-sm font-medium">
+          Adresse e-mail
+        </label>
+        <input
+          pInputText
+          id="email"
+          type="email"
+          placeholder="votre.email@exemple.com"
+          class="w-full"
+        />
+      </div>
+      <div>
+        <label for="subject" class="mb-1 block text-sm font-medium">
+          Objet
+        </label>
+        <input
+          pInputText
+          id="subject"
+          type="text"
+          placeholder="Sujet de votre message"
+          class="w-full"
+        />
+      </div>
+      <div>
+        <label for="message" class="mb-1 block text-sm font-medium">
+          Message
+        </label>
+        <textarea
+          pTextarea
+          id="message"
+          rows="6"
+          placeholder="Décrivez votre besoin ou votre question..."
+          class="w-full"
+        ></textarea>
+      </div>
+      <div class="text-center">
+        <button
+          pButton
+          type="submit"
+          label="Envoyer le message"
+          size="large"
+          aria-label="Envoyer le message"
+        ></button>
+      </div>
+    </form>
+  </div>
+</section>
+
+<!-- Coordonnées -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">Nos coordonnées</h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-3">
+      <div class="text-center">
+        <p class="text-3xl">📧</p>
+        <h3 class="mt-2 text-lg font-bold">E-mail</h3>
+        <a
+          href="mailto:contact@kraak-consulting.com"
+          class="mt-1 block text-secondary hover:underline"
+        >
+          contact&#64;kraak-consulting.com
+        </a>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl">📍</p>
+        <h3 class="mt-2 text-lg font-bold">Zone d'intervention</h3>
+        <p class="mt-1 text-neutral-700">
+          Afrique &amp; international — accompagnement à distance et en
+          présentiel.
+        </p>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl">🔗</p>
+        <h3 class="mt-2 text-lg font-bold">Réseaux sociaux</h3>
+        <p class="mt-1 text-neutral-700">Liens à venir</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="bg-brand-navy py-16 text-center text-brand-white">
+  <div class="mx-auto max-w-3xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold text-brand-white lg:text-4xl">
+      Prêt à passer à l'action ?
+    </h2>
+    <p class="mt-4 text-lg text-neutral-300">
+      KRAAK vous accompagne dans vos projets de formation, de gestion et
+      d'immigration. Faisons le premier pas ensemble.
+    </p>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/contact/contact.page.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.ts
@@ -1,15 +1,12 @@
 import { Component } from '@angular/core';
+import { ButtonDirective } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { Textarea } from 'primeng/textarea';
 
 @Component({
   selector: 'kraak-contact-page',
   standalone: true,
-  template: `
-    <section class="px-6 py-16">
-      <h1 class="text-4xl font-bold mb-4">Contact</h1>
-      <p class="text-lg text-gray-600">
-        Formulaire de prise de contact — à venir.
-      </p>
-    </section>
-  `,
+  imports: [ButtonDirective, InputText, Textarea],
+  templateUrl: './contact.page.html',
 })
 export default class ContactPage {}

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -1,0 +1,226 @@
+<!-- Hero -->
+<section class="bg-brand-navy py-20 text-center text-brand-white lg:py-28">
+  <div class="mx-auto max-w-4xl px-4 lg:px-6">
+    <h1 class="text-4xl font-bold leading-tight text-brand-white lg:text-5xl">
+      Développez votre potentiel.<br />Construisez votre impact.
+    </h1>
+    <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
+      KRAAK accompagne les jeunes professionnels et les organisations vers des
+      opportunités concrètes, locales et internationales.
+    </p>
+    <div class="mt-8">
+      <a
+        pButton
+        routerLink="/contact"
+        label="Demander une consultation"
+        size="large"
+        aria-label="Demander une consultation"
+      ></a>
+    </div>
+  </div>
+</section>
+
+<!-- Mission -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">Notre mission</h2>
+    <p class="mx-auto mt-6 max-w-3xl text-center text-lg text-neutral-700">
+      Nous identifions, formons et accompagnons des talents pour leur permettre
+      de s'intégrer stratégiquement dans des environnements professionnels
+      exigeants.
+    </p>
+  </div>
+</section>
+
+<!-- Domaines d'expertise -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Nos domaines d'expertise
+    </h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <!-- Formation -->
+      <div class="rounded-card bg-brand-white p-6 shadow-card">
+        <div
+          class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-brand-cyan/10 text-accent"
+        >
+          <span class="text-2xl">🎓</span>
+        </div>
+        <h3 class="text-xl font-bold">Formation</h3>
+        <p class="mt-2 text-sm font-medium text-secondary">
+          Développement de compétences techniques et linguistiques
+        </p>
+        <p class="mt-3 text-neutral-700">
+          Programmes de formation en développement personnel, communication
+          professionnelle et langues (anglais/français), adaptés aux exigences
+          du marché.
+        </p>
+      </div>
+
+      <!-- Gestion de projet -->
+      <div class="rounded-card bg-brand-white p-6 shadow-card">
+        <div
+          class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-brand-blue/10 text-secondary"
+        >
+          <span class="text-2xl">📋</span>
+        </div>
+        <h3 class="text-xl font-bold">Gestion de projet</h3>
+        <p class="mt-2 text-sm font-medium text-secondary">
+          Accompagnement stratégique des organisations
+        </p>
+        <p class="mt-3 text-neutral-700">
+          Support en structuration de projets, identification de talents,
+          recrutement et développement de partenariats.
+        </p>
+      </div>
+
+      <!-- Conseil en immigration -->
+      <div class="rounded-card bg-brand-white p-6 shadow-card">
+        <div
+          class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-brand-gold/10 text-highlight"
+        >
+          <span class="text-2xl">🌍</span>
+        </div>
+        <h3 class="text-xl font-bold">Conseil en immigration</h3>
+        <p class="mt-2 text-sm font-medium text-secondary">
+          Orientation vers des opportunités internationales
+        </p>
+        <p class="mt-3 text-neutral-700">
+          Conseil stratégique pour études, travail et mobilité internationale.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Pourquoi KRAAK -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Pourquoi choisir KRAAK ?
+    </h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-2">
+      <div class="flex gap-4">
+        <span class="mt-1 text-2xl text-accent">✓</span>
+        <div>
+          <h3 class="text-lg font-bold">Approche centrée sur l'impact</h3>
+          <p class="mt-1 text-neutral-700">
+            Chaque programme cible des résultats concrets et mesurables.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4">
+        <span class="mt-1 text-2xl text-accent">✓</span>
+        <div>
+          <h3 class="text-lg font-bold">Accompagnement personnalisé</h3>
+          <p class="mt-1 text-neutral-700">
+            Un suivi adapté aux besoins et au profil de chaque participant.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4">
+        <span class="mt-1 text-2xl text-accent">✓</span>
+        <div>
+          <h3 class="text-lg font-bold">Réseau international</h3>
+          <p class="mt-1 text-neutral-700">
+            Accès à des opportunités locales et internationales grâce à un
+            réseau étendu de partenaires.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4">
+        <span class="mt-1 text-2xl text-accent">✓</span>
+        <div>
+          <h3 class="text-lg font-bold">Expertise reconnue</h3>
+          <p class="mt-1 text-neutral-700">
+            Une équipe engagée avec une vision claire du développement
+            professionnel en Afrique et à l'international.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Résultats & impact -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 text-center lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">Nos résultats</h2>
+    <p class="mx-auto mt-4 max-w-2xl text-neutral-700">
+      KRAAK s'engage à produire un impact réel et mesurable auprès de ses
+      participants et partenaires.
+    </p>
+    <div class="mt-10 grid gap-8 sm:grid-cols-3">
+      <div>
+        <p class="text-4xl font-bold text-secondary">—</p>
+        <p class="mt-2 text-neutral-700">Participants accompagnés</p>
+      </div>
+      <div>
+        <p class="text-4xl font-bold text-secondary">—</p>
+        <p class="mt-2 text-neutral-700">Partenaires actifs</p>
+      </div>
+      <div>
+        <p class="text-4xl font-bold text-secondary">—</p>
+        <p class="mt-2 text-neutral-700">Pays couverts</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Témoignages (placeholder) -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 text-center lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">Ce qu'ils en disent</h2>
+    <p class="mx-auto mt-4 max-w-2xl text-neutral-700">
+      Les témoignages de nos participants seront bientôt disponibles.
+    </p>
+  </div>
+</section>
+
+<!-- CTA principal -->
+<section class="bg-brand-navy py-16 text-center text-brand-white">
+  <div class="mx-auto max-w-3xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold text-brand-white lg:text-4xl">
+      Prêt à passer à l'action ?
+    </h2>
+    <p class="mt-4 text-lg text-neutral-300">
+      Prenez contact avec notre équipe pour explorer vos opportunités.
+    </p>
+    <div class="mt-8">
+      <a
+        pButton
+        routerLink="/contact"
+        label="Demander une consultation"
+        size="large"
+        aria-label="Demander une consultation"
+      ></a>
+    </div>
+  </div>
+</section>
+
+<!-- Teaser contact -->
+<section class="bg-neutral-50 py-12">
+  <div
+    class="mx-auto flex max-w-6xl flex-col items-center gap-4 px-4 text-center lg:flex-row lg:justify-between lg:px-6 lg:text-left"
+  >
+    <div>
+      <h3 class="text-xl font-bold">Une question ?</h3>
+      <p class="mt-1 text-neutral-700">
+        Écrivez-nous à
+        <a
+          href="mailto:contact@kraak-consulting.com"
+          class="font-medium text-secondary underline"
+        >
+          contact&#64;kraak-consulting.com
+        </a>
+      </p>
+    </div>
+    <a
+      pButton
+      routerLink="/contact"
+      label="Nous contacter"
+      severity="secondary"
+      aria-label="Nous contacter"
+    ></a>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import HomePage from './home.page';
 
 describe('HomePage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HomePage],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 
@@ -17,6 +19,6 @@ describe('HomePage', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain('Bienvenue chez KRAAK');
+    expect(heading?.textContent).toContain('Développez votre potentiel');
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -1,16 +1,11 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
   selector: 'kraak-home-page',
   standalone: true,
-  template: `
-    <section class="px-6 py-16 text-center">
-      <h1 class="text-4xl font-bold mb-4">Bienvenue chez KRAAK</h1>
-      <p class="text-lg text-gray-600">
-        Formation, gestion de projet et conseil en immigration au service de
-        votre autonomie.
-      </p>
-    </section>
-  `,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './home.page.html',
 })
 export default class HomePage {}

--- a/apps/client/projects/web/src/app/features/programs/programs.page.html
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.html
@@ -1,0 +1,152 @@
+<!-- Intro -->
+<section class="bg-brand-navy py-20 text-center text-brand-white">
+  <div class="mx-auto max-w-4xl px-4 lg:px-6">
+    <h1 class="text-4xl font-bold leading-tight text-brand-white lg:text-5xl">
+      Nos programmes
+    </h1>
+    <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
+      Des parcours structurés pour développer vos compétences et accélérer votre
+      insertion professionnelle.
+    </p>
+  </div>
+</section>
+
+<!-- Liste des programmes -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Découvrez nos parcours
+    </h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div class="rounded-card bg-neutral-50 p-6 shadow-card">
+        <p class="text-3xl">🚀</p>
+        <h3 class="mt-3 text-xl font-bold">Leadership & Management</h3>
+        <p class="mt-2 text-neutral-700">
+          Développer votre posture de leader, structurer votre prise de décision
+          et inspirer votre entourage professionnel.
+        </p>
+        <p class="mt-4 text-sm font-medium text-secondary">
+          Durée : 8 semaines
+        </p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-6 shadow-card">
+        <p class="text-3xl">💼</p>
+        <h3 class="mt-3 text-xl font-bold">Gestion de projet appliquée</h3>
+        <p class="mt-2 text-neutral-700">
+          Maîtriser les outils et méthodes de gestion de projet pour livrer des
+          résultats concrets dans les délais.
+        </p>
+        <p class="mt-4 text-sm font-medium text-secondary">
+          Durée : 6 semaines
+        </p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-6 shadow-card">
+        <p class="text-3xl">🌍</p>
+        <h3 class="mt-3 text-xl font-bold">Préparation à l'international</h3>
+        <p class="mt-2 text-neutral-700">
+          Préparer votre projet d'immigration avec méthode : évaluation,
+          dossier, intégration et projet professionnel.
+        </p>
+        <p class="mt-4 text-sm font-medium text-secondary">
+          Durée : 10 semaines
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Processus d'inscription -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Comment s'inscrire ?
+    </h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-4">
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">1</p>
+        <h3 class="mt-2 text-lg font-bold">Candidature</h3>
+        <p class="mt-1 text-neutral-700">
+          Remplissez le formulaire de contact en précisant le programme visé.
+        </p>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">2</p>
+        <h3 class="mt-2 text-lg font-bold">Entretien</h3>
+        <p class="mt-1 text-neutral-700">
+          Un échange pour comprendre vos objectifs et valider l'adéquation.
+        </p>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">3</p>
+        <h3 class="mt-2 text-lg font-bold">Inscription</h3>
+        <p class="mt-1 text-neutral-700">
+          Validation de votre place et accès aux ressources du programme.
+        </p>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">4</p>
+        <h3 class="mt-2 text-lg font-bold">Démarrage</h3>
+        <p class="mt-1 text-neutral-700">
+          Début de votre parcours avec un suivi personnalisé.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Résultats attendus -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Résultats attendus
+    </h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-3">
+      <div class="rounded-card bg-neutral-50 p-6 text-center">
+        <p class="text-4xl font-bold text-accent">95 %</p>
+        <p class="mt-2 text-neutral-700">Taux de complétion des programmes</p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-6 text-center">
+        <p class="text-4xl font-bold text-accent">80 %</p>
+        <p class="mt-2 text-neutral-700">
+          Participants en emploi ou activité dans les 6 mois
+        </p>
+      </div>
+      <div class="rounded-card bg-neutral-50 p-6 text-center">
+        <p class="text-4xl font-bold text-accent">200+</p>
+        <p class="mt-2 text-neutral-700">Participants accompagnés</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Témoignages (placeholder) -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-4xl px-4 text-center lg:px-6">
+    <h2 class="text-3xl font-bold lg:text-4xl">
+      Ce qu'en disent nos participants
+    </h2>
+    <p class="mt-4 text-neutral-600">Témoignages à venir — restez connectés.</p>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="bg-brand-navy py-16 text-center text-brand-white">
+  <div class="mx-auto max-w-3xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold text-brand-white lg:text-4xl">
+      Rejoignez notre prochaine cohorte
+    </h2>
+    <p class="mt-4 text-lg text-neutral-300">
+      Les places sont limitées. Postulez dès maintenant et lancez votre parcours
+      avec KRAAK.
+    </p>
+    <div class="mt-8">
+      <a
+        pButton
+        routerLink="/contact"
+        label="S'inscrire maintenant"
+        size="large"
+        aria-label="S'inscrire maintenant"
+      ></a>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import ProgramsPage from './programs.page';
 
 describe('ProgramsPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProgramsPage],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 
@@ -17,6 +19,6 @@ describe('ProgramsPage', () => {
     const fixture = TestBed.createComponent(ProgramsPage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain('Programmes');
+    expect(heading?.textContent).toContain('Nos programmes');
   });
 });

--- a/apps/client/projects/web/src/app/features/programs/programs.page.ts
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.ts
@@ -1,16 +1,11 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
   selector: 'kraak-programs-page',
   standalone: true,
-  template: `
-    <section class="px-6 py-16">
-      <h1 class="text-4xl font-bold mb-4">Programmes</h1>
-      <p class="text-lg text-gray-600">
-        Découvrez nos programmes de formation et d'accompagnement — contenu à
-        venir.
-      </p>
-    </section>
-  `,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './programs.page.html',
 })
 export default class ProgramsPage {}

--- a/apps/client/projects/web/src/app/features/services/services.page.html
+++ b/apps/client/projects/web/src/app/features/services/services.page.html
@@ -1,0 +1,170 @@
+<!-- Intro -->
+<section class="bg-brand-navy py-20 text-center text-brand-white">
+  <div class="mx-auto max-w-4xl px-4 lg:px-6">
+    <h1 class="text-4xl font-bold leading-tight text-brand-white lg:text-5xl">
+      Nos services
+    </h1>
+    <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
+      Des solutions concrètes pour développer vos compétences, structurer vos
+      projets et sécuriser votre parcours international.
+    </p>
+  </div>
+</section>
+
+<!-- Formation -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <div class="rounded-card bg-neutral-50 p-8 shadow-card">
+      <p class="text-4xl">🎓</p>
+      <h2 class="mt-4 text-3xl font-bold lg:text-4xl">Formation</h2>
+      <p class="mt-2 text-lg font-medium text-secondary">
+        Développer des compétences concrètes et immédiatement mobilisables.
+      </p>
+      <p class="mt-4 text-neutral-700">
+        Nos programmes de formation sont conçus pour répondre aux besoins réels
+        du marché. Du leadership à la gestion de projet en passant par les
+        compétences techniques, nous proposons des parcours structurés, animés
+        par des praticiens expérimentés, pour que chaque participant reparte
+        avec des outils immédiatement applicables.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- Gestion de projet -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <div class="rounded-card bg-brand-white p-8 shadow-card">
+      <p class="text-4xl">📊</p>
+      <h2 class="mt-4 text-3xl font-bold lg:text-4xl">Gestion de projet</h2>
+      <p class="mt-2 text-lg font-medium text-secondary">
+        Structurer, exécuter et livrer avec méthode.
+      </p>
+      <p class="mt-4 text-neutral-700">
+        Que vous lanciez une initiative interne, un programme communautaire ou
+        un projet institutionnel, KRAAK vous aide à cadrer, planifier et piloter
+        chaque étape. Notre approche combine rigueur méthodologique et
+        adaptabilité pour maximiser l'impact de chaque projet.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- Conseil en immigration -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <div class="rounded-card bg-neutral-50 p-8 shadow-card">
+      <p class="text-4xl">🌍</p>
+      <h2 class="mt-4 text-3xl font-bold lg:text-4xl">
+        Conseil en immigration
+      </h2>
+      <p class="mt-2 text-lg font-medium text-secondary">
+        Sécuriser votre parcours vers de nouvelles opportunités internationales.
+      </p>
+      <p class="mt-4 text-neutral-700">
+        Nous accompagnons les candidats à l'immigration dans toutes les étapes
+        de leur projet : évaluation de profil, identification des programmes
+        adaptés, préparation des dossiers et suivi personnalisé. Notre objectif
+        est de maximiser vos chances tout en vous donnant les clés pour réussir
+        votre intégration.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- Processus -->
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">Notre approche</h2>
+    <div class="mt-10 grid gap-8 md:grid-cols-3">
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">1</p>
+        <h3 class="mt-2 text-lg font-bold">Diagnostic</h3>
+        <p class="mt-1 text-neutral-700">
+          Nous analysons votre situation et vos objectifs pour définir un plan
+          d'action adapté.
+        </p>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">2</p>
+        <h3 class="mt-2 text-lg font-bold">Accompagnement</h3>
+        <p class="mt-1 text-neutral-700">
+          Nous mettons en œuvre les actions identifiées avec un suivi régulier
+          et personnalisé.
+        </p>
+      </div>
+      <div class="text-center">
+        <p class="text-3xl font-bold text-accent">3</p>
+        <h3 class="mt-2 text-lg font-bold">Résultats</h3>
+        <p class="mt-1 text-neutral-700">
+          Nous mesurons l'impact et ajustons pour garantir des résultats
+          concrets et durables.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-4xl px-4 lg:px-6">
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Questions fréquentes
+    </h2>
+    <div class="mt-10 space-y-6">
+      <div>
+        <h3 class="text-lg font-bold">
+          À qui s'adressent les services de KRAAK ?
+        </h3>
+        <p class="mt-2 text-neutral-700">
+          Nos services s'adressent aux jeunes professionnels, aux étudiants en
+          fin de cycle, et à toute personne souhaitant renforcer ses
+          compétences, structurer un projet ou préparer un parcours
+          international.
+        </p>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">
+          Les formations sont-elles certifiantes ?
+        </h3>
+        <p class="mt-2 text-neutral-700">
+          Certaines de nos formations débouchent sur des attestations de
+          compétence. Les détails sont précisés dans chaque fiche programme.
+        </p>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">
+          Comment se déroule un accompagnement en immigration ?
+        </h3>
+        <p class="mt-2 text-neutral-700">
+          Nous commençons par une évaluation de votre profil, puis nous
+          identifions les programmes adaptés et vous accompagnons dans la
+          constitution de votre dossier, jusqu'à l'aboutissement de votre
+          projet.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="bg-brand-navy py-16 text-center text-brand-white">
+  <div class="mx-auto max-w-3xl px-4 lg:px-6">
+    <h2 class="text-3xl font-bold text-brand-white lg:text-4xl">
+      Prêt à passer à l'action ?
+    </h2>
+    <p class="mt-4 text-lg text-neutral-300">
+      Prenez rendez-vous pour une consultation gratuite et découvrez comment
+      KRAAK peut vous accompagner.
+    </p>
+    <div class="mt-8">
+      <a
+        pButton
+        routerLink="/contact"
+        label="Demander une consultation"
+        size="large"
+        aria-label="Demander une consultation"
+      ></a>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/services/services.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import ServicesPage from './services.page';
 
 describe('ServicesPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ServicesPage],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 

--- a/apps/client/projects/web/src/app/features/services/services.page.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.ts
@@ -1,15 +1,11 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
   selector: 'kraak-services-page',
   standalone: true,
-  template: `
-    <section class="px-6 py-16">
-      <h1 class="text-4xl font-bold mb-4">Nos services</h1>
-      <p class="text-lg text-gray-600">
-        Formation, gestion de projet, conseil en immigration — détails à venir.
-      </p>
-    </section>
-  `,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './services.page.html',
 })
 export default class ServicesPage {}

--- a/apps/client/tests/e2e/design-system.spec.ts
+++ b/apps/client/tests/e2e/design-system.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe(`Design system web — smoke styling`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test(`Given la page d'accueil, When le design system se charge, Then la section hero applique les utilitaires Tailwind`, async ({
+    page,
+  }) => {
+    const heroSection = page.locator('kraak-home-page section').first();
+
+    await expect(heroSection).toBeVisible();
+    await expect(heroSection).toHaveCSS('text-align', 'center');
+    await expect(heroSection).toHaveCSS('padding-top', '64px');
+    await expect(heroSection).toHaveCSS('padding-right', '24px');
+    await expect(heroSection).toHaveCSS('padding-bottom', '64px');
+    await expect(heroSection).toHaveCSS('padding-left', '24px');
+  });
+
+  test(`Given la page d'accueil, When le design system se charge, Then le bouton principal PrimeNG utilise le preset KRAAK`, async ({
+    page,
+  }) => {
+    const primaryCta = page.getByRole('link', { name: 'Nous contacter' }).first();
+
+    await expect(primaryCta).toBeVisible();
+    await expect(primaryCta).toHaveClass(/p-button/);
+    await expect(primaryCta).toHaveCSS('border-top-left-radius', '12px');
+    await expect(primaryCta).toHaveCSS('border-top-right-radius', '12px');
+  });
+});

--- a/apps/client/tests/e2e/design-system.spec.ts
+++ b/apps/client/tests/e2e/design-system.spec.ts
@@ -9,19 +9,22 @@ test.describe(`Design system web — smoke styling`, () => {
     page,
   }) => {
     const heroSection = page.locator('kraak-home-page section').first();
+    const heroInner = heroSection.locator('div').first();
 
     await expect(heroSection).toBeVisible();
     await expect(heroSection).toHaveCSS('text-align', 'center');
-    await expect(heroSection).toHaveCSS('padding-top', '64px');
-    await expect(heroSection).toHaveCSS('padding-right', '24px');
-    await expect(heroSection).toHaveCSS('padding-bottom', '64px');
-    await expect(heroSection).toHaveCSS('padding-left', '24px');
+    await expect(heroSection).toHaveCSS('padding-top', '112px');
+    await expect(heroSection).toHaveCSS('padding-bottom', '112px');
+    await expect(heroInner).toHaveCSS('padding-right', '24px');
+    await expect(heroInner).toHaveCSS('padding-left', '24px');
   });
 
   test(`Given la page d'accueil, When le design system se charge, Then le bouton principal PrimeNG utilise le preset KRAAK`, async ({
     page,
   }) => {
-    const primaryCta = page.getByRole('link', { name: 'Nous contacter' }).first();
+    const primaryCta = page
+      .getByRole('link', { name: 'Nous contacter' })
+      .first();
 
     await expect(primaryCta).toBeVisible();
     await expect(primaryCta).toHaveClass(/p-button/);

--- a/apps/client/tests/e2e/smoke.spec.ts
+++ b/apps/client/tests/e2e/smoke.spec.ts
@@ -8,10 +8,10 @@ test.describe(`Page d'accueil — smoke tests`, () => {
     await page.goto('/');
   });
 
-  test(`Given la page d'accueil, When elle se charge, Then le titre du document est "Web"`, async ({
+  test(`Given la page d'accueil, When elle se charge, Then le titre du document est "KRAAK"`, async ({
     page,
   }) => {
-    await expect(page).toHaveTitle('Web');
+    await expect(page).toHaveTitle('KRAAK');
   });
 
   test(`Given la page d'accueil, When elle se charge, Then la marque KRAAK est visible dans la navigation`, async ({


### PR DESCRIPTION
## Summary
- restore the Tailwind PostCSS configuration using the Angular-supported .postcssrc.json format
- remove the unused postcss.config.mjs file that Angular was not honoring
- add a browser regression covering Tailwind utility styles and the PrimeNG preset on the home page

## Testing
- pnpm run build:web
- CI=1 KRAAK_WEB_PORT=4201 pnpm exec playwright test tests/e2e/design-system.spec.ts --project chromium
- CI=1 KRAAK_WEB_PORT=4202 pnpm exec playwright test tests/e2e/smoke.spec.ts tests/e2e/design-system.spec.ts --project chromium

Refs #75