### PR TITLE
feat(api): PRG-02 endpoints liste/detail programmes

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { DashboardModule } from './dashboard/dashboard.module';
+import { ProgramsModule } from './programs/programs.module';
 import { resolveApiEnvFilePaths } from './config/environment-files';
 import { SupabaseModule } from './supabase/supabase.module';
 import { SupportModule } from './support/support.module';
@@ -17,6 +18,7 @@ import { SupportModule } from './support/support.module';
     SupabaseModule,
     AuthModule,
     DashboardModule,
+    ProgramsModule,
     SupportModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/programs/programs.controller.spec.ts
+++ b/apps/api/src/programs/programs.controller.spec.ts
@@ -1,0 +1,126 @@
+import {
+  NotFoundException,
+  RequestMethod,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProgramsController } from './programs.controller';
+import { ProgramsService } from './programs.service';
+
+describe('ProgramsController', () => {
+  let controller: ProgramsController;
+  const programsService = {
+    listPrograms: jest.fn(),
+    getProgramDetail: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    programsService.listPrograms.mockReset();
+    programsService.getProgramDetail.mockReset();
+
+    programsService.listPrograms.mockResolvedValue([]);
+    programsService.getProgramDetail.mockResolvedValue({
+      enrollmentId: 'enrollment-1',
+      enrollmentStatus: 'active',
+      program: {
+        id: 'program-1',
+        slug: 'leadership-essentials',
+        title: 'Leadership Essentials',
+        summary: 'Bases du leadership de service.',
+        description: 'Parcours complet de leadership.',
+        status: 'published',
+        visibility: 'participants',
+        createdAt: '2026-04-10T10:00:00.000Z',
+        updatedAt: '2026-04-10T10:00:00.000Z',
+      },
+      cohort: null,
+      sessions: [],
+      resources: [],
+      announcements: [],
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProgramsController],
+      providers: [
+        {
+          provide: ProgramsService,
+          useValue: programsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ProgramsController>(ProgramsController);
+  });
+
+  it('devrait être défini', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // Given le module programmes MVP
+  // When on lit ses métadonnées NestJS
+  // Then GET /programs est exposé
+  it('Given le module programmes MVP, When on lit la route liste, Then GET /programs est exposé', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, ProgramsController)).toBe(
+      'programs',
+    );
+    expect(Reflect.getMetadata(METHOD_METADATA, controller.listPrograms)).toBe(
+      RequestMethod.GET,
+    );
+  });
+
+  // Given le module programmes MVP
+  // When on lit ses métadonnées NestJS
+  // Then GET /programs/:programId est exposé
+  it('Given le module programmes MVP, When on lit la route détail, Then GET /programs/:programId est exposé', () => {
+    expect(
+      Reflect.getMetadata(METHOD_METADATA, controller.getProgramDetail),
+    ).toBe(RequestMethod.GET);
+  });
+
+  // Given un header Authorization Bearer valide
+  // When GET /programs est appelé
+  // Then le token est transmis au service programmes
+  it('Given un header Authorization valide, When listPrograms est appelé, Then le token est transmis au service', async () => {
+    await controller.listPrograms('Bearer access-token');
+
+    expect(programsService.listPrograms).toHaveBeenCalledWith('access-token');
+  });
+
+  // Given un header Authorization Bearer valide
+  // When GET /programs/:programId est appelé
+  // Then le token et le programId sont transmis au service
+  it('Given un header Authorization valide, When getProgramDetail est appelé, Then le token et le programId sont transmis au service', async () => {
+    await controller.getProgramDetail('program-1', 'Bearer access-token');
+
+    expect(programsService.getProgramDetail).toHaveBeenCalledWith(
+      'access-token',
+      'program-1',
+    );
+  });
+
+  // Given un header Authorization absent
+  // When GET /programs est appelé
+  // Then une erreur d'authentification explicite est renvoyée
+  it('Given un header Authorization absent, When listPrograms est appelé, Then une UnauthorizedException est renvoyée', async () => {
+    await expect(controller.listPrograms()).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  // Given un programId inaccessible
+  // When GET /programs/:programId est appelé
+  // Then la NotFoundException du service est propagée
+  it('Given un programme inaccessible, When getProgramDetail est appelé, Then une NotFoundException est propagée', async () => {
+    programsService.getProgramDetail.mockRejectedValueOnce(
+      new NotFoundException({
+        success: false,
+        message: 'Programme introuvable pour ce participant.',
+      }),
+    );
+
+    await expect(
+      controller.getProgramDetail('program-missing', 'Bearer access-token'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/src/programs/programs.controller.spec.ts
+++ b/apps/api/src/programs/programs.controller.spec.ts
@@ -76,6 +76,9 @@ describe('ProgramsController', () => {
     expect(
       Reflect.getMetadata(METHOD_METADATA, controller.getProgramDetail),
     ).toBe(RequestMethod.GET);
+    expect(
+      Reflect.getMetadata(PATH_METADATA, controller.getProgramDetail),
+    ).toBe(':programId');
   });
 
   // Given un header Authorization Bearer valide
@@ -106,6 +109,15 @@ describe('ProgramsController', () => {
     await expect(controller.listPrograms()).rejects.toBeInstanceOf(
       UnauthorizedException,
     );
+  });
+
+  // Given un header Authorization absent
+  // When GET /programs/:programId est appelé
+  // Then une erreur d'authentification explicite est renvoyée
+  it('Given un header Authorization absent, When getProgramDetail est appelé, Then une UnauthorizedException est renvoyée', async () => {
+    await expect(
+      controller.getProgramDetail('program-1'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
   // Given un programId inaccessible

--- a/apps/api/src/programs/programs.controller.ts
+++ b/apps/api/src/programs/programs.controller.ts
@@ -1,0 +1,285 @@
+import {
+  Controller,
+  Get,
+  Headers,
+  Param,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import type {
+  ParticipantProgramDetailDto,
+  ParticipantProgramListItemDto,
+} from '@kraak/contracts';
+import { extractAccessToken } from '../auth/auth.dto';
+import { ProgramsService } from './programs.service';
+
+const apiErrorSchema = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', example: false },
+    message: { type: 'string' },
+  },
+};
+
+const programSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'slug',
+    'title',
+    'summary',
+    'description',
+    'status',
+    'visibility',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    slug: { type: 'string' },
+    title: { type: 'string' },
+    summary: { type: 'string' },
+    description: { type: 'string' },
+    status: { type: 'string', enum: ['draft', 'published', 'archived'] },
+    visibility: {
+      type: 'string',
+      enum: ['private', 'participants', 'public'],
+    },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const cohortSchema = {
+  type: 'object',
+  nullable: true,
+  required: [
+    'id',
+    'programId',
+    'name',
+    'code',
+    'status',
+    'startDate',
+    'endDate',
+    'capacity',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    programId: { type: 'string' },
+    name: { type: 'string' },
+    code: { type: 'string', nullable: true },
+    status: {
+      type: 'string',
+      enum: ['draft', 'open', 'active', 'completed', 'archived'],
+    },
+    startDate: { type: 'string' },
+    endDate: { type: 'string', nullable: true },
+    capacity: { type: 'integer', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const programListItemSchema = {
+  type: 'object',
+  required: ['enrollmentId', 'enrollmentStatus', 'program', 'cohort'],
+  properties: {
+    enrollmentId: { type: 'string' },
+    enrollmentStatus: {
+      type: 'string',
+      enum: ['pending', 'active', 'completed', 'cancelled'],
+    },
+    program: programSchema,
+    cohort: cohortSchema,
+  },
+};
+
+const sessionSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'cohortId',
+    'title',
+    'description',
+    'status',
+    'startsAt',
+    'endsAt',
+    'locationType',
+    'locationLabel',
+    'meetingLink',
+    'trainerUserId',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    cohortId: { type: 'string' },
+    title: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    status: {
+      type: 'string',
+      enum: ['scheduled', 'live', 'completed', 'cancelled'],
+    },
+    startsAt: { type: 'string', format: 'date-time' },
+    endsAt: { type: 'string', format: 'date-time' },
+    locationType: { type: 'string', enum: ['online', 'onsite', 'hybrid'] },
+    locationLabel: { type: 'string', nullable: true },
+    meetingLink: { type: 'string', nullable: true },
+    trainerUserId: { type: 'string', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const resourceSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'programId',
+    'cohortId',
+    'title',
+    'description',
+    'resourceType',
+    'url',
+    'filePath',
+    'status',
+    'publishedAt',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    programId: { type: 'string', nullable: true },
+    cohortId: { type: 'string', nullable: true },
+    title: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    resourceType: {
+      type: 'string',
+      enum: ['link', 'file', 'video', 'document'],
+    },
+    url: { type: 'string', nullable: true },
+    filePath: { type: 'string', nullable: true },
+    status: { type: 'string', enum: ['draft', 'published', 'archived'] },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const announcementPreviewSchema = {
+  type: 'object',
+  required: ['id', 'title', 'audienceType', 'publishedAt'],
+  properties: {
+    id: { type: 'string' },
+    title: { type: 'string' },
+    audienceType: {
+      type: 'string',
+      enum: ['all_participants', 'program', 'cohort', 'custom'],
+    },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+  },
+};
+
+const programDetailSchema = {
+  type: 'object',
+  required: [
+    'enrollmentId',
+    'enrollmentStatus',
+    'program',
+    'cohort',
+    'sessions',
+    'resources',
+    'announcements',
+  ],
+  properties: {
+    enrollmentId: { type: 'string' },
+    enrollmentStatus: {
+      type: 'string',
+      enum: ['pending', 'active', 'completed', 'cancelled'],
+    },
+    program: programSchema,
+    cohort: cohortSchema,
+    sessions: { type: 'array', items: sessionSchema },
+    resources: { type: 'array', items: resourceSchema },
+    announcements: { type: 'array', items: announcementPreviewSchema },
+  },
+};
+
+@ApiTags('Programs')
+@Controller('programs')
+export class ProgramsController {
+  constructor(private readonly programsService: ProgramsService) {}
+
+  @Get()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Lister les programmes accessibles au participant connecté',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste des programmes accessible avec succès',
+    schema: { type: 'array', items: programListItemSchema },
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Session invalide ou header d'autorisation manquant",
+    schema: apiErrorSchema,
+  })
+  async listPrograms(
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ParticipantProgramListItemDto[]> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.programsService.listPrograms(accessToken.data);
+  }
+
+  @Get(':programId')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Récupérer le détail d’un programme accessible au participant',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Détail du programme chargé avec succès',
+    schema: programDetailSchema,
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Session invalide ou header d'autorisation manquant",
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Programme introuvable ou non accessible pour ce participant',
+    schema: apiErrorSchema,
+  })
+  async getProgramDetail(
+    @Param('programId') programId: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ParticipantProgramDetailDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.programsService.getProgramDetail(accessToken.data, programId);
+  }
+}

--- a/apps/api/src/programs/programs.controller.ts
+++ b/apps/api/src/programs/programs.controller.ts
@@ -224,12 +224,17 @@ export class ProgramsController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Liste des programmes accessible avec succès',
+    description: 'Liste des programmes accessibles avec succès',
     schema: { type: 'array', items: programListItemSchema },
   })
   @ApiResponse({
     status: 401,
     description: "Session invalide ou header d'autorisation manquant",
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Erreur serveur lors du chargement des programmes',
     schema: apiErrorSchema,
   })
   async listPrograms(
@@ -265,6 +270,11 @@ export class ProgramsController {
   @ApiResponse({
     status: 404,
     description: 'Programme introuvable ou non accessible pour ce participant',
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Erreur serveur lors du chargement du détail programme',
     schema: apiErrorSchema,
   })
   async getProgramDetail(

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { ProgramsController } from './programs.controller';
+import { ProgramsService } from './programs.service';
+
+@Module({
+  imports: [SupabaseModule],
+  controllers: [ProgramsController],
+  providers: [ProgramsService],
+})
+export class ProgramsModule {}

--- a/apps/api/src/programs/programs.service.spec.ts
+++ b/apps/api/src/programs/programs.service.spec.ts
@@ -179,6 +179,36 @@ describe('ProgramsService', () => {
     await expect(service.listPrograms('access-token')).resolves.toEqual([]);
   });
 
+  // Given une erreur de lecture des enrollments
+  // When la liste programmes est demandée
+  // Then une InternalServerErrorException explicite est renvoyée
+  it('Given une erreur sur enrollment, When listPrograms est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentQuery = createListQuery({
+      data: null,
+      error: { message: 'db-error' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        return enrollmentQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listPrograms('access-token')).rejects.toBeInstanceOf(
+      InternalServerErrorException,
+    );
+  });
+
   // Given un programme accessible avec cohorte
   // When le détail programme est demandé
   // Then le détail inclut sessions, ressources et annonces visibles
@@ -398,5 +428,128 @@ describe('ProgramsService', () => {
     await expect(
       service.getProgramDetail('access-token', 'program-1'),
     ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  // Given des annonces mixtes
+  // When le détail programme est demandé
+  // Then seules les annonces visibles pour le programme/cohorte sont renvoyées
+  it('Given des annonces mixtes, When getProgramDetail est appelé, Then seules les annonces visibles sont conservées', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentDetailQuery = createSingleRowQuery({
+      data: {
+        id: 'enrollment-1',
+        status: 'active',
+        program_id: 'program-1',
+        cohort_id: 'cohort-1',
+        program: {
+          id: 'program-1',
+          slug: 'leadership-essentials',
+          title: 'Leadership Essentials',
+          summary: 'Bases du leadership.',
+          description: 'Parcours complet.',
+          status: 'published',
+          visibility: 'participants',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+        cohort: {
+          id: 'cohort-1',
+          program_id: 'program-1',
+          name: 'Cohorte Avril',
+          code: null,
+          status: 'active',
+          start_date: '2026-04-10',
+          end_date: null,
+          capacity: null,
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      },
+      error: null,
+    });
+    const sessionsQuery = createListQuery({ data: [], error: null });
+    const resourcesQuery = createListQuery({ data: [], error: null });
+    const announcementsQuery = createListQuery({
+      data: [
+        {
+          id: 'announcement-visible-all',
+          title: 'Visible all',
+          audience_type: 'all_participants',
+          published_at: '2026-04-25T00:00:00.000Z',
+          program_id: null,
+          cohort_id: null,
+        },
+        {
+          id: 'announcement-visible-program',
+          title: 'Visible program',
+          audience_type: 'program',
+          published_at: '2026-04-24T00:00:00.000Z',
+          program_id: 'program-1',
+          cohort_id: null,
+        },
+        {
+          id: 'announcement-visible-cohort',
+          title: 'Visible cohort',
+          audience_type: 'cohort',
+          published_at: '2026-04-23T00:00:00.000Z',
+          program_id: null,
+          cohort_id: 'cohort-1',
+        },
+        {
+          id: 'announcement-hidden-custom',
+          title: 'Hidden custom',
+          audience_type: 'custom',
+          published_at: '2026-04-22T00:00:00.000Z',
+          program_id: null,
+          cohort_id: null,
+        },
+        {
+          id: 'announcement-hidden-program',
+          title: 'Hidden program',
+          audience_type: 'program',
+          published_at: '2026-04-21T00:00:00.000Z',
+          program_id: 'program-other',
+          cohort_id: null,
+        },
+      ],
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        return enrollmentDetailQuery;
+      }
+
+      if (tableName === 'session') {
+        return sessionsQuery;
+      }
+
+      if (tableName === 'resource') {
+        return resourcesQuery;
+      }
+
+      if (tableName === 'announcement') {
+        return announcementsQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getProgramDetail('access-token', 'program-1'),
+    ).resolves.toMatchObject({
+      announcements: [
+        { id: 'announcement-visible-all' },
+        { id: 'announcement-visible-program' },
+        { id: 'announcement-visible-cohort' },
+      ],
+    });
   });
 });

--- a/apps/api/src/programs/programs.service.spec.ts
+++ b/apps/api/src/programs/programs.service.spec.ts
@@ -1,0 +1,402 @@
+import {
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SupabaseService } from '../supabase/supabase.service';
+import { ProgramsService } from './programs.service';
+
+function createSingleRowQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    in: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function createListQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    in: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue(result),
+  };
+}
+
+describe('ProgramsService', () => {
+  let service: ProgramsService;
+
+  const authClient = {
+    auth: {
+      getUser: jest.fn(),
+    },
+  };
+
+  const adminClient = {
+    from: jest.fn(),
+  };
+
+  const supabaseService = {
+    createAuthClient: jest.fn(() => authClient),
+    getClient: jest.fn(() => adminClient),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    authClient.auth.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: 'user-1',
+        },
+      },
+      error: null,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProgramsService,
+        {
+          provide: SupabaseService,
+          useValue: supabaseService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProgramsService>(ProgramsService);
+  });
+
+  it('devrait être défini', () => {
+    expect(service).toBeDefined();
+  });
+
+  // Given un participant authentifié avec des enrollments visibles
+  // When la liste des programmes est demandée
+  // Then la liste mappée des programmes est renvoyée
+  it('Given un participant authentifié, When listPrograms est appelé, Then les programmes visibles sont renvoyés', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentQuery = createListQuery({
+      data: [
+        {
+          id: 'enrollment-1',
+          status: 'active',
+          program_id: 'program-1',
+          cohort_id: 'cohort-1',
+          program: {
+            id: 'program-1',
+            slug: 'leadership-essentials',
+            title: 'Leadership Essentials',
+            summary: 'Bases du leadership.',
+            description: 'Parcours complet.',
+            status: 'published',
+            visibility: 'participants',
+            created_at: '2026-04-01T00:00:00.000Z',
+            updated_at: '2026-04-01T00:00:00.000Z',
+          },
+          cohort: {
+            id: 'cohort-1',
+            program_id: 'program-1',
+            name: 'Cohorte Avril',
+            code: 'APR-26',
+            status: 'active',
+            start_date: '2026-04-10',
+            end_date: null,
+            capacity: 25,
+            created_at: '2026-04-01T00:00:00.000Z',
+            updated_at: '2026-04-01T00:00:00.000Z',
+          },
+        },
+      ],
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        return enrollmentQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listPrograms('access-token')).resolves.toMatchObject([
+      {
+        enrollmentId: 'enrollment-1',
+        enrollmentStatus: 'active',
+        program: {
+          id: 'program-1',
+          slug: 'leadership-essentials',
+        },
+        cohort: {
+          id: 'cohort-1',
+          name: 'Cohorte Avril',
+        },
+      },
+    ]);
+  });
+
+  // Given un token invalide
+  // When une liste programmes est demandée
+  // Then une erreur d'authentification explicite est renvoyée
+  it('Given un token invalide, When listPrograms est appelé, Then une UnauthorizedException est renvoyée', async () => {
+    authClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'invalid token' },
+    });
+
+    await expect(service.listPrograms('expired-token')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  // Given un utilisateur authentifié sans participant lié
+  // When la liste programmes est demandée
+  // Then une liste vide stable est renvoyée
+  it('Given un utilisateur sans participant, When listPrograms est appelé, Then une liste vide est renvoyée', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listPrograms('access-token')).resolves.toEqual([]);
+  });
+
+  // Given un programme accessible avec cohorte
+  // When le détail programme est demandé
+  // Then le détail inclut sessions, ressources et annonces visibles
+  it('Given un programme accessible, When getProgramDetail est appelé, Then le détail agrégé est renvoyé', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentDetailQuery = createSingleRowQuery({
+      data: {
+        id: 'enrollment-1',
+        status: 'active',
+        program_id: 'program-1',
+        cohort_id: 'cohort-1',
+        program: {
+          id: 'program-1',
+          slug: 'leadership-essentials',
+          title: 'Leadership Essentials',
+          summary: 'Bases du leadership.',
+          description: 'Parcours complet.',
+          status: 'published',
+          visibility: 'participants',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+        cohort: {
+          id: 'cohort-1',
+          program_id: 'program-1',
+          name: 'Cohorte Avril',
+          code: 'APR-26',
+          status: 'active',
+          start_date: '2026-04-10',
+          end_date: null,
+          capacity: 25,
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      },
+      error: null,
+    });
+    const sessionsQuery = createListQuery({
+      data: [
+        {
+          id: 'session-1',
+          cohort_id: 'cohort-1',
+          title: 'Atelier Vision',
+          description: 'Vision et priorités',
+          status: 'scheduled',
+          starts_at: '2026-05-02T09:00:00.000Z',
+          ends_at: '2026-05-02T11:00:00.000Z',
+          location_type: 'online',
+          location_label: null,
+          meeting_link: 'https://meet.example.com/kraak',
+          trainer_user_id: null,
+          created_at: '2026-04-20T00:00:00.000Z',
+          updated_at: '2026-04-20T00:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const resourcesQuery = createListQuery({
+      data: [
+        {
+          id: 'resource-1',
+          program_id: 'program-1',
+          cohort_id: null,
+          title: 'Guide participant',
+          description: null,
+          resource_type: 'document',
+          url: null,
+          file_path: '/resources/guide.pdf',
+          status: 'published',
+          published_at: '2026-04-21T00:00:00.000Z',
+          created_at: '2026-04-20T00:00:00.000Z',
+          updated_at: '2026-04-20T00:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const announcementsQuery = createListQuery({
+      data: [
+        {
+          id: 'announcement-1',
+          title: 'Message cohorte',
+          audience_type: 'cohort',
+          published_at: '2026-04-22T00:00:00.000Z',
+          program_id: null,
+          cohort_id: 'cohort-1',
+        },
+      ],
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        return enrollmentDetailQuery;
+      }
+
+      if (tableName === 'session') {
+        return sessionsQuery;
+      }
+
+      if (tableName === 'resource') {
+        return resourcesQuery;
+      }
+
+      if (tableName === 'announcement') {
+        return announcementsQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getProgramDetail('access-token', 'program-1'),
+    ).resolves.toMatchObject({
+      enrollmentId: 'enrollment-1',
+      program: { id: 'program-1' },
+      sessions: [{ id: 'session-1' }],
+      resources: [{ id: 'resource-1' }],
+      announcements: [{ id: 'announcement-1' }],
+    });
+  });
+
+  // Given un enrollment introuvable pour le participant
+  // When le détail programme est demandé
+  // Then une NotFoundException explicite est renvoyée
+  it('Given un enrollment introuvable, When getProgramDetail est appelé, Then une NotFoundException est renvoyée', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentDetailQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        return enrollmentDetailQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getProgramDetail('access-token', 'program-missing'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  // Given une erreur de lecture des ressources
+  // When le détail programme est demandé
+  // Then une InternalServerErrorException explicite est renvoyée
+  it('Given une erreur sur resource, When getProgramDetail est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentDetailQuery = createSingleRowQuery({
+      data: {
+        id: 'enrollment-1',
+        status: 'active',
+        program_id: 'program-1',
+        cohort_id: null,
+        program: {
+          id: 'program-1',
+          slug: 'leadership-essentials',
+          title: 'Leadership Essentials',
+          summary: 'Bases du leadership.',
+          description: 'Parcours complet.',
+          status: 'published',
+          visibility: 'participants',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+        cohort: null,
+      },
+      error: null,
+    });
+    const resourcesQuery = createListQuery({
+      data: null,
+      error: { message: 'db-error' },
+    });
+    const announcementsQuery = createListQuery({
+      data: [],
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        return enrollmentDetailQuery;
+      }
+
+      if (tableName === 'resource') {
+        return resourcesQuery;
+      }
+
+      if (tableName === 'announcement') {
+        return announcementsQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getProgramDetail('access-token', 'program-1'),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+});

--- a/apps/api/src/programs/programs.service.spec.ts
+++ b/apps/api/src/programs/programs.service.spec.ts
@@ -20,6 +20,7 @@ function createListQuery(result: { data: unknown; error: unknown }) {
   return {
     select: jest.fn().mockReturnThis(),
     eq: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
     in: jest.fn().mockReturnThis(),
     or: jest.fn().mockReturnThis(),
     order: jest.fn().mockReturnThis(),

--- a/apps/api/src/programs/programs.service.ts
+++ b/apps/api/src/programs/programs.service.ts
@@ -1,0 +1,447 @@
+import {
+  InternalServerErrorException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type {
+  AudienceTypeValue,
+  CohortDto,
+  CohortStatusValue,
+  EnrollmentStatusValue,
+  ParticipantProgramDetailDto,
+  ParticipantProgramListItemDto,
+  ProgramAnnouncementPreviewDto,
+  ProgramDto,
+  ProgramVisibilityValue,
+  PublicationStatusValue,
+  ResourceDto,
+  ResourceTypeValue,
+  SessionDto,
+  SessionStatusValue,
+  LocationTypeValue,
+} from '@kraak/contracts';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type ParticipantRow = {
+  id: string;
+};
+
+type ProgramRow = {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  status: PublicationStatusValue;
+  visibility: ProgramVisibilityValue;
+  created_at: string;
+  updated_at: string;
+};
+
+type CohortRow = {
+  id: string;
+  program_id: string;
+  name: string;
+  code: string | null;
+  status: CohortStatusValue;
+  start_date: string;
+  end_date: string | null;
+  capacity: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type EnrollmentRow = {
+  id: string;
+  status: EnrollmentStatusValue;
+  program_id: string;
+  cohort_id: string | null;
+  program: ProgramRow | ProgramRow[] | null;
+  cohort: CohortRow | CohortRow[] | null;
+};
+
+type SessionRow = {
+  id: string;
+  cohort_id: string;
+  title: string;
+  description: string | null;
+  status: SessionStatusValue;
+  starts_at: string;
+  ends_at: string;
+  location_type: LocationTypeValue;
+  location_label: string | null;
+  meeting_link: string | null;
+  trainer_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ResourceRow = {
+  id: string;
+  program_id: string | null;
+  cohort_id: string | null;
+  title: string;
+  description: string | null;
+  resource_type: ResourceTypeValue;
+  url: string | null;
+  file_path: string | null;
+  status: PublicationStatusValue;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type AnnouncementPreviewRow = Pick<
+  {
+    id: string;
+    title: string;
+    audience_type: AudienceTypeValue;
+    program_id: string | null;
+    cohort_id: string | null;
+    published_at: string | null;
+  },
+  'id' | 'title' | 'audience_type' | 'program_id' | 'cohort_id' | 'published_at'
+>;
+
+function normalizeRelation<T>(value: T | T[] | null | undefined): T | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+}
+
+@Injectable()
+export class ProgramsService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async listPrograms(
+    accessToken: string,
+  ): Promise<ParticipantProgramListItemDto[]> {
+    const participantId = await this.resolveParticipantId(accessToken);
+
+    if (!participantId) {
+      return [];
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('enrollment')
+      .select(
+        'id, status, program_id, cohort_id, program:program(id, slug, title, summary, description, status, visibility, created_at, updated_at), cohort:cohort(id, program_id, name, code, status, start_date, end_date, capacity, created_at, updated_at)',
+      )
+      .eq('participant_id', participantId)
+      .in('status', ['pending', 'active', 'completed'])
+      .order('enrolled_at', { ascending: false })
+      .limit(20);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger la liste des programmes.',
+      });
+    }
+
+    return ((data as EnrollmentRow[] | null) ?? [])
+      .map((row) => {
+        const program = normalizeRelation(row.program);
+
+        if (!program) {
+          return null;
+        }
+
+        return {
+          enrollmentId: row.id,
+          enrollmentStatus: row.status,
+          program: this.mapProgram(program),
+          cohort: this.mapCohort(normalizeRelation(row.cohort)),
+        };
+      })
+      .filter((item): item is ParticipantProgramListItemDto => item !== null);
+  }
+
+  async getProgramDetail(
+    accessToken: string,
+    programId: string,
+  ): Promise<ParticipantProgramDetailDto> {
+    const participantId = await this.resolveParticipantId(accessToken);
+
+    if (!participantId) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Programme introuvable pour ce participant.',
+      });
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('enrollment')
+      .select(
+        'id, status, program_id, cohort_id, program:program(id, slug, title, summary, description, status, visibility, created_at, updated_at), cohort:cohort(id, program_id, name, code, status, start_date, end_date, capacity, created_at, updated_at)',
+      )
+      .eq('participant_id', participantId)
+      .eq('program_id', programId)
+      .in('status', ['pending', 'active', 'completed'])
+      .maybeSingle();
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger le programme demandé.',
+      });
+    }
+
+    const enrollment = data as EnrollmentRow | null;
+
+    if (!enrollment) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Programme introuvable pour ce participant.',
+      });
+    }
+
+    const program = normalizeRelation(enrollment.program);
+
+    if (!program) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Programme introuvable pour ce participant.',
+      });
+    }
+
+    const cohort = this.mapCohort(normalizeRelation(enrollment.cohort));
+    const [sessions, resources, announcements] = await Promise.all([
+      cohort ? this.readSessions(cohort.id) : Promise.resolve<SessionDto[]>([]),
+      this.readResources(program.id, cohort?.id ?? null),
+      this.readAnnouncements(program.id, cohort?.id ?? null),
+    ]);
+
+    return {
+      enrollmentId: enrollment.id,
+      enrollmentStatus: enrollment.status,
+      program: this.mapProgram(program),
+      cohort,
+      sessions,
+      resources,
+      announcements,
+    };
+  }
+
+  private async resolveParticipantId(
+    accessToken: string,
+  ): Promise<string | null> {
+    const authClient = this.supabaseService.createAuthClient();
+    const { data, error } = await authClient.auth.getUser(accessToken);
+
+    if (error || !data.user) {
+      throw new UnauthorizedException({
+        success: false,
+        message: 'La session est invalide ou expirée.',
+      });
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data: participant, error: participantError } = await adminClient
+      .from('participant')
+      .select('id')
+      .eq('user_id', data.user.id)
+      .maybeSingle();
+
+    if (participantError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger le participant courant.',
+      });
+    }
+
+    return (participant as ParticipantRow | null)?.id ?? null;
+  }
+
+  private async readSessions(cohortId: string): Promise<SessionDto[]> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('session')
+      .select(
+        'id, cohort_id, title, description, status, starts_at, ends_at, location_type, location_label, meeting_link, trainer_user_id, created_at, updated_at',
+      )
+      .eq('cohort_id', cohortId)
+      .in('status', ['scheduled', 'live', 'completed'])
+      .order('starts_at', { ascending: true })
+      .limit(50);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les sessions du programme.',
+      });
+    }
+
+    return ((data as SessionRow[] | null) ?? []).map((row) =>
+      this.mapSession(row),
+    );
+  }
+
+  private async readResources(
+    programId: string,
+    cohortId: string | null,
+  ): Promise<ResourceDto[]> {
+    const adminClient = this.supabaseService.getClient();
+    const relationScopedQuery = adminClient
+      .from('resource')
+      .select(
+        'id, program_id, cohort_id, title, description, resource_type, url, file_path, status, published_at, created_at, updated_at',
+      )
+      .eq('status', 'published');
+
+    const query = cohortId
+      ? relationScopedQuery.or(
+          `program_id.eq.${programId},cohort_id.eq.${cohortId}`,
+        )
+      : relationScopedQuery.eq('program_id', programId);
+
+    const { data, error } = await query
+      .order('published_at', { ascending: false })
+      .limit(50);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les ressources du programme.',
+      });
+    }
+
+    return ((data as ResourceRow[] | null) ?? []).map((row) =>
+      this.mapResource(row),
+    );
+  }
+
+  private async readAnnouncements(
+    programId: string,
+    cohortId: string | null,
+  ): Promise<ProgramAnnouncementPreviewDto[]> {
+    const adminClient = this.supabaseService.getClient();
+    const visibilityFilters = [
+      'audience_type.eq.all_participants',
+      `and(audience_type.eq.program,program_id.eq.${programId})`,
+    ];
+
+    if (cohortId) {
+      visibilityFilters.push(
+        `and(audience_type.eq.cohort,cohort_id.eq.${cohortId})`,
+      );
+    }
+
+    const { data, error } = await adminClient
+      .from('announcement')
+      .select('id, title, audience_type, program_id, cohort_id, published_at')
+      .eq('status', 'published')
+      .or(visibilityFilters.join(','))
+      .order('published_at', { ascending: false })
+      .limit(20);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les annonces du programme.',
+      });
+    }
+
+    return ((data as AnnouncementPreviewRow[] | null) ?? [])
+      .filter((row) => this.isVisibleAnnouncement(row, programId, cohortId))
+      .map((row) => ({
+        id: row.id,
+        title: row.title,
+        audienceType: row.audience_type,
+        publishedAt: row.published_at,
+      }));
+  }
+
+  private isVisibleAnnouncement(
+    announcement: AnnouncementPreviewRow,
+    programId: string,
+    cohortId: string | null,
+  ): boolean {
+    if (announcement.audience_type === 'all_participants') {
+      return true;
+    }
+
+    if (announcement.audience_type === 'program') {
+      return announcement.program_id === programId;
+    }
+
+    if (announcement.audience_type === 'cohort') {
+      return Boolean(cohortId && announcement.cohort_id === cohortId);
+    }
+
+    return false;
+  }
+
+  private mapProgram(row: ProgramRow): ProgramDto {
+    return {
+      id: row.id,
+      slug: row.slug,
+      title: row.title,
+      summary: row.summary,
+      description: row.description,
+      status: row.status,
+      visibility: row.visibility,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapCohort(row: CohortRow | null): CohortDto | null {
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      programId: row.program_id,
+      name: row.name,
+      code: row.code,
+      status: row.status,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      capacity: row.capacity,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapSession(row: SessionRow): SessionDto {
+    return {
+      id: row.id,
+      cohortId: row.cohort_id,
+      title: row.title,
+      description: row.description,
+      status: row.status,
+      startsAt: row.starts_at,
+      endsAt: row.ends_at,
+      locationType: row.location_type,
+      locationLabel: row.location_label,
+      meetingLink: row.meeting_link,
+      trainerUserId: row.trainer_user_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapResource(row: ResourceRow): ResourceDto {
+    return {
+      id: row.id,
+      programId: row.program_id,
+      cohortId: row.cohort_id,
+      title: row.title,
+      description: row.description,
+      resourceType: row.resource_type,
+      url: row.url,
+      filePath: row.file_path,
+      status: row.status,
+      publishedAt: row.published_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/apps/api/src/programs/programs.service.ts
+++ b/apps/api/src/programs/programs.service.ts
@@ -287,33 +287,67 @@ export class ProgramsService {
     cohortId: string | null,
   ): Promise<ResourceDto[]> {
     const adminClient = this.supabaseService.getClient();
-    const relationScopedQuery = adminClient
-      .from('resource')
-      .select(
-        'id, program_id, cohort_id, title, description, resource_type, url, file_path, status, published_at, created_at, updated_at',
-      )
-      .eq('status', 'published');
-
-    const query = cohortId
-      ? relationScopedQuery.or(
-          `program_id.eq.${programId},cohort_id.eq.${cohortId}`,
+    const { data: programResources, error: programResourcesError } =
+      await adminClient
+        .from('resource')
+        .select(
+          'id, program_id, cohort_id, title, description, resource_type, url, file_path, status, published_at, created_at, updated_at',
         )
-      : relationScopedQuery.eq('program_id', programId);
+        .eq('status', 'published')
+        .eq('program_id', programId)
+        .is('cohort_id', null)
+        .order('published_at', { ascending: false })
+        .limit(50);
 
-    const { data, error } = await query
-      .order('published_at', { ascending: false })
-      .limit(50);
-
-    if (error) {
+    if (programResourcesError) {
       throw new InternalServerErrorException({
         success: false,
         message: 'Impossible de charger les ressources du programme.',
       });
     }
 
-    return ((data as ResourceRow[] | null) ?? []).map((row) =>
-      this.mapResource(row),
-    );
+    let cohortResources: ResourceRow[] = [];
+
+    if (cohortId) {
+      const { data, error } = await adminClient
+        .from('resource')
+        .select(
+          'id, program_id, cohort_id, title, description, resource_type, url, file_path, status, published_at, created_at, updated_at',
+        )
+        .eq('status', 'published')
+        .eq('cohort_id', cohortId)
+        .order('published_at', { ascending: false })
+        .limit(50);
+
+      if (error) {
+        throw new InternalServerErrorException({
+          success: false,
+          message: 'Impossible de charger les ressources du programme.',
+        });
+      }
+
+      cohortResources = (data as ResourceRow[] | null) ?? [];
+    }
+
+    const mergedResources = [
+      ...((programResources as ResourceRow[] | null) ?? []),
+      ...cohortResources,
+    ];
+
+    const uniqueResources = Array.from(
+      new Map(mergedResources.map((row) => [row.id, row])).values(),
+    ).sort((left, right) => {
+      const leftPublishedAt = left.published_at
+        ? new Date(left.published_at).getTime()
+        : 0;
+      const rightPublishedAt = right.published_at
+        ? new Date(right.published_at).getTime()
+        : 0;
+
+      return rightPublishedAt - leftPublishedAt;
+    });
+
+    return uniqueResources.slice(0, 50).map((row) => this.mapResource(row));
   }
 
   private async readAnnouncements(

--- a/packages/contracts/src/dto.spec.ts
+++ b/packages/contracts/src/dto.spec.ts
@@ -35,6 +35,9 @@ import type {
   DashboardProgramSummaryDto,
   DashboardSessionReminderDto,
   DashboardAnnouncementSummaryDto,
+  ParticipantProgramListItemDto,
+  ParticipantProgramDetailDto,
+  ProgramAnnouncementPreviewDto,
 } from './dto';
 
 // Runtime import to ensure the module actually exists (prevents vacuous type test passes)
@@ -108,6 +111,69 @@ describe('DashboardAggregateDto', () => {
     expectTypeOf<DashboardAggregateDto>()
       .toHaveProperty('recentAnnouncements')
       .toEqualTypeOf<DashboardAnnouncementSummaryDto[]>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Programs for participant area
+// ---------------------------------------------------------------------------
+describe('ParticipantProgramListItemDto', () => {
+  it('should expose list item payload for participant programs', () => {
+    expectTypeOf<ParticipantProgramListItemDto>()
+      .toHaveProperty('enrollmentId')
+      .toBeString();
+    expectTypeOf<ParticipantProgramListItemDto>()
+      .toHaveProperty('enrollmentStatus')
+      .toEqualTypeOf<EnrollmentStatusValue>();
+    expectTypeOf<ParticipantProgramListItemDto>()
+      .toHaveProperty('program')
+      .toEqualTypeOf<ProgramDto>();
+    expectTypeOf<ParticipantProgramListItemDto>()
+      .toHaveProperty('cohort')
+      .toEqualTypeOf<CohortDto | null>();
+  });
+});
+
+describe('ParticipantProgramDetailDto', () => {
+  it('should expose detail payload for participant program page', () => {
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('enrollmentId')
+      .toBeString();
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('enrollmentStatus')
+      .toEqualTypeOf<EnrollmentStatusValue>();
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('program')
+      .toEqualTypeOf<ProgramDto>();
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('cohort')
+      .toEqualTypeOf<CohortDto | null>();
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('sessions')
+      .toEqualTypeOf<SessionDto[]>();
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('resources')
+      .toEqualTypeOf<ResourceDto[]>();
+    expectTypeOf<ParticipantProgramDetailDto>()
+      .toHaveProperty('announcements')
+      .toEqualTypeOf<ProgramAnnouncementPreviewDto[]>();
+  });
+});
+
+describe('ProgramAnnouncementPreviewDto', () => {
+  it('should expose lightweight announcement summary for program detail', () => {
+    expectTypeOf<ProgramAnnouncementPreviewDto>()
+      .toHaveProperty('id')
+      .toBeString();
+    expectTypeOf<ProgramAnnouncementPreviewDto>()
+      .toHaveProperty('title')
+      .toBeString();
+    expectTypeOf<ProgramAnnouncementPreviewDto>()
+      .toHaveProperty('audienceType')
+      .toEqualTypeOf<AudienceTypeValue>();
+    expectTypeOf<ProgramAnnouncementPreviewDto>()
+      .toHaveProperty('publishedAt')
+      .toEqualTypeOf<string | null>();
   });
 });
 

--- a/packages/contracts/src/dto.ts
+++ b/packages/contracts/src/dto.ts
@@ -142,6 +142,33 @@ export interface DashboardAggregateDto {
 }
 
 // ---------------------------------------------------------------------------
+// Programs
+// ---------------------------------------------------------------------------
+export interface ParticipantProgramListItemDto {
+  enrollmentId: string;
+  enrollmentStatus: EnrollmentStatusValue;
+  program: ProgramDto;
+  cohort: CohortDto | null;
+}
+
+export interface ProgramAnnouncementPreviewDto {
+  id: string;
+  title: string;
+  audienceType: AudienceTypeValue;
+  publishedAt: string | null;
+}
+
+export interface ParticipantProgramDetailDto {
+  enrollmentId: string;
+  enrollmentStatus: EnrollmentStatusValue;
+  program: ProgramDto;
+  cohort: CohortDto | null;
+  sessions: SessionDto[];
+  resources: ResourceDto[];
+  announcements: ProgramAnnouncementPreviewDto[];
+}
+
+// ---------------------------------------------------------------------------
 // AppUser
 // ---------------------------------------------------------------------------
 export interface AppUserDto {


### PR DESCRIPTION
## Résumé
- implémentation du module API `programs` avec endpoints authentifiés :
  - `GET /programs` (liste des programmes accessibles)
  - `GET /programs/:programId` (détail programme avec cohorte, sessions, ressources, annonces)
- ajout de la documentation Swagger inline pour succès/erreurs sur les deux routes
- ajout des DTO contracts pour la couche participant programmes
- wiring du module dans `AppModule`

## Validation
- `pnpm --filter @kraak/contracts test -- --run`
- `pnpm --filter @kraak/api test -- --runInBand programs`
- hooks de commit/push exécutés avec succès (typecheck, format:check, lint, test)

## Issue liée
Closes #95
