### PR TITLE
chore(config): réorganiser les fichiers .env par application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,15 @@
 # ===========================
-# Variables d'environnement
+# Variables d'environnement — Racine (CI/CD uniquement)
 # ===========================
-# Copier ce fichier vers .env et renseigner les valeurs.
+# Ce fichier ne contient que les variables CI/CD transverses.
+# Pour les variables applicatives, voir :
+#   - apps/api/.env.example        (backend local)
+#   - apps/api/.env.staging.example (backend staging)
+#   - apps/client/.env.example      (client / E2E)
+#
 # Ne jamais commiter de secrets dans le dépôt.
-
-# --- Frontend (apps/client) ---
-PUBLIC_SITE_URL=http://localhost:4200
-PUBLIC_GA4_ID=
-PUBLIC_API_BASE_URL=http://localhost:3000
-
-# --- Backend (apps/api) ---
-NODE_ENV=development
-PORT=3000
-SUPABASE_URL=
-SUPABASE_SERVICE_ROLE_KEY=
-RESEND_API_KEY=
-CONTACT_TO_EMAIL=
-CORS_ALLOWED_ORIGINS=http://localhost:4200
+# Injecter les secrets CI/CD via GitHub Secrets ou les variables
+# d'environnement des hébergeurs (Vercel, Render).
 
 # --- CI/CD ---
 VERCEL_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ out/
 .env.local
 .env.*.local
 .env.staging
-!.env.staging.example
 
 # IDE / Éditeurs
 .idea/

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,19 @@
+# ===========================
+# Variables d'environnement — API (local)
+# ===========================
+# Copier ce fichier vers .env et renseigner les valeurs.
+# Ne jamais commiter de secrets dans le dépôt.
+
+NODE_ENV=development
+PORT=3000
+
+# Supabase
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Resend (envoi d'e-mails)
+RESEND_API_KEY=
+CONTACT_TO_EMAIL=
+
+# CORS
+CORS_ALLOWED_ORIGINS=http://localhost:4200

--- a/apps/api/.env.staging.example
+++ b/apps/api/.env.staging.example
@@ -1,21 +1,19 @@
 # ===========================
-# Variables d'environnement — Staging
+# Variables d'environnement — API (staging)
 # ===========================
 # Copier ce fichier vers .env.staging et renseigner les valeurs.
 # Ne jamais commiter de secrets dans le dépôt.
 
-# --- Backend (apps/api) ---
 NODE_ENV=staging
 PORT=3000
+
+# Supabase
 SUPABASE_URL=
-SUPABASE_PUBLISHABLE_KEY=
-SUPABASE_SECRET_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Resend (envoi d'e-mails)
 RESEND_API_KEY=
 CONTACT_TO_EMAIL=
-CORS_ALLOWED_ORIGINS=
 
-# --- CI/CD ---
-VERCEL_TOKEN=
-VERCEL_ORG_ID=
-VERCEL_PROJECT_ID=
-RENDER_API_KEY=
+# CORS
+CORS_ALLOWED_ORIGINS=https://kraak-group.vercel.app

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,5 +1,3 @@
-.vercel
-
 # Environnement
 .env
 .env.local

--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -1,0 +1,11 @@
+# ===========================
+# Variables d'environnement — Client (local)
+# ===========================
+# Copier ce fichier vers .env et renseigner les valeurs si besoin.
+#
+# Note : Angular utilise des fichiers environment.ts compilés à la build,
+# pas des variables .env à l'exécution.
+# Ce fichier concerne uniquement les scripts et les tests E2E.
+
+# Port du serveur de développement Angular (utilisé par Playwright)
+KRAAK_WEB_PORT=4200

--- a/docs/context/tech_stack.md
+++ b/docs/context/tech_stack.md
@@ -287,13 +287,14 @@ flowchart TD
 
 ## 8. Variables d’environnement recommandées
 
-### Variables front-end (`.env` racine / apps client)
+### Variables client (`apps/client/.env.example`)
 
-- `PUBLIC_SITE_URL`
-- `PUBLIC_API_BASE_URL`
-- `PUBLIC_GA4_ID`
+- `KRAAK_WEB_PORT` — port du serveur de dev Angular (scripts / Playwright)
 
-### Variables back-end (`apps/api`)
+> Angular utilise des fichiers `environment.ts` compilés à la build, pas des
+> variables `.env` à l'exécution.
+
+### Variables back-end (`apps/api/.env.example`)
 
 - `NODE_ENV`
 - `PORT`
@@ -303,10 +304,8 @@ flowchart TD
 - `RESEND_API_KEY`
 - `CONTACT_TO_EMAIL`
 
-Variables de staging déjà documentées dans `.env.staging.example` :
-
-- `SUPABASE_PUBLISHABLE_KEY`
-- `SUPABASE_SECRET_KEY`
+Les mêmes variables s'appliquent en staging (`apps/api/.env.staging.example`)
+avec des valeurs adaptées.
 
 ### Variables optionnelles mais utiles
 

--- a/docs/runbooks/DEV_MODE.md
+++ b/docs/runbooks/DEV_MODE.md
@@ -16,19 +16,21 @@ Avant de lancer quoi que ce soit :
 ### Configurer les variables d'environnement
 
 ```bash
-# À la racine du projet
-cp .env.example .env
+# Backend
+cp apps/api/.env.example apps/api/.env
+
+# Client (optionnel, utile pour Playwright / scripts)
+cp apps/client/.env.example apps/client/.env
 ```
 
 Remplir les valeurs — voir [`ENVIRONMENT_VARIABLES.md`](ENVIRONMENT_VARIABLES.md) pour la référence complète.
 
 **Variables minimales pour développer en local :**
 
-| Variable                    | Fichier | Exemple                        |
-| --------------------------- | ------- | ------------------------------ |
-| `SUPABASE_URL`              | `.env`  | `http://127.0.0.1:54321`       |
-| `SUPABASE_SERVICE_ROLE_KEY` | `.env`  | clé fournie par Supabase local |
-| `PUBLIC_API_BASE_URL`       | `.env`  | `http://localhost:3000`        |
+| Variable                    | Fichier         | Exemple                        |
+| --------------------------- | --------------- | ------------------------------ |
+| `SUPABASE_URL`              | `apps/api/.env` | `http://127.0.0.1:54321`       |
+| `SUPABASE_SERVICE_ROLE_KEY` | `apps/api/.env` | clé fournie par Supabase local |
 
 ---
 

--- a/docs/runbooks/ENVIRONMENT_VARIABLES.md
+++ b/docs/runbooks/ENVIRONMENT_VARIABLES.md
@@ -1,47 +1,76 @@
 # Variables d'environnement
 
-Ce document decrit les variables d'environnement du MVP.
-Ne jamais commiter de secrets dans le depot.
+Ce document decrit les variables d'environnement du MVP et leur emplacement
+dans le monorepo. Ne jamais commiter de secrets dans le depot.
 
-## Frontend (apps/client)
+## Organisation des fichiers
 
-- `PUBLIC_SITE_URL`: URL publique du site (ex: https://kraak.example)
-- `PUBLIC_GA4_ID`: identifiant Google Analytics 4
-- `PUBLIC_API_BASE_URL`: URL de base de l'API backend
+| Fichier                         | Contenu                                                |
+| ------------------------------- | ------------------------------------------------------ |
+| `apps/api/.env.example`         | Variables backend local (copier vers `.env`)           |
+| `apps/api/.env.staging.example` | Variables backend staging (copier vers `.env.staging`) |
+| `apps/client/.env.example`      | Variables client / scripts / E2E (copier vers `.env`)  |
+| `.env.example` (racine)         | Variables CI/CD uniquement                             |
+
+> Le client Angular n'utilise **pas** de `.env` a l'execution. Les URLs et cles
+> publiques sont gerees via les fichiers `environment.ts` dans
+> `apps/client/projects/web/src/environments/` et remplaces a la compilation
+> par `angular.json` (`fileReplacements`).
+
+## Backend — `apps/api/`
+
+Variables lues par `process.env` dans le code NestJS :
+
+| Variable                    | Description                        | Exemple local             |
+| --------------------------- | ---------------------------------- | ------------------------- |
+| `NODE_ENV`                  | Environnement d'execution          | `development`             |
+| `PORT`                      | Port d'ecoute de l'API             | `3000`                    |
+| `SUPABASE_URL`              | URL du projet Supabase             | `https://xxx.supabase.co` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Cle service role (secret)          | —                         |
+| `RESEND_API_KEY`            | Cle API Resend (secret)            | —                         |
+| `CONTACT_TO_EMAIL`          | Email destinataire des formulaires | `contact@kraak.org`       |
+| `CORS_ALLOWED_ORIGINS`      | Origines autorisees (virgule)      | `http://localhost:4200`   |
+
+En staging, les memes variables s'appliquent avec des valeurs differentes
+(voir `apps/api/.env.staging.example`).
+
+## Client — `apps/client/`
+
+| Variable         | Description                                    | Exemple |
+| ---------------- | ---------------------------------------------- | ------- |
+| `KRAAK_WEB_PORT` | Port du serveur de dev Angular (scripts / E2E) | `4200`  |
+
+Les URLs publiques (site, API, GA4) sont definies dans les fichiers
+`environment.ts` / `environment.staging.ts` / `environment.production.ts`
+sous `apps/client/projects/web/src/environments/`.
 
 ## Domaines publics documentes
 
 - Domaine Vercel actuellement aligne sur le depot : `https://kraak-group.vercel.app`
-- Tant qu'aucun domaine custom n'est branche, garder `PUBLIC_SITE_URL` alignee
-  sur cette URL pour les environnements web publics heberges sur Vercel.
+- Tant qu'aucun domaine custom n'est branche, garder les URLs alignees sur
+  cette adresse pour les environnements web publics heberges sur Vercel.
 
-## Backend (apps/api)
+## CI/CD — `.env.example` (racine)
 
-- `NODE_ENV`: `development` | `test` | `production`
-- `PORT`: port d'ecoute de l'API
-- `SUPABASE_URL`: URL du projet Supabase
-- `SUPABASE_SERVICE_ROLE_KEY`: cle service role (secret)
-- `RESEND_API_KEY`: cle API Resend (secret)
-- `CONTACT_TO_EMAIL`: email destinataire des formulaires
-- `CORS_ALLOWED_ORIGINS`: origines autorisees separees par virgule
+| Variable            | Description                     |
+| ------------------- | ------------------------------- |
+| `VERCEL_TOKEN`      | Token d'authentification Vercel |
+| `VERCEL_ORG_ID`     | ID organisation Vercel          |
+| `VERCEL_PROJECT_ID` | ID projet Vercel                |
+| `RENDER_API_KEY`    | Cle API Render                  |
 
-## Staging / variantes documentees
+Ces variables sont injectees via GitHub Secrets et ne sont pas necessaires
+en developpement local.
 
-- `.env.staging.example` utilise actuellement `SUPABASE_PUBLISHABLE_KEY` et
-  `SUPABASE_SECRET_KEY` pour les environnements de preproduction/staging.
-- Garder les noms de variables alignes entre les fichiers d'exemple, Render,
-  Vercel et le code avant tout changement d'environnement.
+## Deploiement — Render (`render.yaml`)
 
-## CI/CD
-
-- `VERCEL_TOKEN`
-- `VERCEL_ORG_ID`
-- `VERCEL_PROJECT_ID`
-- `RENDER_API_KEY`
+Le fichier `render.yaml` declare les variables d'environnement de production
+pour l'API : `NODE_ENV`, `PORT`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`,
+`RESEND_API_KEY`, `CONTACT_TO_EMAIL`, `CORS_ALLOWED_ORIGINS`.
 
 ## Convention de gestion
 
-- Utiliser `.env.example` sans valeurs sensibles.
+- Utiliser les fichiers `.env.example` sans valeurs sensibles.
 - Mettre a jour ce document a chaque ajout, suppression ou renommage de variable.
-- Injecter les secrets via GitHub Secrets/variables d'environnement hebergeur.
+- Injecter les secrets via GitHub Secrets ou variables d'environnement de l'hebergeur.
 - Rotation immediate en cas de fuite.


### PR DESCRIPTION
Closes #167

## Résumé

Réorganisation des fichiers `.env.example` et `.gitignore` pour isoler les variables d'environnement par application (racine, API, client) au lieu de tout centraliser à la racine.

## Changements

- **`.env.example` racine** : réduit aux seules variables globales du monorepo
- **`apps/api/.env.example`** : créé avec les variables spécifiques à l'API NestJS
- **`apps/api/.env.staging.example`** : déplacé depuis la racine
- **`apps/api/.gitignore`** : créé pour ignorer `.env*` localement
- **`apps/client/.env.example`** : créé avec les variables spécifiques au client Angular
- **`apps/client/.gitignore`** : mis à jour pour ignorer `.env*`
- **`.gitignore` racine** : nettoyé
- **Documentation** : `ENVIRONMENT_VARIABLES.md`, `DEV_MODE.md`, `tech_stack.md` mis à jour

## Validation

- Pre-commit : prettier ✅, lint ✅, commitlint ✅
- Pre-push : typecheck (web/mobile/api) ✅, tests API 14/14 ✅
