### PR TITLE
feat(web): intégrer formulaire contact avec gestion d'erreurs API

### DIFF
--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -1,15 +1,26 @@
 import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import ContactPage from './contact.page';
 
 describe('ContactPage', () => {
+  let httpTestingController: HttpTestingController;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ContactPage],
       providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   // Given la page de contact est chargée
@@ -90,5 +101,74 @@ describe('ContactPage', () => {
   it('devrait initialiser loading à false', () => {
     const fixture = TestBed.createComponent(ContactPage);
     expect(fixture.componentInstance.loading()).toBe(false);
+  });
+
+  // Given un formulaire valide
+  // When la soumission API réussit
+  // Then le formulaire est réinitialisé et le message de succès est affiché
+  it('devrait afficher un succès après une soumission réussie', () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      name: 'Alice Dupont',
+      email: 'alice@exemple.com',
+      subject: 'Renseignements',
+      message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
+    });
+
+    component.onSubmit();
+
+    const request = httpTestingController.expectOne((req) =>
+      req.url.endsWith('/contact'),
+    );
+    expect(request.request.method).toBe('POST');
+    request.flush({
+      success: true,
+      message: 'Votre message a bien été reçu.',
+    });
+
+    fixture.detectChanges();
+
+    expect(component.success()).toBe(true);
+    expect(component.apiErrors()).toEqual([]);
+    expect(component.loading()).toBe(false);
+  });
+
+  // Given un formulaire valide
+  // When l'API répond avec des erreurs de validation
+  // Then les erreurs API doivent être affichées dans la page
+  it('devrait afficher les erreurs API renvoyées par le backend', () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      name: 'Alice Dupont',
+      email: 'alice@exemple.com',
+      subject: 'Renseignements',
+      message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
+    });
+
+    component.onSubmit();
+
+    const request = httpTestingController.expectOne((req) =>
+      req.url.endsWith('/contact'),
+    );
+    request.flush(
+      { errors: ['Le nom est requis.', "L'objet est requis."] },
+      { status: 400, statusText: 'Bad Request' },
+    );
+
+    fixture.detectChanges();
+
+    expect(component.success()).toBe(false);
+    expect(component.loading()).toBe(false);
+    expect(component.apiErrors()).toEqual([
+      'Le nom est requis.',
+      "L'objet est requis.",
+    ]);
+    expect(fixture.nativeElement.textContent).toContain('Le nom est requis.');
   });
 });

--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -136,6 +136,44 @@ describe('ContactPage', () => {
     expect(component.loading()).toBe(false);
   });
 
+  // Given un succès précédent
+  // When l'utilisateur soumet à nouveau le formulaire
+  // Then success doit repasser à false immédiatement avant la réponse HTTP
+  it("devrait réinitialiser success à false au début d'une nouvelle soumission", () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    // Première soumission réussie
+    component.form.setValue({
+      name: 'Alice Dupont',
+      email: 'alice@exemple.com',
+      subject: 'Renseignements',
+      message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
+    });
+    component.onSubmit();
+    httpTestingController
+      .expectOne((req) => req.url.endsWith('/contact'))
+      .flush({ success: true, message: 'OK' });
+    fixture.detectChanges();
+    expect(component.success()).toBe(true);
+
+    // Deuxième soumission : success doit être false immédiatement
+    component.form.setValue({
+      name: 'Alice Dupont',
+      email: 'alice@exemple.com',
+      subject: 'Renseignements',
+      message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
+    });
+    component.onSubmit();
+    expect(component.success()).toBe(false);
+
+    // Flush pour ne pas laisser de requêtes en suspens
+    httpTestingController
+      .expectOne((req) => req.url.endsWith('/contact'))
+      .flush({ success: true, message: 'OK' });
+  });
+
   // Given un formulaire valide
   // When l'API répond avec des erreurs de validation
   // Then les erreurs API doivent être affichées dans la page

--- a/apps/client/projects/web/src/app/features/contact/contact.page.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.ts
@@ -1,4 +1,5 @@
 import { NgClass } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, inject, signal } from '@angular/core';
 import {
   AbstractControl,
@@ -9,8 +10,8 @@ import {
 } from '@angular/forms';
 import { ButtonDirective } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
-import { Textarea } from 'primeng/textarea';
 import { Message } from 'primeng/message';
+import { Textarea } from 'primeng/textarea';
 
 import { ContactService } from './contact.service';
 
@@ -73,6 +74,7 @@ export default class ContactPage {
     }
 
     this.loading.set(true);
+    this.success.set(false);
 
     this.contactService
       .submit({
@@ -82,22 +84,30 @@ export default class ContactPage {
         message: this.form.value.message!,
       })
       .subscribe({
-        next: (res) => {
+        next: () => {
           this.loading.set(false);
-          if ('errors' in res) {
-            this.apiErrors.set(res.errors);
-          } else {
-            this.success.set(true);
-            this.form.reset();
-            this.submitted.set(false);
-          }
+          this.success.set(true);
+          this.form.reset();
+          this.submitted.set(false);
         },
-        error: () => {
+        error: (errorResponse: HttpErrorResponse) => {
           this.loading.set(false);
-          this.apiErrors.set([
-            'Une erreur est survenue. Veuillez réessayer plus tard.',
-          ]);
+          this.apiErrors.set(this.extractApiErrors(errorResponse));
         },
       });
+  }
+
+  private extractApiErrors(errorResponse: HttpErrorResponse): string[] {
+    const rawErrors = (errorResponse.error as { errors?: unknown })?.errors;
+
+    if (
+      Array.isArray(rawErrors) &&
+      rawErrors.every((error) => typeof error === 'string') &&
+      rawErrors.length > 0
+    ) {
+      return rawErrors;
+    }
+
+    return ['Une erreur est survenue. Veuillez réessayer plus tard.'];
   }
 }

--- a/apps/client/projects/web/src/app/features/contact/contact.service.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.service.ts
@@ -16,21 +16,12 @@ export interface ContactResponse {
   message: string;
 }
 
-export interface ContactErrorResponse {
-  errors: string[];
-}
-
 @Injectable({ providedIn: 'root' })
 export class ContactService {
   private readonly http = inject(HttpClient);
   private readonly endpoint = `${environment.apiBaseUrl}/contact`;
 
-  submit(
-    payload: ContactPayload,
-  ): Observable<ContactResponse | ContactErrorResponse> {
-    return this.http.post<ContactResponse | ContactErrorResponse>(
-      this.endpoint,
-      payload,
-    );
+  submit(payload: ContactPayload): Observable<ContactResponse> {
+    return this.http.post<ContactResponse>(this.endpoint, payload);
   }
 }

--- a/apps/client/tests/e2e/contact-form.spec.ts
+++ b/apps/client/tests/e2e/contact-form.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+test.describe(`Page contact — comportement formulaire`, () => {
+  test(`Given la page contact, When l'utilisateur soumet un formulaire valide, Then un message de confirmation est affiché`, async ({
+    page,
+  }) => {
+    await page.route('**/contact', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          message:
+            'Votre message a bien été reçu. Nous vous répondrons dans les plus brefs délais.',
+        }),
+      });
+    });
+
+    await page.goto('/contact');
+
+    await page.getByLabel('Nom complet *').fill('Alice Dupont');
+    await page.getByLabel('Adresse e-mail *').fill('alice@exemple.com');
+    await page.getByLabel('Objet *').fill('Demande de renseignements');
+    await page
+      .getByLabel('Message *')
+      .fill('Bonjour, je souhaite discuter de vos programmes de formation.');
+
+    await page.getByRole('button', { name: 'Envoyer le message' }).click();
+
+    await expect(
+      page.getByText(
+        'Votre message a bien été envoyé. Nous vous répondrons dans les plus brefs délais.',
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/client/tests/e2e/contact-form.spec.ts
+++ b/apps/client/tests/e2e/contact-form.spec.ts
@@ -26,7 +26,7 @@ test.describe(`Page contact — comportement formulaire`, () => {
     await page.getByLabel('Adresse e-mail').fill('alice@exemple.com');
     await page.getByLabel('Objet').fill('Demande de renseignements');
     await page
-      .getByLabel('Message')
+      .getByRole('textbox', { name: 'Message' })
       .fill('Bonjour, je souhaite discuter de vos programmes de formation.');
 
     await page.getByRole('button', { name: 'Envoyer le message' }).click();

--- a/apps/client/tests/e2e/contact-form.spec.ts
+++ b/apps/client/tests/e2e/contact-form.spec.ts
@@ -5,6 +5,10 @@ test.describe(`Page contact — comportement formulaire`, () => {
     page,
   }) => {
     await page.route('**/contact', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -18,11 +22,11 @@ test.describe(`Page contact — comportement formulaire`, () => {
 
     await page.goto('/contact');
 
-    await page.getByLabel('Nom complet *').fill('Alice Dupont');
-    await page.getByLabel('Adresse e-mail *').fill('alice@exemple.com');
-    await page.getByLabel('Objet *').fill('Demande de renseignements');
+    await page.getByLabel('Nom complet').fill('Alice Dupont');
+    await page.getByLabel('Adresse e-mail').fill('alice@exemple.com');
+    await page.getByLabel('Objet').fill('Demande de renseignements');
     await page
-      .getByLabel('Message *')
+      .getByLabel('Message')
       .fill('Bonjour, je souhaite discuter de vos programmes de formation.');
 
     await page.getByRole('button', { name: 'Envoyer le message' }).click();


### PR DESCRIPTION
### Motivation
- Rendre le formulaire de contact web robuste face aux erreurs renvoyées par l'API en extrayant et affichant les `errors[]` de validation au lieu d'un message générique.
- Éviter les états incohérents après une nouvelle tentative de soumission en réinitialisant explicitement le signal `success` au moment de l'envoi.

### Description
- Amélioration de la logique de soumission dans `contact.page.ts` : réinitialisation de `success` sur nouvelle soumission, gestion de `HttpErrorResponse` et extraction des erreurs via la nouvelle fonction privée `extractApiErrors`.
- Renforcement des tests unitaires `contact.page.spec.ts` pour utiliser `HttpTestingController` et couvrir les scénarios de soumission réussie et de réponse 400 contenant `errors[]` du backend.
- Ajout d'un scénario E2E Playwright `apps/client/tests/e2e/contact-form.spec.ts` formulé en `Given/When/Then` pour vérifier le parcours de soumission du formulaire avec interception de l'endpoint `/contact`.
- Aucun style de composant ajouté (respect de la règle Tailwind/PrimeNG), et modifications limitées au périmètre MVP du formulaire de contact.

### Testing
- Tests unitaires ciblés exécutés avec `ng test` pour le spec modifié : les tests unitaires de la page contact sont passés (`9 tests | 9 passed`).
- E2E Playwright exécuté avec `pnpm --filter @kraak/client exec playwright test tests/e2e/contact-form.spec.ts --project=chromium` échoué pour des raisons d'environnement car les navigateurs Playwright n'étaient pas installés dans le runner (`pnpm exec playwright install` requis). 
- Vérifications automatiques : `prettier --check` et la passe `pnpm -r lint` se sont exécutées et n'ont pas signalé d'erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db7550187c832eb0cd7821eb055f84)