### PR TITLE
fix(api): corriger le chemin dist et ajouter la dépendance contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ dist/
 .next/
 out/
 
+# Artefacts TypeScript compilés hors dist/
+*.d.ts
+*.js.map
+
 # Environnement
 .env
 .env.local

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:prod": "node dist/src/main.js",
+    "start:prod": "node dist/main.js",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "test": "jest",
@@ -20,6 +20,7 @@
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
+    "@kraak/contracts": "workspace:*",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "paths": {}
+  },
+  "include": ["src"],
   "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@kraak/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2)


### PR DESCRIPTION
## Résumé

Corrige le crash au démarrage en production de l'API et nettoie les artefacts de build.

### Changements

- **`apps/api/package.json`** : `start:prod` corrigé de `node dist/src/main.js` → `node dist/main.js` ; ajout de `@kraak/contracts: "workspace:*"`
- **`apps/api/tsconfig.build.json`** : ajout de `rootDir: "./src"`, `paths: {}`, et `include: ["src"]`
- **`.gitignore`** : ajout de `*.d.ts` et `*.js.map` pour empêcher le suivi des artefacts compilés hors `dist/`

### Validation

- ✅ 374 tests unitaires / intégration passent
- ✅ Typecheck réussi (web, mobile, api)
- ✅ Les 3 serveurs de dev démarrent correctement

Closes #177