### PR TITLE
chore(config): simplifier le hook pre-push en utilisant pnpm test

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 command -v pnpm >/dev/null 2>&1 || exit 0
 pnpm exec validate-branch-name
 pnpm typecheck
-pnpm test:api
-pnpm --filter @kraak/client exec ng test --watch=false
+pnpm test


### PR DESCRIPTION
## Changement\n\nRemplace les deux commandes de test séparées (`pnpm test:api` + `pnpm --filter @kraak/client exec ng test --watch=false`) par un seul `pnpm test` dans le hook pre-push.\n\n## Pourquoi\n\nLe script `pnpm test` exécute déjà `test:libs`, `test:api`, `test:unit` et `test:e2e` — les commandes séparées étaient redondantes et incomplètes (elles ne couvraient ni les libs ni les E2E).\n\n## Validation\n\n- Tous les tests passent : libs (307/307), API (13/13), unit (54/54), E2E (9/9)