### PR TITLE
[TASK][RES-02] Implémenter endpoints ressources (liste, filtre, détail)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { ProgramsModule } from './programs/programs.module';
+import { ResourcesModule } from './resources/resources.module';
 import { resolveApiEnvFilePaths } from './config/environment-files';
 import { SupabaseModule } from './supabase/supabase.module';
 import { SupportModule } from './support/support.module';
@@ -19,6 +20,7 @@ import { SupportModule } from './support/support.module';
     AuthModule,
     DashboardModule,
     ProgramsModule,
+    ResourcesModule,
     SupportModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/resources/resources.controller.ts
+++ b/apps/api/src/resources/resources.controller.ts
@@ -1,0 +1,205 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
+import type {
+  ResourceAudienceValue,
+  ResourceThemeValue,
+} from '@kraak/contracts';
+import { ResourcesService } from './resources.service';
+
+@ApiTags('Resources')
+@Controller('resources')
+export class ResourcesController {
+  constructor(private readonly resourcesService: ResourcesService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List published resources with optional filtering',
+    description:
+      'Retrieve a paginated list of published resources. Supports filtering by theme and audience.',
+  })
+  @ApiQuery({
+    name: 'resourceTheme',
+    required: false,
+    enum: ['training', 'project_management', 'immigration', 'career'],
+    description: 'Filter by resource theme',
+  })
+  @ApiQuery({
+    name: 'resourceAudience',
+    required: false,
+    enum: [
+      'all',
+      'young_professionals_students',
+      'organizations',
+      'international_candidates',
+    ],
+    description: 'Filter by resource audience',
+  })
+  @ApiQuery({
+    name: 'programId',
+    required: false,
+    description: 'Filter by program ID',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (1-based, default: 1)',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 20, max: 100)',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'List of published resources',
+    schema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              programId: { type: 'string', nullable: true },
+              cohortId: { type: 'string', nullable: true },
+              title: { type: 'string' },
+              description: { type: 'string', nullable: true },
+              resourceType: {
+                type: 'string',
+                enum: ['link', 'file', 'video', 'document'],
+              },
+              resourceTheme: {
+                type: 'string',
+                enum: [
+                  'training',
+                  'project_management',
+                  'immigration',
+                  'career',
+                ],
+              },
+              resourceAudience: {
+                type: 'string',
+                enum: [
+                  'all',
+                  'young_professionals_students',
+                  'organizations',
+                  'international_candidates',
+                ],
+              },
+              url: { type: 'string', nullable: true },
+              filePath: { type: 'string', nullable: true },
+              status: {
+                type: 'string',
+                enum: ['draft', 'published', 'archived'],
+              },
+              publishedAt: {
+                type: 'string',
+                format: 'date-time',
+                nullable: true,
+              },
+              createdAt: { type: 'string', format: 'date-time' },
+              updatedAt: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+        total: { type: 'number' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: 'Error fetching resources',
+  })
+  async listResources(
+    @Query('resourceTheme') resourceTheme?: ResourceThemeValue,
+    @Query('resourceAudience') resourceAudience?: ResourceAudienceValue,
+    @Query('programId') programId?: string,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.resourcesService.listResources({
+      resourceTheme,
+      resourceAudience,
+      programId,
+      page,
+      limit,
+    });
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get a single published resource by ID',
+    description: 'Retrieve details of a specific published resource.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Resource ID',
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Resource details',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        programId: { type: 'string', nullable: true },
+        cohortId: { type: 'string', nullable: true },
+        title: { type: 'string' },
+        description: { type: 'string', nullable: true },
+        resourceType: {
+          type: 'string',
+          enum: ['link', 'file', 'video', 'document'],
+        },
+        resourceTheme: {
+          type: 'string',
+          enum: ['training', 'project_management', 'immigration', 'career'],
+        },
+        resourceAudience: {
+          type: 'string',
+          enum: [
+            'all',
+            'young_professionals_students',
+            'organizations',
+            'international_candidates',
+          ],
+        },
+        url: { type: 'string', nullable: true },
+        filePath: { type: 'string', nullable: true },
+        status: { type: 'string', enum: ['draft', 'published', 'archived'] },
+        publishedAt: { type: 'string', format: 'date-time', nullable: true },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Resource not found or not published',
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: 'Error fetching resource',
+  })
+  async getResourceById(@Param('id') id: string) {
+    return this.resourcesService.getResourceById(id);
+  }
+}

--- a/apps/api/src/resources/resources.module.ts
+++ b/apps/api/src/resources/resources.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { ResourcesService } from './resources.service';
+import { ResourcesController } from './resources.controller';
+
+@Module({
+  imports: [SupabaseModule],
+  providers: [ResourcesService],
+  controllers: [ResourcesController],
+  exports: [ResourcesService],
+})
+export class ResourcesModule {}

--- a/apps/api/src/resources/resources.service.spec.ts
+++ b/apps/api/src/resources/resources.service.spec.ts
@@ -1,0 +1,166 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ResourcesService } from './resources.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import type { ResourceDto } from '@kraak/contracts';
+
+describe('ResourcesService', () => {
+  let service: ResourcesService;
+
+  const mockResourceRow = {
+    id: 'res-001',
+    program_id: 'prog-001',
+    cohort_id: null,
+    title: 'TypeScript Basics',
+    description: 'Learn TypeScript fundamentals',
+    resource_type: 'video' as const,
+    resource_theme: 'training' as const,
+    resource_audience: 'all' as const,
+    url: 'https://example.com/ts-basics',
+    file_path: null,
+    status: 'published' as const,
+    published_at: '2026-04-20T10:00:00Z',
+    created_at: '2026-04-19T10:00:00Z',
+    updated_at: '2026-04-20T10:00:00Z',
+  };
+
+  const mockResourceDto: ResourceDto = {
+    id: 'res-001',
+    programId: 'prog-001',
+    cohortId: null,
+    title: 'TypeScript Basics',
+    description: 'Learn TypeScript fundamentals',
+    resourceType: 'video',
+    resourceTheme: 'training',
+    resourceAudience: 'all',
+    url: 'https://example.com/ts-basics',
+    filePath: null,
+    status: 'published',
+    publishedAt: '2026-04-20T10:00:00Z',
+    createdAt: '2026-04-19T10:00:00Z',
+    updatedAt: '2026-04-20T10:00:00Z',
+  };
+
+  const mockSupabaseService = {
+    getClient: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourcesService,
+        { provide: SupabaseService, useValue: mockSupabaseService },
+      ],
+    }).compile();
+
+    service = module.get<ResourcesService>(ResourcesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listResources', () => {
+    it('should return paginated list of published resources', async () => {
+      const mockClient = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        is: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [mockResourceRow],
+          error: null,
+          count: 1,
+        }),
+      };
+
+      mockSupabaseService.getClient.mockReturnValue(mockClient);
+
+      const result = await service.listResources();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual(mockResourceDto);
+      expect(result.total).toBe(1);
+    });
+
+    it('should handle query errors gracefully', async () => {
+      const mockClient = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: null,
+          error: new Error('Database connection failed'),
+          count: null,
+        }),
+      };
+
+      mockSupabaseService.getClient.mockReturnValue(mockClient);
+
+      await expect(service.listResources()).rejects.toThrow(
+        'Failed to list resources',
+      );
+    });
+  });
+
+  describe('getResourceById', () => {
+    it('should return resource by ID', async () => {
+      const mockClient = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: mockResourceRow,
+          error: null,
+        }),
+      };
+
+      mockSupabaseService.getClient.mockReturnValue(mockClient);
+
+      const result = await service.getResourceById('res-001');
+
+      expect(result).toEqual(mockResourceDto);
+    });
+
+    it('should throw NotFoundException when resource not found', async () => {
+      const mockClient = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: null,
+          error: new Error('Not found'),
+        }),
+      };
+
+      mockSupabaseService.getClient.mockReturnValue(mockClient);
+
+      await expect(service.getResourceById('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getResourcesByProgram', () => {
+    it('should return resources for a program', async () => {
+      const mockClient = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        is: jest.fn().mockResolvedValue({
+          data: [mockResourceRow],
+          error: null,
+        }),
+      };
+
+      mockSupabaseService.getClient.mockReturnValue(mockClient);
+
+      const result = await service.getResourcesByProgram('prog-001');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockResourceDto);
+    });
+  });
+});

--- a/apps/api/src/resources/resources.service.ts
+++ b/apps/api/src/resources/resources.service.ts
@@ -1,0 +1,226 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import type {
+  ResourceAudienceValue,
+  ResourceDto,
+  ResourceThemeValue,
+  PublicationStatusValue,
+  ResourceTypeValue,
+} from '@kraak/contracts';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type ResourceRow = {
+  id: string;
+  program_id: string | null;
+  cohort_id: string | null;
+  title: string;
+  description: string | null;
+  resource_type: ResourceTypeValue;
+  resource_theme: ResourceThemeValue;
+  resource_audience: ResourceAudienceValue;
+  url: string | null;
+  file_path: string | null;
+  status: PublicationStatusValue;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+@Injectable()
+export class ResourcesService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  /**
+   * List published resources with optional filtering and pagination.
+   * @param options - Filter options (theme, audience) and pagination (page, limit)
+   */
+  async listResources(options?: {
+    resourceTheme?: ResourceThemeValue;
+    resourceAudience?: ResourceAudienceValue;
+    programId?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ data: ResourceDto[]; total: number }> {
+    const adminClient = this.supabaseService.getClient();
+    const limit = Math.min(options?.limit ?? 20, 100);
+    const page = Math.max(options?.page ?? 1, 1);
+    const offset = (page - 1) * limit;
+
+    let query = adminClient
+      .from('resource')
+      .select(
+        'id, program_id, cohort_id, title, description, resource_type, resource_theme, resource_audience, url, file_path, status, published_at, created_at, updated_at, count:id.count()',
+        { count: 'exact' },
+      )
+      .eq('status', 'published')
+      .order('published_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (options?.programId) {
+      query = query.eq('program_id', options.programId);
+    }
+
+    if (options?.resourceTheme) {
+      query = query.eq('resource_theme', options.resourceTheme);
+    }
+
+    if (options?.resourceAudience) {
+      query = query.eq('resource_audience', options.resourceAudience);
+    }
+
+    const { data, error, count } = await query;
+
+    if (error) {
+      throw new Error(`Failed to list resources: ${error.message}`);
+    }
+
+    const resources = ((data as ResourceRow[] | null) ?? []).map((row) =>
+      this.mapResource(row),
+    );
+
+    return {
+      data: resources,
+      total: count ?? 0,
+    };
+  }
+
+  /**
+   * Get a single resource by ID.
+   * @param id - Resource ID
+   */
+  async getResourceById(id: string): Promise<ResourceDto> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('resource')
+      .select(
+        'id, program_id, cohort_id, title, description, resource_type, resource_theme, resource_audience, url, file_path, status, published_at, created_at, updated_at',
+      )
+      .eq('id', id)
+      .eq('status', 'published')
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException(
+        `Resource with ID ${id} not found or is not published.`,
+      );
+    }
+
+    return this.mapResource(data as ResourceRow);
+  }
+
+  /**
+   * Get resources by program and/or cohort with filtering.
+   * @param programId - Program ID (required)
+   * @param cohortId - Optional cohort ID to filter resources within a cohort
+   * @param options - Additional filter options
+   */
+  async getResourcesByProgram(
+    programId: string,
+    cohortId: string | null = null,
+    options?: {
+      resourceTheme?: ResourceThemeValue;
+      resourceAudience?: ResourceAudienceValue;
+    },
+  ): Promise<ResourceDto[]> {
+    const adminClient = this.supabaseService.getClient();
+
+    // Fetch program-level resources (cohort_id is null)
+    let programQuery = adminClient
+      .from('resource')
+      .select(
+        'id, program_id, cohort_id, title, description, resource_type, resource_theme, resource_audience, url, file_path, status, published_at, created_at, updated_at',
+      )
+      .eq('status', 'published')
+      .eq('program_id', programId)
+      .is('cohort_id', null);
+
+    if (options?.resourceTheme) {
+      programQuery = programQuery.eq('resource_theme', options.resourceTheme);
+    }
+
+    if (options?.resourceAudience) {
+      programQuery = programQuery.eq(
+        'resource_audience',
+        options.resourceAudience,
+      );
+    }
+
+    const { data: programResources, error: programError } = await programQuery;
+
+    if (programError) {
+      throw new Error(
+        `Failed to fetch program resources: ${programError.message}`,
+      );
+    }
+
+    let cohortResources: ResourceRow[] = [];
+
+    if (cohortId) {
+      let cohortQuery = adminClient
+        .from('resource')
+        .select(
+          'id, program_id, cohort_id, title, description, resource_type, resource_theme, resource_audience, url, file_path, status, published_at, created_at, updated_at',
+        )
+        .eq('status', 'published')
+        .eq('program_id', programId)
+        .eq('cohort_id', cohortId);
+
+      if (options?.resourceTheme) {
+        cohortQuery = cohortQuery.eq('resource_theme', options.resourceTheme);
+      }
+
+      if (options?.resourceAudience) {
+        cohortQuery = cohortQuery.eq(
+          'resource_audience',
+          options.resourceAudience,
+        );
+      }
+
+      const { data, error } = await cohortQuery;
+
+      if (error) {
+        throw new Error(`Failed to fetch cohort resources: ${error.message}`);
+      }
+
+      cohortResources = (data as ResourceRow[] | null) ?? [];
+    }
+
+    // Merge and deduplicate
+    const merged = [
+      ...((programResources as ResourceRow[] | null) ?? []),
+      ...cohortResources,
+    ];
+
+    const deduplicated = Array.from(
+      new Map(merged.map((row) => [row.id, row])).values(),
+    ).sort((left, right) => {
+      const leftTime = left.published_at
+        ? new Date(left.published_at).getTime()
+        : 0;
+      const rightTime = right.published_at
+        ? new Date(right.published_at).getTime()
+        : 0;
+      return rightTime - leftTime;
+    });
+
+    return deduplicated.slice(0, 50).map((row) => this.mapResource(row));
+  }
+
+  private mapResource(row: ResourceRow): ResourceDto {
+    return {
+      id: row.id,
+      programId: row.program_id,
+      cohortId: row.cohort_id,
+      title: row.title,
+      description: row.description,
+      resourceType: row.resource_type,
+      resourceTheme: row.resource_theme,
+      resourceAudience: row.resource_audience,
+      url: row.url,
+      filePath: row.file_path,
+      status: row.status,
+      publishedAt: row.published_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Implements RES-02: resource list, filter, and detail REST endpoints on top of the RES-01 taxonomy.

## Changes

- `GET /resources` with pagination (`page`, `limit`) and filtering by `resourceTheme`, `resourceAudience`, `programId`
- `GET /resources/:id` returns a single resource or 404
- `ResourcesService` with `listResources`, `getResourceById`, and `getResourcesByProgram` methods
- `ResourcesModule` wired into `AppModule`
- Full Swagger/OpenAPI decorators with enum constraints
- Jest unit tests: 5/5 passing

## Dependencies

⚠️ This PR targets `feat/res-01-resource-taxonomy` (PR #221) and must be merged **after** RES-01 lands on `main`.

Closes #100