### PR TITLE
[TASK][AUT-05] Ajouter gestion role participant/admin minimal

### DIFF
--- a/apps/client/projects/mobile/src/app/app.routes.spec.ts
+++ b/apps/client/projects/mobile/src/app/app.routes.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { routes } from './app.routes';
+import { participantRoleGuard } from './core/auth/auth.guard';
 
 describe('Mobile routes', () => {
   const topPaths = routes.map((r) => r.path);
@@ -13,6 +14,8 @@ describe('Mobile routes', () => {
 
   it('should define the tabs shell route', () => {
     expect(topPaths).toContain('tabs');
+    const tabsRoute = routes.find((route) => route.path === 'tabs');
+    expect(tabsRoute?.canActivate).toContain(participantRoleGuard);
   });
 
   it('should redirect empty path to tabs', () => {

--- a/apps/client/projects/mobile/src/app/app.routes.ts
+++ b/apps/client/projects/mobile/src/app/app.routes.ts
@@ -1,5 +1,5 @@
 import { Routes } from '@angular/router';
-import { authGuard } from './core/auth/auth.guard';
+import { participantRoleGuard } from './core/auth/auth.guard';
 
 export const routes: Routes = [
   {
@@ -22,7 +22,7 @@ export const routes: Routes = [
     path: 'tabs',
     loadComponent: () =>
       import('./layouts/tabs/tabs.layout').then((m) => m.TabsLayout),
-    canActivate: [authGuard],
+    canActivate: [participantRoleGuard],
     children: [
       {
         path: 'accueil',

--- a/apps/client/projects/mobile/src/app/core/auth/auth.guard.spec.ts
+++ b/apps/client/projects/mobile/src/app/core/auth/auth.guard.spec.ts
@@ -7,14 +7,22 @@ import {
 } from '@angular/router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Component } from '@angular/core';
-import { authGuard, authChildGuard } from './auth.guard';
+import {
+  adminRoleChildGuard,
+  adminRoleGuard,
+  authChildGuard,
+  authGuard,
+  participantRoleChildGuard,
+  participantRoleGuard,
+} from './auth.guard';
 import { MobileAuthService } from '../../features/auth/mobile-auth.service';
 
 @Component({ template: '' })
 class DummyComponent {}
 
-const mockAuthService = (isAuthenticated: boolean) => ({
+const mockAuthService = (isAuthenticated: boolean, hasRole = false) => ({
   isAuthenticated: vi.fn(() => isAuthenticated),
+  hasRole: vi.fn(() => hasRole),
 });
 
 const buildRoute = (): ActivatedRouteSnapshot =>
@@ -114,5 +122,139 @@ describe('authChildGuard (mobile)', () => {
       const router = TestBed.inject(Router);
       expect(result).toEqual(router.createUrlTree(['/sign-in']));
     });
+  });
+});
+
+describe('participantRoleGuard (mobile)', () => {
+  describe('Given an authenticated participant user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([]),
+          {
+            provide: MobileAuthService,
+            useValue: mockAuthService(true, true),
+          },
+        ],
+      });
+    });
+
+    it('when the participant role guard is triggered, then navigation is allowed', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        participantRoleGuard(buildRoute(), buildState()),
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Given an authenticated non-participant user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{ path: 'sign-in', component: DummyComponent }]),
+          {
+            provide: MobileAuthService,
+            useValue: mockAuthService(true, false),
+          },
+        ],
+      });
+    });
+
+    it('when the participant role guard is triggered, then the user is redirected to sign-in', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        participantRoleGuard(buildRoute(), buildState()),
+      );
+
+      const router = TestBed.inject(Router);
+      expect(result).toEqual(router.createUrlTree(['/sign-in']));
+    });
+  });
+});
+
+describe('participantRoleChildGuard (mobile)', () => {
+  it('Given an authenticated participant user, when the child role guard is triggered, then navigation is allowed', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: MobileAuthService,
+          useValue: mockAuthService(true, true),
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      participantRoleChildGuard(buildRoute(), buildState()),
+    );
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('adminRoleGuard (mobile)', () => {
+  describe('Given an authenticated admin user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([]),
+          {
+            provide: MobileAuthService,
+            useValue: mockAuthService(true, true),
+          },
+        ],
+      });
+    });
+
+    it('when the admin role guard is triggered, then navigation is allowed', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        adminRoleGuard(buildRoute(), buildState()),
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Given an authenticated non-admin user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{ path: 'sign-in', component: DummyComponent }]),
+          {
+            provide: MobileAuthService,
+            useValue: mockAuthService(true, false),
+          },
+        ],
+      });
+    });
+
+    it('when the admin role guard is triggered, then the user is redirected to sign-in', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        adminRoleGuard(buildRoute(), buildState()),
+      );
+
+      const router = TestBed.inject(Router);
+      expect(result).toEqual(router.createUrlTree(['/sign-in']));
+    });
+  });
+});
+
+describe('adminRoleChildGuard (mobile)', () => {
+  it('Given an authenticated admin user, when the child admin role guard is triggered, then navigation is allowed', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: MobileAuthService,
+          useValue: mockAuthService(true, true),
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      adminRoleChildGuard(buildRoute(), buildState()),
+    );
+
+    expect(result).toBe(true);
   });
 });

--- a/apps/client/projects/mobile/src/app/core/auth/auth.guard.ts
+++ b/apps/client/projects/mobile/src/app/core/auth/auth.guard.ts
@@ -4,6 +4,7 @@ import {
   type CanActivateChildFn,
   Router,
 } from '@angular/router';
+import type { UserRoleValue } from '@kraak/contracts';
 import { MobileAuthService } from '../../features/auth/mobile-auth.service';
 
 export const authGuard: CanActivateFn = () => {
@@ -17,13 +18,39 @@ export const authGuard: CanActivateFn = () => {
   return router.createUrlTree(['/sign-in']);
 };
 
-export const authChildGuard: CanActivateChildFn = () => {
-  const authService = inject(MobileAuthService);
-  const router = inject(Router);
+export const authChildGuard: CanActivateChildFn = authGuard;
 
-  if (authService.isAuthenticated()) {
+function canAccessRole(
+  authService: MobileAuthService,
+  router: Router,
+  ...roles: UserRoleValue[]
+): true | ReturnType<Router['createUrlTree']> {
+  if (!authService.isAuthenticated()) {
+    return router.createUrlTree(['/sign-in']);
+  }
+
+  if (authService.hasRole(...roles)) {
     return true;
   }
 
   return router.createUrlTree(['/sign-in']);
+}
+
+export const participantRoleGuard: CanActivateFn = () => {
+  const authService = inject(MobileAuthService);
+  const router = inject(Router);
+
+  return canAccessRole(authService, router, 'participant');
 };
+
+export const participantRoleChildGuard: CanActivateChildFn =
+  participantRoleGuard;
+
+export const adminRoleGuard: CanActivateFn = () => {
+  const authService = inject(MobileAuthService);
+  const router = inject(Router);
+
+  return canAccessRole(authService, router, 'admin');
+};
+
+export const adminRoleChildGuard: CanActivateChildFn = adminRoleGuard;

--- a/apps/client/projects/mobile/src/app/features/auth/mobile-auth.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/auth/mobile-auth.service.spec.ts
@@ -63,5 +63,55 @@ describe('MobileAuthService', () => {
     expect(localStorage.getItem('kraak.mobile.session')).toContain(
       'access-token',
     );
+    expect(service.currentRole()).toBe('participant');
+    expect(service.isParticipant()).toBe(true);
+    expect(service.isAdmin()).toBe(false);
+    expect(service.hasRole('participant')).toBe(true);
+    expect(service.hasRole('admin')).toBe(false);
+  });
+
+  it('Given an admin sign-in payload, when the session is stored, then admin permissions are exposed', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        session: {
+          accessToken: 'admin-access-token',
+          refreshToken: 'admin-refresh-token',
+          expiresIn: 3600,
+          expiresAt: '2026-04-14T12:00:00.000Z',
+          tokenType: 'bearer',
+        },
+        profile: {
+          appUser: {
+            id: 'admin-user-1',
+            email: 'admin@example.com',
+            role: 'admin',
+            firstName: 'Admin',
+            lastName: 'Kraak',
+            phone: null,
+            preferredContactChannel: null,
+            isActive: true,
+            createdAt: '2026-04-14T12:00:00.000Z',
+            updatedAt: '2026-04-14T12:00:00.000Z',
+          },
+          participant: null,
+        },
+      }),
+    } satisfies Partial<Response>);
+
+    TestBed.configureTestingModule({});
+    const service = TestBed.inject(MobileAuthService);
+
+    await service.signIn({
+      email: 'admin@example.com',
+      password: 'motdepasse-securise',
+    });
+
+    expect(service.currentRole()).toBe('admin');
+    expect(service.isAdmin()).toBe(true);
+    expect(service.isParticipant()).toBe(false);
+    expect(service.hasRole('admin')).toBe(true);
+    expect(service.hasRole('participant')).toBe(false);
   });
 });

--- a/apps/client/projects/mobile/src/app/features/auth/mobile-auth.service.ts
+++ b/apps/client/projects/mobile/src/app/features/auth/mobile-auth.service.ts
@@ -10,6 +10,7 @@ import type {
   SignInRequestDto,
   SignUpRequestDto,
   SignUpResponseDto,
+  UserRoleValue,
 } from '@kraak/contracts';
 import { environment } from '../../../environments/environment';
 
@@ -35,9 +36,19 @@ export class MobileAuthService {
 
   readonly currentSession = this.sessionState.asReadonly();
   readonly currentProfile = this.profileState.asReadonly();
+  readonly currentRole = computed<UserRoleValue | null>(
+    () => this.currentProfile()?.appUser.role ?? null,
+  );
   readonly isAuthenticated = computed(
     () => this.currentSession() !== null && this.currentProfile() !== null,
   );
+  readonly isParticipant = computed(() => this.currentRole() === 'participant');
+  readonly isAdmin = computed(() => this.currentRole() === 'admin');
+
+  hasRole(...roles: UserRoleValue[]): boolean {
+    const role = this.currentRole();
+    return role !== null && roles.includes(role);
+  }
 
   async signIn(body: SignInRequestDto): Promise<AuthSessionBundleDto> {
     const bundle = await this.client.auth.signIn(body);

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -1,5 +1,8 @@
 import { routes } from './app.routes';
-import { authGuard, authChildGuard } from './core/auth/auth.guard';
+import {
+  participantRoleGuard,
+  participantRoleChildGuard,
+} from './core/auth/auth.guard';
 
 describe('Web routes', () => {
   const paths = routes.map((r) => r.path);
@@ -42,8 +45,10 @@ describe('Web routes', () => {
     it('should define a protected participant route with auth guards', () => {
       const participantRoute = routes.find((r) => r.path === 'participant');
       expect(participantRoute).toBeDefined();
-      expect(participantRoute!.canActivate).toContain(authGuard);
-      expect(participantRoute!.canActivateChild).toContain(authChildGuard);
+      expect(participantRoute!.canActivate).toContain(participantRoleGuard);
+      expect(participantRoute!.canActivateChild).toContain(
+        participantRoleChildGuard,
+      );
     });
 
     it('should have a dashboard child route under participant', () => {

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -1,6 +1,9 @@
 import { Route, Routes } from '@angular/router';
 
-import { authGuard, authChildGuard } from './core/auth/auth.guard';
+import {
+  participantRoleGuard,
+  participantRoleChildGuard,
+} from './core/auth/auth.guard';
 import { findSeoPageByPath } from './seo/site-seo';
 
 const buildMarketingRoute = (
@@ -38,8 +41,8 @@ export const routes: Routes = [
   ),
   {
     path: 'participant',
-    canActivate: [authGuard],
-    canActivateChild: [authChildGuard],
+    canActivate: [participantRoleGuard],
+    canActivateChild: [participantRoleChildGuard],
     children: [
       {
         path: 'dashboard',

--- a/apps/client/projects/web/src/app/core/auth/auth.guard.spec.ts
+++ b/apps/client/projects/web/src/app/core/auth/auth.guard.spec.ts
@@ -7,14 +7,22 @@ import {
 } from '@angular/router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Component } from '@angular/core';
-import { authGuard, authChildGuard } from './auth.guard';
+import {
+  adminRoleChildGuard,
+  adminRoleGuard,
+  authChildGuard,
+  authGuard,
+  participantRoleChildGuard,
+  participantRoleGuard,
+} from './auth.guard';
 import { WebAuthService } from './web-auth.service';
 
 @Component({ template: '' })
 class DummyComponent {}
 
-const mockAuthService = (isAuthenticated: boolean) => ({
+const mockAuthService = (isAuthenticated: boolean, hasRole = false) => ({
   isAuthenticated: vi.fn(() => isAuthenticated),
+  hasRole: vi.fn(() => hasRole),
 });
 
 const buildRoute = (): ActivatedRouteSnapshot =>
@@ -114,5 +122,139 @@ describe('authChildGuard (web)', () => {
       const router = TestBed.inject(Router);
       expect(result).toEqual(router.createUrlTree(['/']));
     });
+  });
+});
+
+describe('participantRoleGuard (web)', () => {
+  describe('Given an authenticated participant user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([]),
+          {
+            provide: WebAuthService,
+            useValue: mockAuthService(true, true),
+          },
+        ],
+      });
+    });
+
+    it('when the participant role guard is triggered, then navigation is allowed', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        participantRoleGuard(buildRoute(), buildState()),
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Given an authenticated non-participant user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{ path: '', component: DummyComponent }]),
+          {
+            provide: WebAuthService,
+            useValue: mockAuthService(true, false),
+          },
+        ],
+      });
+    });
+
+    it('when the participant role guard is triggered, then the user is redirected to home', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        participantRoleGuard(buildRoute(), buildState()),
+      );
+
+      const router = TestBed.inject(Router);
+      expect(result).toEqual(router.createUrlTree(['/']));
+    });
+  });
+});
+
+describe('participantRoleChildGuard (web)', () => {
+  it('Given an authenticated participant user, when the child role guard is triggered, then navigation is allowed', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: WebAuthService,
+          useValue: mockAuthService(true, true),
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      participantRoleChildGuard(buildRoute(), buildState()),
+    );
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('adminRoleGuard (web)', () => {
+  describe('Given an authenticated admin user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([]),
+          {
+            provide: WebAuthService,
+            useValue: mockAuthService(true, true),
+          },
+        ],
+      });
+    });
+
+    it('when the admin role guard is triggered, then navigation is allowed', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        adminRoleGuard(buildRoute(), buildState()),
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Given an authenticated non-admin user', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{ path: '', component: DummyComponent }]),
+          {
+            provide: WebAuthService,
+            useValue: mockAuthService(true, false),
+          },
+        ],
+      });
+    });
+
+    it('when the admin role guard is triggered, then the user is redirected to home', () => {
+      const result = TestBed.runInInjectionContext(() =>
+        adminRoleGuard(buildRoute(), buildState()),
+      );
+
+      const router = TestBed.inject(Router);
+      expect(result).toEqual(router.createUrlTree(['/']));
+    });
+  });
+});
+
+describe('adminRoleChildGuard (web)', () => {
+  it('Given an authenticated admin user, when the child admin role guard is triggered, then navigation is allowed', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: WebAuthService,
+          useValue: mockAuthService(true, true),
+        },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() =>
+      adminRoleChildGuard(buildRoute(), buildState()),
+    );
+
+    expect(result).toBe(true);
   });
 });

--- a/apps/client/projects/web/src/app/core/auth/auth.guard.ts
+++ b/apps/client/projects/web/src/app/core/auth/auth.guard.ts
@@ -4,6 +4,7 @@ import {
   type CanActivateChildFn,
   Router,
 } from '@angular/router';
+import type { UserRoleValue } from '@kraak/contracts';
 import { WebAuthService } from './web-auth.service';
 
 export const authGuard: CanActivateFn = () => {
@@ -17,13 +18,39 @@ export const authGuard: CanActivateFn = () => {
   return router.createUrlTree(['/']);
 };
 
-export const authChildGuard: CanActivateChildFn = () => {
-  const authService = inject(WebAuthService);
-  const router = inject(Router);
+export const authChildGuard: CanActivateChildFn = authGuard;
 
-  if (authService.isAuthenticated()) {
+function canAccessRole(
+  authService: WebAuthService,
+  router: Router,
+  ...roles: UserRoleValue[]
+): true | ReturnType<Router['createUrlTree']> {
+  if (!authService.isAuthenticated()) {
+    return router.createUrlTree(['/']);
+  }
+
+  if (authService.hasRole(...roles)) {
     return true;
   }
 
   return router.createUrlTree(['/']);
+}
+
+export const participantRoleGuard: CanActivateFn = () => {
+  const authService = inject(WebAuthService);
+  const router = inject(Router);
+
+  return canAccessRole(authService, router, 'participant');
 };
+
+export const participantRoleChildGuard: CanActivateChildFn =
+  participantRoleGuard;
+
+export const adminRoleGuard: CanActivateFn = () => {
+  const authService = inject(WebAuthService);
+  const router = inject(Router);
+
+  return canAccessRole(authService, router, 'admin');
+};
+
+export const adminRoleChildGuard: CanActivateChildFn = adminRoleGuard;

--- a/apps/client/projects/web/src/app/core/auth/web-auth.service.spec.ts
+++ b/apps/client/projects/web/src/app/core/auth/web-auth.service.spec.ts
@@ -99,8 +99,98 @@ describe('WebAuthService', () => {
 
       const stored = localStorage.getItem(WEB_AUTH_STORAGE_KEY);
       expect(stored).not.toBeNull();
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored ?? '{}');
       expect(parsed.session.accessToken).toBe('access-token');
+    });
+
+    it('when the stored profile role is participant, then role helpers are resolved correctly', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          session: {
+            accessToken: 'access-token',
+            refreshToken: 'refresh-token',
+            expiresIn: 3600,
+            expiresAt: '2026-04-28T12:00:00.000Z',
+            tokenType: 'bearer',
+          },
+          profile: {
+            appUser: {
+              id: 'user-1',
+              email: 'alice@example.com',
+              role: 'participant',
+              firstName: 'Alice',
+              lastName: 'Dupont',
+              phone: null,
+              preferredContactChannel: null,
+              isActive: true,
+              createdAt: '2026-04-28T12:00:00.000Z',
+              updatedAt: '2026-04-28T12:00:00.000Z',
+            },
+            participant: null,
+          },
+        }),
+      } satisfies Partial<Response>);
+
+      TestBed.configureTestingModule({});
+      const service = TestBed.inject(WebAuthService);
+
+      await service.signIn({
+        email: 'alice@example.com',
+        password: 'motdepasse-securise',
+      });
+
+      expect(service.currentRole()).toBe('participant');
+      expect(service.isParticipant()).toBe(true);
+      expect(service.isAdmin()).toBe(false);
+      expect(service.hasRole('participant')).toBe(true);
+      expect(service.hasRole('admin')).toBe(false);
+    });
+
+    it('when the stored profile role is admin, then role helpers detect admin access', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          session: {
+            accessToken: 'access-token',
+            refreshToken: 'refresh-token',
+            expiresIn: 3600,
+            expiresAt: '2026-04-28T12:00:00.000Z',
+            tokenType: 'bearer',
+          },
+          profile: {
+            appUser: {
+              id: 'user-2',
+              email: 'admin@example.com',
+              role: 'admin',
+              firstName: 'Admin',
+              lastName: 'Kraak',
+              phone: null,
+              preferredContactChannel: null,
+              isActive: true,
+              createdAt: '2026-04-28T12:00:00.000Z',
+              updatedAt: '2026-04-28T12:00:00.000Z',
+            },
+            participant: null,
+          },
+        }),
+      } satisfies Partial<Response>);
+
+      TestBed.configureTestingModule({});
+      const service = TestBed.inject(WebAuthService);
+
+      await service.signIn({
+        email: 'admin@example.com',
+        password: 'motdepasse-securise',
+      });
+
+      expect(service.currentRole()).toBe('admin');
+      expect(service.isAdmin()).toBe(true);
+      expect(service.isParticipant()).toBe(false);
+      expect(service.hasRole('admin')).toBe(true);
+      expect(service.hasRole('participant')).toBe(false);
     });
   });
 

--- a/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
+++ b/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
@@ -1,5 +1,5 @@
 import { computed, Injectable, signal } from '@angular/core';
-import { ApiError, createApiClient } from '@kraak/api-client';
+import { createApiClient } from '@kraak/api-client';
 import type {
   AuthProfileDto,
   AuthSessionBundleDto,
@@ -10,12 +10,13 @@ import type {
   SignInRequestDto,
   SignUpRequestDto,
   SignUpResponseDto,
+  UserRoleValue,
 } from '@kraak/contracts';
 import { environment } from '../../../environments/environment';
 
 export const WEB_AUTH_STORAGE_KEY = 'kraak.web.session';
 
-export { ApiError };
+export { ApiError } from '@kraak/api-client';
 
 @Injectable({
   providedIn: 'root',
@@ -35,9 +36,19 @@ export class WebAuthService {
 
   readonly currentSession = this.sessionState.asReadonly();
   readonly currentProfile = this.profileState.asReadonly();
+  readonly currentRole = computed<UserRoleValue | null>(
+    () => this.currentProfile()?.appUser.role ?? null,
+  );
   readonly isAuthenticated = computed(
     () => this.currentSession() !== null && this.currentProfile() !== null,
   );
+  readonly isParticipant = computed(() => this.currentRole() === 'participant');
+  readonly isAdmin = computed(() => this.currentRole() === 'admin');
+
+  hasRole(...roles: UserRoleValue[]): boolean {
+    const role = this.currentRole();
+    return role !== null && roles.includes(role);
+  }
 
   async signIn(body: SignInRequestDto): Promise<AuthSessionBundleDto> {
     const bundle = await this.client.auth.signIn(body);


### PR DESCRIPTION
## Parent epic
AUT

## Description
Implemente une gestion minimale des roles participant/admin cote client avec verification d'autorisation active sur les routes participant.

## Changements
- ajoute les capacites de role dans les services auth web/mobile (currentRole, isParticipant, isAdmin, hasRole)
- ajoute des guards de role (participantRoleGuard, adminRoleGuard et variantes child) web/mobile
- active la verification de role participant sur les routes protegees web/mobile
- etend la couverture de tests pour les cas participant/admin/non autorise

## Validation
- pnpm --filter @kraak/client test:web
- pnpm --filter @kraak/client test:mobile

Closes #89
