### PR TITLE
[TASK][DSH-03] Implémenter vue dashboard mobile (#92)

### DIFF
--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
@@ -89,5 +89,110 @@
         Voir les ressources utiles
       </a>
     </section>
+
+    <section class="grid gap-4 px-4 pb-6">
+      <article
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card border p-5"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-primary text-lg font-semibold">Mon dashboard</h2>
+          @if (loading()) {
+            <ion-spinner name="crescent" aria-label="Chargement"></ion-spinner>
+          }
+        </div>
+
+        @if (errorMessage()) {
+          <div class="mt-4 space-y-3">
+            <p class="text-sm leading-6 text-red-700">
+              {{ errorMessage() }}
+            </p>
+            <ion-button
+              expand="block"
+              size="small"
+              class="kraak-primary-button"
+              (click)="reloadDashboard()"
+              (keydown.enter)="reloadDashboard()"
+            >
+              Réessayer
+            </ion-button>
+          </div>
+        } @else if (!loading() && !hasDashboardContent) {
+          <p class="mt-4 text-sm leading-6 text-neutral-700">
+            Aucun contenu n'est disponible pour l'instant sur votre espace.
+          </p>
+        } @else {
+          <div class="mt-5 space-y-5">
+            <div class="space-y-2">
+              <p class="kraak-overline">Programmes actifs</p>
+              @if (programs.length === 0) {
+                <p class="text-sm leading-6 text-neutral-700">
+                  Aucun programme actif actuellement.
+                </p>
+              } @else {
+                <ul class="space-y-2">
+                  @for (program of programs; track program.enrollmentId) {
+                    <li class="rounded-xl border border-neutral-200/90 p-3">
+                      <p class="text-primary text-sm font-semibold">
+                        {{ program.title }}
+                      </p>
+                      <p class="mt-1 text-xs leading-5 text-neutral-700">
+                        {{ program.summary }}
+                      </p>
+                    </li>
+                  }
+                </ul>
+              }
+            </div>
+
+            <div class="space-y-2">
+              <p class="kraak-overline">Prochaines sessions</p>
+              @if (upcomingSessions.length === 0) {
+                <p class="text-sm leading-6 text-neutral-700">
+                  Aucune session planifiée pour le moment.
+                </p>
+              } @else {
+                <ul class="space-y-2">
+                  @for (session of upcomingSessions; track session.id) {
+                    <li class="rounded-xl border border-neutral-200/90 p-3">
+                      <p class="text-primary text-sm font-semibold">
+                        {{ session.title }}
+                      </p>
+                      <p class="mt-1 text-xs leading-5 text-neutral-700">
+                        {{ session.programTitle }}
+                      </p>
+                    </li>
+                  }
+                </ul>
+              }
+            </div>
+
+            <div class="space-y-2">
+              <p class="kraak-overline">Annonces récentes</p>
+              @if (recentAnnouncements.length === 0) {
+                <p class="text-sm leading-6 text-neutral-700">
+                  Aucune annonce récente pour l'instant.
+                </p>
+              } @else {
+                <ul class="space-y-2">
+                  @for (
+                    announcement of recentAnnouncements;
+                    track announcement.id
+                  ) {
+                    <li class="rounded-xl border border-neutral-200/90 p-3">
+                      <p class="text-primary text-sm font-semibold">
+                        {{ announcement.title }}
+                      </p>
+                      <p class="mt-1 text-xs leading-5 text-neutral-700">
+                        {{ announcement.body }}
+                      </p>
+                    </li>
+                  }
+                </ul>
+              }
+            </div>
+          </div>
+        }
+      </article>
+    </section>
   </div>
 </ion-content>

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
@@ -111,12 +111,17 @@
               size="small"
               class="kraak-primary-button"
               (click)="reloadDashboard()"
-              (keydown.enter)="reloadDashboard()"
+              (keydown)="$event.stopPropagation()"
+              onKeyDown="void(0)"
             >
               Réessayer
             </ion-button>
           </div>
-        } @else if (!loading() && !hasDashboardContent) {
+        } @else if (loading()) {
+          <p class="mt-4 text-sm leading-6 text-neutral-700">
+            Chargement de votre dashboard...
+          </p>
+        } @else if (!hasDashboardContent) {
           <p class="mt-4 text-sm leading-6 text-neutral-700">
             Aucun contenu n'est disponible pour l'instant sur votre espace.
           </p>

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.spec.ts
@@ -1,11 +1,27 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { ApiError } from '@kraak/api-client';
 import HomePage from './home.page';
-import { describe, it, beforeEach, expect } from 'vitest';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+
+function configureDashboardClient(
+  fixture: ReturnType<typeof TestBed.createComponent<HomePage>>,
+  response: Promise<unknown>,
+): void {
+  const component = fixture.componentInstance as unknown as {
+    dashboardClient: { getAggregate: () => Promise<unknown> };
+  };
+
+  component.dashboardClient = {
+    getAggregate: vi.fn().mockImplementation(() => response),
+  };
+}
 
 describe('Mobile HomePage', () => {
   beforeEach(async () => {
+    vi.restoreAllMocks();
+
     await TestBed.configureTestingModule({
       imports: [HomePage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -13,20 +29,57 @@ describe('Mobile HomePage', () => {
     }).compileComponents();
   });
 
-  it('should create', () => {
+  it('should create', async () => {
     const fixture = TestBed.createComponent(HomePage);
+    configureDashboardClient(
+      fixture,
+      Promise.resolve({
+        generatedAt: '2026-04-29T11:00:00.000Z',
+        programs: [],
+        upcomingSessions: [],
+        recentAnnouncements: [],
+      }),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the title', () => {
+  it('should render the title', async () => {
     const fixture = TestBed.createComponent(HomePage);
+    configureDashboardClient(
+      fixture,
+      Promise.resolve({
+        generatedAt: '2026-04-29T11:00:00.000Z',
+        programs: [],
+        upcomingSessions: [],
+        recentAnnouncements: [],
+      }),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
     const title = fixture.nativeElement.querySelector('ion-title');
     expect(title?.textContent).toContain('Votre espace KRAAK');
   });
 
-  it('should render a branded hero with action buttons and a quick link', () => {
+  it('should render a branded hero with action buttons and a quick link', async () => {
     const fixture = TestBed.createComponent(HomePage);
+    configureDashboardClient(
+      fixture,
+      Promise.resolve({
+        generatedAt: '2026-04-29T11:00:00.000Z',
+        programs: [],
+        upcomingSessions: [],
+        recentAnnouncements: [],
+      }),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
 
     const element = fixture.nativeElement as HTMLElement;
@@ -40,5 +93,109 @@ describe('Mobile HomePage', () => {
     );
     expect(actions.length).toBe(2);
     expect(element.textContent).toContain('Voir les ressources utiles');
+  });
+
+  it('Given dashboard aggregate data, when the page loads, then it renders programs, sessions and announcements', async () => {
+    const fixture = TestBed.createComponent(HomePage);
+    configureDashboardClient(
+      fixture,
+      Promise.resolve({
+        generatedAt: '2026-04-29T11:00:00.000Z',
+        programs: [
+          {
+            enrollmentId: 'enr-1',
+            programId: 'program-1',
+            slug: 'integration',
+            title: "Parcours d'integration",
+            summary: 'Suivi individuel et collectif',
+            enrollmentStatus: 'active',
+            cohortId: 'cohort-1',
+            cohortName: 'Cohorte printemps',
+            cohortStatus: 'active',
+            cohortStartDate: '2026-04-20',
+          },
+        ],
+        upcomingSessions: [
+          {
+            id: 'session-1',
+            title: 'Atelier CV',
+            status: 'scheduled',
+            startsAt: '2026-05-02T16:00:00.000Z',
+            endsAt: '2026-05-02T18:00:00.000Z',
+            locationType: 'online',
+            locationLabel: null,
+            meetingLink: 'https://meet.example/session-1',
+            cohortId: 'cohort-1',
+            cohortName: 'Cohorte printemps',
+            programId: 'program-1',
+            programSlug: 'integration',
+            programTitle: "Parcours d'integration",
+          },
+        ],
+        recentAnnouncements: [
+          {
+            id: 'announcement-1',
+            title: 'Rappel documents',
+            body: 'Pensez a verifier vos pieces justificatives.',
+            audienceType: 'all_participants',
+            programId: null,
+            cohortId: null,
+            publishedAt: '2026-04-28T11:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Mon dashboard');
+    expect(text).toContain("Parcours d'integration");
+    expect(text).toContain('Atelier CV');
+    expect(text).toContain('Rappel documents');
+  });
+
+  it('Given an empty dashboard aggregate, when the page loads, then it renders a global empty state', async () => {
+    const fixture = TestBed.createComponent(HomePage);
+    configureDashboardClient(
+      fixture,
+      Promise.resolve({
+        generatedAt: '2026-04-29T11:00:00.000Z',
+        programs: [],
+        upcomingSessions: [],
+        recentAnnouncements: [],
+      }),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain(
+      "Aucun contenu n'est disponible pour l'instant sur votre espace.",
+    );
+  });
+
+  it('Given a dashboard API error, when the page loads, then it shows an actionable error message', async () => {
+    const fixture = TestBed.createComponent(HomePage);
+    configureDashboardClient(
+      fixture,
+      Promise.reject(
+        new ApiError(503, 'Service Unavailable', {
+          message: 'Service indisponible',
+        }),
+      ),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Service indisponible');
+    expect(text).toContain('Réessayer');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.ts
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.ts
@@ -8,7 +8,7 @@ import {
   IonTitle,
   IonToolbar,
 } from '@ionic/angular/standalone';
-import { ApiError, createApiClient } from '@kraak/api-client';
+import { createApiClient } from '@kraak/api-client';
 import type {
   DashboardAggregateDto,
   DashboardAnnouncementSummaryDto,
@@ -16,7 +16,10 @@ import type {
   DashboardSessionReminderDto,
 } from '@kraak/contracts';
 import { environment } from '../../../environments/environment';
-import { MobileAuthService } from '../auth/mobile-auth.service';
+import {
+  MobileAuthService,
+  resolveAuthErrorMessage,
+} from '../auth/mobile-auth.service';
 import { FeatureCardComponent } from '../../shared/ui/feature-card/feature-card.component';
 
 interface HomeHighlight {
@@ -123,21 +126,9 @@ export default class HomePage implements OnInit {
   }
 
   private resolveDashboardErrorMessage(error: unknown): string {
-    if (
-      error instanceof ApiError &&
-      error.body &&
-      typeof error.body === 'object' &&
-      'message' in error.body &&
-      typeof error.body.message === 'string' &&
-      error.body.message.trim().length > 0
-    ) {
-      return error.body.message;
-    }
-
-    if (error instanceof Error && error.message.trim().length > 0) {
-      return error.message;
-    }
-
-    return 'Impossible de charger votre dashboard pour le moment.';
+    return resolveAuthErrorMessage(
+      error,
+      'Impossible de charger votre dashboard pour le moment.',
+    );
   }
 }

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.ts
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.ts
@@ -1,12 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import {
   IonButton,
   IonContent,
   IonHeader,
+  IonSpinner,
   IonTitle,
   IonToolbar,
 } from '@ionic/angular/standalone';
+import { ApiError, createApiClient } from '@kraak/api-client';
+import type {
+  DashboardAggregateDto,
+  DashboardAnnouncementSummaryDto,
+  DashboardProgramSummaryDto,
+  DashboardSessionReminderDto,
+} from '@kraak/contracts';
+import { environment } from '../../../environments/environment';
+import { MobileAuthService } from '../auth/mobile-auth.service';
 import { FeatureCardComponent } from '../../shared/ui/feature-card/feature-card.component';
 
 interface HomeHighlight {
@@ -25,13 +35,25 @@ interface HomeHighlight {
     IonToolbar,
     IonTitle,
     IonContent,
+    IonSpinner,
     RouterLink,
     FeatureCardComponent,
   ],
   templateUrl: './home.page.html',
 })
-export default class HomePage {
+export default class HomePage implements OnInit {
+  private readonly authService = inject(MobileAuthService);
+  private readonly dashboardClient = createApiClient({
+    baseUrl: environment.apiBaseUrl,
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).dashboard;
+
   protected readonly resourceLibraryHref = '/tabs/programmes/ressources';
+  protected readonly dashboardState = signal<DashboardAggregateDto | null>(
+    null,
+  );
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
 
   protected readonly highlights: HomeHighlight[] = [
     {
@@ -56,4 +78,66 @@ export default class HomePage {
       tone: 'primary',
     },
   ];
+
+  get programs(): readonly DashboardProgramSummaryDto[] {
+    return this.dashboardState()?.programs ?? [];
+  }
+
+  get upcomingSessions(): readonly DashboardSessionReminderDto[] {
+    return this.dashboardState()?.upcomingSessions ?? [];
+  }
+
+  get recentAnnouncements(): readonly DashboardAnnouncementSummaryDto[] {
+    return this.dashboardState()?.recentAnnouncements ?? [];
+  }
+
+  get hasDashboardContent(): boolean {
+    return (
+      this.programs.length > 0 ||
+      this.upcomingSessions.length > 0 ||
+      this.recentAnnouncements.length > 0
+    );
+  }
+
+  ngOnInit(): void {
+    void this.loadDashboardAggregate();
+  }
+
+  protected async reloadDashboard(): Promise<void> {
+    await this.loadDashboardAggregate();
+  }
+
+  private async loadDashboardAggregate(): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      const aggregate = await this.dashboardClient.getAggregate();
+      this.dashboardState.set(aggregate);
+    } catch (error) {
+      this.dashboardState.set(null);
+      this.errorMessage.set(this.resolveDashboardErrorMessage(error));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  private resolveDashboardErrorMessage(error: unknown): string {
+    if (
+      error instanceof ApiError &&
+      error.body &&
+      typeof error.body === 'object' &&
+      'message' in error.body &&
+      typeof error.body.message === 'string' &&
+      error.body.message.trim().length > 0
+    ) {
+      return error.body.message;
+    }
+
+    if (error instanceof Error && error.message.trim().length > 0) {
+      return error.message;
+    }
+
+    return 'Impossible de charger votre dashboard pour le moment.';
+  }
 }

--- a/packages/api-client/src/client.spec.ts
+++ b/packages/api-client/src/client.spec.ts
@@ -31,13 +31,14 @@ function baseConfig(overrides?: Partial<ApiClientConfig>): ApiClientConfig {
 // ---------------------------------------------------------------------------
 
 describe('createApiClient', () => {
-  it('retourne un objet avec les 11 groupes de ressources', () => {
+  it('retourne un objet avec les 12 groupes de ressources', () => {
     const client = createApiClient(baseConfig());
     const keys = Object.keys(client).sort((a, b) => a.localeCompare(b));
     expect(keys).toEqual([
       'announcements',
       'auth',
       'cohorts',
+      'dashboard',
       'enrollments',
       'notifications',
       'participants',
@@ -91,6 +92,11 @@ describe('createApiClient', () => {
     expect(typeof client.auth.refreshSession).toBe('function');
     expect(typeof client.auth.requestPasswordReset).toBe('function');
     expect(typeof client.auth.getSession).toBe('function');
+  });
+
+  it('dashboard expose getAggregate', () => {
+    const client = createApiClient(baseConfig());
+    expect(typeof client.dashboard.getAggregate).toBe('function');
   });
 });
 
@@ -252,6 +258,23 @@ describe('HTTP behaviour', () => {
     expect(url).toBe('https://api.test/auth/sign-up');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body as string)).toEqual(body);
+  });
+
+  it('GET /dashboard appelle le endpoint aggregate', async () => {
+    fetchSpy = mockFetch(200, {
+      generatedAt: '2026-04-29T11:00:00.000Z',
+      programs: [],
+      upcomingSessions: [],
+      recentAnnouncements: [],
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const client = createApiClient(baseConfig());
+    await client.dashboard.getAggregate();
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.test/dashboard');
+    expect(init.method).toBe('GET');
   });
 });
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -36,6 +36,7 @@ import type {
   SignInRequestDto,
   SignUpRequestDto,
   SignUpResponseDto,
+  DashboardAggregateDto,
 } from '@kraak/contracts';
 
 // ---------------------------------------------------------------------------
@@ -98,12 +99,17 @@ export interface AuthClient {
   getSession(options?: RequestOptions): Promise<AuthSessionContextDto>;
 }
 
+export interface DashboardClient {
+  getAggregate(options?: RequestOptions): Promise<DashboardAggregateDto>;
+}
+
 // ---------------------------------------------------------------------------
 // ApiClient interface
 // ---------------------------------------------------------------------------
 
 export interface ApiClient {
   auth: AuthClient;
+  dashboard: DashboardClient;
   users: FullResourceClient<AppUserDto, CreateAppUserDto, UpdateAppUserDto>;
   participants: FullResourceClient<
     ParticipantDto,
@@ -298,6 +304,19 @@ function createAuthClient(config: ApiClientConfig): AuthClient {
   };
 }
 
+function createDashboardClient(config: ApiClientConfig): DashboardClient {
+  return {
+    getAggregate: (options?) =>
+      request<DashboardAggregateDto>(
+        config,
+        'GET',
+        '/dashboard',
+        undefined,
+        options,
+      ),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -305,6 +324,7 @@ function createAuthClient(config: ApiClientConfig): AuthClient {
 export function createApiClient(config: ApiClientConfig): ApiClient {
   return {
     auth: createAuthClient(config),
+    dashboard: createDashboardClient(config),
     users: createFullResourceClient(config, '/users'),
     participants: createFullResourceClient(config, '/participants'),
     programs: createFullResourceClient(config, '/programs'),

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -2,6 +2,7 @@ export { createApiClient, ApiError } from './client.js';
 export type {
   ApiClient,
   AuthClient,
+  DashboardClient,
   ApiClientConfig,
   RequestOptions,
   ReadonlyResourceClient,


### PR DESCRIPTION
## Summary
- implémente la vue dashboard mobile participant (DSH-03) avec états chargement, erreur et vide
- branche la page mobile sur l'agrégat API dashboard via @kraak/api-client
- ajoute les tests unitaires dashboard mobile et les tests api-client du client dashboard

## Validation
- pnpm --filter @kraak/api-client test -- --runInBand
- pnpm --dir apps/client test:mobile
- hooks de push exécutés: typecheck + format:check + lint + tests libs/api/client + e2e Playwright

## Dependencies
- MOB-02: shell tabs mobile existant utilisé
- AUT-04: garde participant déjà appliquée sur route tabs
- DSH-02: endpoint agrégé dashboard consommé

Closes #92