### PR TITLE
[codex] Corriger le prebundle Vite du dev server mobile

### DIFF
--- a/apps/client/angular.json
+++ b/apps/client/angular.json
@@ -247,6 +247,11 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "prebundle": {
+              "exclude": ["@kraak/api-client"]
+            }
+          },
           "configurations": {
             "production": {
               "buildTarget": "mobile:build:production"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:api": "pnpm --filter @kraak/api dev",
     "dev:api:staging": "pnpm --filter @kraak/api run start:staging",
     "build:api": "pnpm --filter @kraak/api build",
-    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs",
+    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs",
     "test:api": "pnpm --filter @kraak/api test",
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
     "lint:api": "pnpm --filter @kraak/api lint",

--- a/scripts/verify-mobile-dev-server-config.test.mjs
+++ b/scripts/verify-mobile-dev-server-config.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const workspaceConfigPath = path.join(
+  scriptDirectory,
+  '..',
+  'apps',
+  'client',
+  'angular.json',
+);
+
+function readWorkspaceConfig() {
+  return JSON.parse(readFileSync(workspaceConfigPath, 'utf8'));
+}
+
+test(
+  'le dev server mobile exclut @kraak/api-client du prebundle Vite',
+  () => {
+    const workspaceConfig = readWorkspaceConfig();
+    const prebundleConfig =
+      workspaceConfig.projects.mobile.architect.serve.options?.prebundle;
+
+    assert.deepEqual(prebundleConfig, {
+      exclude: ['@kraak/api-client'],
+    });
+  },
+);


### PR DESCRIPTION
## Résumé
Corrige le démarrage du serveur de développement mobile quand Vite tente de prébundler `@kraak/api-client`.

## Ce qui change
- exclusion de `@kraak/api-client` du prébundle du dev server mobile
- ajout d'un test workspace qui protège cette configuration
- intégration du nouveau test dans `test:workspace`

## Cause racine
Le prébundle Vite/Angular suivait l'export interne `./client` de `@kraak/api-client` pendant l'optimisation de dépendances du shell mobile, ce qui faisait échouer `ng serve mobile` avant même le rendu de l'application.

## Validation
- `pnpm test:workspace`
- `git push -u origin fix/mobile-api-client-prebundle` avec hooks pre-push verts
- vérification de démarrage de `ng serve mobile --configuration local --port 4300`

Closes #206