### PR TITLE
fix(client,tokens): correct smoke test title assertion and tokens barrel export

### DIFF
--- a/apps/client/tests/e2e/smoke.spec.ts
+++ b/apps/client/tests/e2e/smoke.spec.ts
@@ -8,10 +8,10 @@ test.describe(`Page d'accueil — smoke tests`, () => {
     await page.goto('/');
   });
 
-  test(`Given la page d'accueil, When elle se charge, Then le titre du document est "KRAAK"`, async ({
+  test(`Given la page d'accueil, When elle se charge, Then le titre du document contient "KRAAK"`, async ({
     page,
   }) => {
-    await expect(page).toHaveTitle('KRAAK');
+    await expect(page).toHaveTitle('KRAAK | Développez votre potentiel');
   });
 
   test(`Given la page d'accueil, When elle se charge, Then la marque KRAAK est visible dans la navigation`, async ({

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,1 +1,1 @@
-export * from './tokens';
+export * from './tokens.js';


### PR DESCRIPTION
## Résumé

Corrige deux problèmes qui faisaient échouer `pnpm test` :

### Changements

- **`packages/tokens/src/index.ts`** : ajout de l'extension `.js` dans le barrel export (`'./tokens'` → `'./tokens.js'`) pour résoudre l'erreur `Could not resolve "./tokens"` d'esbuild.
- **`apps/client/tests/e2e/smoke.spec.ts`** : mise à jour de l'assertion du titre de la page d'accueil pour correspondre au titre réel du document (`'KRAAK'` → `'KRAAK | Développez votre potentiel'`).

### Validation

- 9/9 tests E2E Playwright passent
- 13/13 tests unitaires API passent
- Tous les tests unitaires client passent
- `pnpm test` au complet passe sans erreur