### PR TITLE
chore(repo): ajouter les scripts lint:fix à l'API, au client et à la racine

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "start:dev": "nest start --watch",
     "start:prod": "node dist/src/main.js",
     "lint": "eslint \"src/**/*.ts\"",
+    "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage"

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -21,6 +21,7 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "lint": "ng lint",
+    "lint:fix": "ng lint --fix",
     "serve:ssr:web": "node dist/web/server/server.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
     "lint:api": "pnpm --filter @kraak/api lint",
     "lint": "pnpm -r lint",
+    "lint:fix": "pnpm -r lint:fix",
     "typecheck:web": "pnpm --filter @kraak/client exec tsc --noEmit -p projects/web/tsconfig.app.json",
     "typecheck:mobile": "pnpm --filter @kraak/client exec tsc --noEmit -p projects/mobile/tsconfig.app.json",
     "typecheck:api": "pnpm --filter @kraak/api exec tsc --noEmit -p tsconfig.build.json",


### PR DESCRIPTION
## Résumé\n\nAjout de scripts `lint:fix` dans le monorepo pour permettre la correction automatique des erreurs de lint en une seule commande.\n\n## Changements\n\n- **`package.json` (racine)** : ajout de `\"lint:fix\": \"pnpm -r lint:fix\"` — orchestre `lint:fix` dans tous les workspaces\n- **`apps/api/package.json`** : ajout de `\"lint:fix\": \"eslint \\\"src/**/*.ts\\\" --fix\"` — corrige les fichiers TypeScript de l'API\n- **`apps/client/package.json`** : ajout de `\"lint:fix\": \"ng lint --fix\"` — corrige via Angular ESLint\n\n## Validation\n\n- ✅ Typecheck (web, mobile, API)\n- ✅ Tests API (jest) : 5 suites, 13 tests\n- ✅ Tests web (vitest) : 12 fichiers, 33 tests\n- ✅ Tests mobile (vitest) : 10 fichiers, 21 tests\n- ✅ Pre-push hooks passés intégralement