### PR TITLE
chore(repo): utiliser lint:fix dans le hook pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 command -v pnpm >/dev/null 2>&1 || exit 0
 pnpm format:check
-pnpm lint
+pnpm lint:fix


### PR DESCRIPTION
## Changement

Remplace `pnpm lint` par `pnpm lint:fix` dans le hook Husky `pre-commit`.

### Pourquoi

Les scripts `lint:fix` ont été ajoutés au monorepo dans la PR #173. Ce changement
permet au hook pre-commit de corriger automatiquement les problèmes de lint avant
chaque commit, au lieu de simplement les signaler.

### Fichier modifié

- `.husky/pre-commit` : `pnpm lint` → `pnpm lint:fix`

### Validation

- ✅ Commit passé (pre-commit hook exécuté avec `lint:fix`)
- ✅ Typecheck web, mobile, API
- ✅ Tests API (jest : 5 suites, 13 tests)
- ✅ Tests client web (vitest : 12 fichiers, 33 tests)
- ✅ Tests client mobile (vitest : 10 fichiers, 21 tests)