### PR TITLE
[TASK][PRG-05] Ajouter scenarii de test Given/When/Then programmes

### DIFF
--- a/apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
@@ -10,15 +10,49 @@ describe('ProgramsPage', () => {
     }).compileComponents();
   });
 
-  it('should create', () => {
+  it('Given the Programs page route, when the component initializes, then the page instance is created', () => {
     const fixture = TestBed.createComponent(ProgramsPage);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the heading', () => {
+  it('Given the Programs page, when the view is rendered, then the heading and key program cards are visible', () => {
     const fixture = TestBed.createComponent(ProgramsPage);
     fixture.detectChanges();
-    const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain('Nos programmes');
+    const page = fixture.nativeElement as HTMLElement;
+
+    expect(page.querySelector('h1')?.textContent).toContain('Nos programmes');
+    expect(page.textContent).toContain('Leadership & Management');
+    expect(page.textContent).toContain('Gestion de projet appliquée');
+    expect(page.textContent).toContain("Préparation à l'international");
+  });
+
+  it('Given the registration process section, when the Programs page is rendered, then the four expected steps are displayed in order', () => {
+    const fixture = TestBed.createComponent(ProgramsPage);
+    fixture.detectChanges();
+    const page = fixture.nativeElement as HTMLElement;
+
+    const content = page.textContent ?? '';
+    const candidatureIndex = content.indexOf('Candidature');
+    const entretienIndex = content.indexOf('Entretien');
+    const inscriptionIndex = content.indexOf('Inscription');
+    const demarrageIndex = content.indexOf('Démarrage');
+
+    expect(candidatureIndex).toBeGreaterThan(-1);
+    expect(entretienIndex).toBeGreaterThan(candidatureIndex);
+    expect(inscriptionIndex).toBeGreaterThan(entretienIndex);
+    expect(demarrageIndex).toBeGreaterThan(inscriptionIndex);
+  });
+
+  it('Given the Programs page CTA, when a visitor reaches the end of the page, then the registration call-to-action points to contact', () => {
+    const fixture = TestBed.createComponent(ProgramsPage);
+    fixture.detectChanges();
+    const page = fixture.nativeElement as HTMLElement;
+
+    const registrationLink = page.querySelector(
+      'a[href="/contact"]',
+    ) as HTMLAnchorElement | null;
+
+    expect(registrationLink).toBeTruthy();
+    expect(registrationLink?.textContent).toContain("S'inscrire maintenant");
   });
 });

--- a/apps/client/tests/e2e/programs.spec.ts
+++ b/apps/client/tests/e2e/programs.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Page programmes - parcours vitrine', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/programmes');
+  });
+
+  test('Given la page Programmes, When elle se charge, Then le titre principal et les trois parcours sont visibles', async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Nos programmes' }),
+    ).toBeVisible();
+
+    await expect(page.getByText('Leadership & Management')).toBeVisible();
+    await expect(page.getByText('Gestion de projet appliquée')).toBeVisible();
+    await expect(page.getByText("Préparation à l'international")).toBeVisible();
+  });
+
+  test("Given la section d'inscription, When elle est lue, Then les quatre étapes de parcours sont présentées", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole('heading', { name: "Comment s'inscrire ?" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Candidature' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Entretien' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Inscription' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Démarrage' }),
+    ).toBeVisible();
+  });
+
+  test("Given le call-to-action de fin de page, When un visiteur veut rejoindre une cohorte, Then l'action mène vers la page contact", async ({
+    page,
+  }) => {
+    const cta = page.getByRole('link', { name: "S'inscrire maintenant" });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', '/contact');
+  });
+});


### PR DESCRIPTION
## Summary

Implements PRG-05 by adding Given/When/Then test scenarios for Programs coverage, while explicitly including the existing mobile Programs HTML updates in scope.

## Changes

- Added and strengthened Program scenarios in web unit tests:
  - apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
  - Given/When/Then coverage for heading/cards, registration flow steps, and CTA routing.
- Added Program behavior E2E scenarios:
  - apps/client/tests/e2e/programs.spec.ts
  - Given/When/Then checks for route /programmes, key offers, registration steps, and contact CTA link.
- Included existing mobile Program HTML updates explicitly in this scope:
  - apps/client/projects/mobile/src/app/features/programs/program-list.page.html
  - apps/client/projects/mobile/src/app/features/programs/program-detail.page.html
  - apps/client/projects/mobile/src/app/features/programs/session-detail.page.html

## Dependencies

- PRG-03: satisfied (mobile list/detail Program screens covered and present)
- PRG-04: satisfied (progression behaviors already covered in session-detail specs)
- QAT-01: satisfied (page/component/behavior test matrix alignment through unit + E2E scenarios)

## Validation Evidence

- pnpm --dir apps/client ng test web --watch=false --include=projects/web/src/app/features/programs/programs.page.spec.ts
- pnpm --dir apps/client ng test mobile --watch=false --include=projects/mobile/src/app/features/programs/program-list.page.spec.ts --include=projects/mobile/src/app/features/programs/program-detail.page.spec.ts --include=projects/mobile/src/app/features/programs/session-detail.page.spec.ts
- cd /c/Users/USER/kraak-group/apps/client && pnpm playwright test tests/e2e/programs.spec.ts

Closes #98
