### PR TITLE
[codex] fix(repo): restage auto-fixed files in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 command -v pnpm >/dev/null 2>&1 || exit 0
 pnpm format
 pnpm lint:fix
+# Restage les fichiers corrigés par les auto-fixers avant de créer le commit.
+git update-index --again

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,21 +126,21 @@ Règles associées :
 Chaque module API fonctionnel dans `apps/api` qui expose au moins une route doit
 comporter **au minimum cinq fichiers** :
 
-| Fichier | Rôle |
-| ------- | ---- |
-| `<name>.module.ts` | Déclaration NestJS (`controllers`, `providers`) |
-| `<name>.controller.ts` | Routes HTTP + décorateurs Swagger |
+| Fichier                     | Rôle                                                   |
+| --------------------------- | ------------------------------------------------------ |
+| `<name>.module.ts`          | Déclaration NestJS (`controllers`, `providers`)        |
+| `<name>.controller.ts`      | Routes HTTP + décorateurs Swagger                      |
 | `<name>.controller.spec.ts` | Tests unitaires du contrôleur en BDD `Given/When/Then` |
-| `<name>.service.ts` | Logique métier |
-| `<name>.service.spec.ts` | Tests unitaires du service en BDD `Given/When/Then` |
+| `<name>.service.ts`         | Logique métier                                         |
+| `<name>.service.spec.ts`    | Tests unitaires du service en BDD `Given/When/Then`    |
 
 Fichiers conditionnels obligatoires dès qu'une route accepte un corps de requête
 ou un payload d'entrée complexe à valider :
 
-| Fichier | Rôle |
-| ------- | ---- |
-| `<name>.dto.ts` | Validation d'entrée hand-rolled, sans `class-validator` |
-| `<name>.dto.spec.ts` | Tests unitaires de la validation |
+| Fichier              | Rôle                                                    |
+| -------------------- | ------------------------------------------------------- |
+| `<name>.dto.ts`      | Validation d'entrée hand-rolled, sans `class-validator` |
+| `<name>.dto.spec.ts` | Tests unitaires de la validation                        |
 
 Cas particuliers et règles associées :
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,15 +144,15 @@ Ces réglages sont déjà appliqués dans le `.git/config` du dépôt. Si vous c
 
 Des vérifications automatiques s'exécutent à chaque étape :
 
-| Moment       | Vérification                                                              | Effet si échec |
-| ------------ | ------------------------------------------------------------------------- | -------------- |
-| `commit-msg` | Format Conventional Commits (commitlint)                                  | Commit rejeté  |
-| `pre-commit` | `pnpm format:check` + `pnpm lint`                                         | Commit rejeté  |
-| `pre-push`   | Nom de branche valide + `pnpm typecheck` + `pnpm test:api` + tests client | Push rejeté    |
+| Moment       | Vérification                                                                | Effet si échec |
+| ------------ | --------------------------------------------------------------------------- | -------------- |
+| `commit-msg` | Format Conventional Commits (commitlint)                                    | Commit rejeté  |
+| `pre-commit` | `pnpm format` + `pnpm lint:fix` + restage automatique des fichiers modifiés | Commit rejeté  |
+| `pre-push`   | Nom de branche valide + `pnpm typecheck` + `pnpm test:api` + tests client   | Push rejeté    |
 
 ### Si un hook échoue
 
-- **Formatage** : exécuter `pnpm format` puis réessayer
+- **Formatage** : le hook applique déjà `pnpm format` et restage les fichiers corrigés ; si l'échec persiste, corriger le blocage signalé puis recommiter
 - **Lint** : corriger les erreurs signalées par ESLint
 - **Typecheck** : corriger les erreurs TypeScript signalées par `pnpm typecheck`
 - **Nom de branche** : renommer avec `git branch -m <nouveau-nom>`
@@ -190,7 +190,7 @@ pnpm format
 pnpm format:check
 ```
 
-> Le hook `pre-commit` vérifie automatiquement le formatage. Exécuter `pnpm format` avant de commiter évite les surprises.
+> Le hook `pre-commit` applique automatiquement `pnpm format` et `pnpm lint:fix`, puis restage les fichiers corrigés avant le commit.
 
 ---
 


### PR DESCRIPTION
## Summary
- restage files automatically after `pnpm format` and `pnpm lint:fix` in `.husky/pre-commit`
- keep the repository documentation aligned with the real Husky behavior in `CONTRIBUTING.md`
- commit the Prettier normalization needed in `AGENTS.md` so `pnpm format:check` stops failing in CI

## Root cause
The pre-commit hook auto-fixed files but did not re-add them to the index. A commit could therefore be created with the stale staged version, and GitHub Actions would later fail on `pnpm format:check`.

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git push -u origin fix/precommit-restage-format` (replayed `pre-push` successfully)

Closes #66
