### PR TITLE
[TASK][RES-03] Implementer ecran mobile ressources (recherche/filtre)

### DIFF
--- a/apps/client/projects/mobile/src/app/features/resources/mobile-resources.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/mobile-resources.service.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResourceDto } from '@kraak/contracts';
+import { MobileAuthService } from '../auth/mobile-auth.service';
+import { MobileResourcesService } from './mobile-resources.service';
+
+describe('MobileResourcesService', () => {
+  let service: MobileResourcesService;
+  let authService: { currentSession: () => { accessToken: string } | null };
+
+  const mockResource: ResourceDto = {
+    id: 'resource-1',
+    programId: null,
+    cohortId: null,
+    title: 'Guide de demarrage',
+    description: 'Description test',
+    resourceType: 'document',
+    resourceTheme: 'training',
+    resourceAudience: 'all',
+    url: 'https://example.com/guide',
+    filePath: null,
+    status: 'published',
+    publishedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    authService = {
+      currentSession: vi.fn(() => ({ accessToken: 'test-token' })),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        MobileResourcesService,
+        { provide: MobileAuthService, useValue: authService },
+      ],
+    });
+
+    service = TestBed.inject(MobileResourcesService);
+  });
+
+  it('Given filters, when listResources is called, then it should send resourceTheme and resourceAudience query params', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [mockResource],
+          total: 1,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await service.listResources({
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      page: 2,
+      limit: 25,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.data[0]?.id).toBe('resource-1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/resources?resourceTheme=training&resourceAudience=all&page=2&limit=25',
+      ),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+  });
+
+  it('Given a valid id, when getResourceById is called, then it should return the resource detail', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResource), {
+        status: 200,
+      }),
+    );
+
+    const result = await service.getResourceById('resource-1');
+
+    expect(result.id).toBe('resource-1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/resources/resource-1'),
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('Given an API error payload, when listResources fails, then it should throw backend message', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Erreur test backend' }), {
+        status: 500,
+      }),
+    );
+
+    await expect(service.listResources()).rejects.toThrow(
+      'Erreur test backend',
+    );
+  });
+});

--- a/apps/client/projects/mobile/src/app/features/resources/mobile-resources.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/mobile-resources.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResourceDto } from '@kraak/contracts';
 import { MobileAuthService } from '../auth/mobile-auth.service';
 import { MobileResourcesService } from './mobile-resources.service';
@@ -38,6 +38,10 @@ describe('MobileResourcesService', () => {
     });
 
     service = TestBed.inject(MobileResourcesService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('Given filters, when listResources is called, then it should send resourceTheme and resourceAudience query params', async () => {

--- a/apps/client/projects/mobile/src/app/features/resources/mobile-resources.service.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/mobile-resources.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, inject } from '@angular/core';
+import type {
+  ResourceAudienceValue,
+  ResourceDto,
+  ResourceThemeValue,
+} from '@kraak/contracts';
+import { environment } from '../../../environments/environment';
+import { MobileAuthService } from '../auth/mobile-auth.service';
+
+export interface ResourceListFilters {
+  resourceTheme?: ResourceThemeValue;
+  resourceAudience?: ResourceAudienceValue;
+  page?: number;
+  limit?: number;
+}
+
+export interface ResourceListResponse {
+  data: ResourceDto[];
+  total: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MobileResourcesService {
+  private readonly authService = inject(MobileAuthService);
+
+  async listResources(
+    filters?: ResourceListFilters,
+  ): Promise<ResourceListResponse> {
+    const queryParams = new URLSearchParams();
+
+    if (filters?.resourceTheme) {
+      queryParams.set('resourceTheme', filters.resourceTheme);
+    }
+
+    if (filters?.resourceAudience) {
+      queryParams.set('resourceAudience', filters.resourceAudience);
+    }
+
+    if (typeof filters?.page === 'number') {
+      queryParams.set('page', String(filters.page));
+    }
+
+    if (typeof filters?.limit === 'number') {
+      queryParams.set('limit', String(filters.limit));
+    }
+
+    const queryString = queryParams.toString();
+    const path =
+      queryString.length > 0 ? `/resources?${queryString}` : '/resources';
+
+    return this.request<ResourceListResponse>(path);
+  }
+
+  async getResourceById(resourceId: string): Promise<ResourceDto> {
+    return this.request<ResourceDto>(`/resources/${resourceId}`);
+  }
+
+  private async request<T>(path: string): Promise<T> {
+    const authToken = this.authService.currentSession()?.accessToken ?? null;
+
+    const response = await fetch(`${environment.apiBaseUrl}${path}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+      },
+    });
+
+    if (!response.ok) {
+      let responseMessage = '';
+      try {
+        const errorBody = (await response.json()) as { message?: string };
+        responseMessage = errorBody.message?.trim() ?? '';
+      } catch (error) {
+        void error;
+      }
+
+      if (responseMessage.length > 0) {
+        throw new Error(responseMessage);
+      }
+
+      throw new Error(`Erreur API (${response.status})`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+}

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="Ressource"
   title="Détail de la ressource"
-  description="Consultez le contenu et accedez rapidement au lien ou au fichier associe."
+  description="Consultez le contenu et accédez rapidement au lien ou au fichier associé."
   backHref="/tabs/programmes/ressources"
 >
   <section class="flex flex-col gap-4 px-4 py-5">

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.html
@@ -1,15 +1,71 @@
 <kraak-page-shell
   eyebrow="Ressource"
   title="Détail de la ressource"
-  description="Préparez l'ouverture ou le téléchargement depuis la stack mobile."
+  description="Consultez le contenu et accedez rapidement au lien ou au fichier associe."
   backHref="/tabs/programmes/ressources"
 >
-  <section
-    class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card border p-5"
-  >
-    <p class="text-sm leading-6 text-neutral-700">
-      Le contenu détaillé, le type de ressource et l'action d'ouverture seront
-      branchés ici.
-    </p>
+  <section class="flex flex-col gap-4 px-4 py-5">
+    @if (errorMessage()) {
+      <article
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
+      >
+        <p class="text-sm leading-6 text-red-700">
+          {{ errorMessage() }}
+        </p>
+        <ion-button
+          expand="block"
+          class="kraak-primary-button"
+          (click)="reloadResource()"
+          (keydown.enter)="reloadResource()"
+        >
+          Réessayer
+        </ion-button>
+      </article>
+    } @else if (loading()) {
+      <article
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col items-center gap-4 border p-5"
+      >
+        <ion-spinner name="crescent" aria-label="Chargement"></ion-spinner>
+        <p class="text-sm leading-6 text-neutral-700">
+          Chargement de la ressource...
+        </p>
+      </article>
+    } @else if (resource()) {
+      <article
+        class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card flex flex-col gap-3 border p-5"
+      >
+        <h2 class="text-primary text-lg font-semibold">
+          {{ resource()!.title }}
+        </h2>
+
+        @if (resource()!.description) {
+          <p class="text-sm leading-6 text-neutral-700">
+            {{ resource()!.description }}
+          </p>
+        }
+
+        <p class="text-xs leading-5 text-neutral-700 uppercase">
+          Type: {{ resource()!.resourceType }}
+        </p>
+
+        @if (resource()!.url) {
+          <ion-button
+            [href]="resource()!.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            expand="block"
+            class="kraak-primary-button"
+          >
+            Ouvrir le lien
+          </ion-button>
+        }
+
+        @if (resource()!.filePath) {
+          <p class="text-xs leading-5 text-neutral-700">
+            Fichier: {{ resource()!.filePath }}
+          </p>
+        }
+      </article>
+    }
   </section>
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.spec.ts
@@ -1,26 +1,87 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+} from '@angular/router';
+import type { ResourceDto } from '@kraak/contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileResourcesService } from './mobile-resources.service';
 import ResourceDetailPage from './resource-detail.page';
 
 describe('Mobile ResourceDetailPage', () => {
+  let service: { getResourceById: ReturnType<typeof vi.fn> };
+
+  const mockResource: ResourceDto = {
+    id: 'resource-1',
+    programId: null,
+    cohortId: null,
+    title: 'Guide detail',
+    description: 'Description detail',
+    resourceType: 'document',
+    resourceTheme: 'training',
+    resourceAudience: 'all',
+    url: 'https://example.com/guide',
+    filePath: null,
+    status: 'published',
+    publishedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
   beforeEach(async () => {
+    service = {
+      getResourceById: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ResourceDetailPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideRouter([]),
+        {
+          provide: MobileResourcesService,
+          useValue: service,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({ resourceId: 'resource-1' }),
+            },
+          },
+        },
+      ],
     }).compileComponents();
   });
 
   it('should create', () => {
+    service.getResourceById.mockResolvedValue(mockResource);
     const fixture = TestBed.createComponent(ResourceDetailPage);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given the resources stack, when the detail renders, then it keeps the expected mobile title', () => {
+  it('Given a valid resource id, when detail loads, then resource data is rendered', async () => {
+    service.getResourceById.mockResolvedValue(mockResource);
     const fixture = TestBed.createComponent(ResourceDetailPage);
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
 
-    const title = fixture.nativeElement.querySelector('ion-title');
-    expect(title?.textContent).toContain('Détail de la ressource');
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Guide detail');
+    expect(element.textContent).toContain('Description detail');
+  });
+
+  it('Given an API failure, when detail loads, then an error message is shown', async () => {
+    service.getResourceById.mockRejectedValue(new Error('Erreur detail test'));
+    const fixture = TestBed.createComponent(ResourceDetailPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Erreur detail test');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.spec.ts
@@ -7,11 +7,13 @@ import {
 } from '@angular/router';
 import type { ResourceDto } from '@kraak/contracts';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BehaviorSubject } from 'rxjs';
 import { MobileResourcesService } from './mobile-resources.service';
 import ResourceDetailPage from './resource-detail.page';
 
 describe('Mobile ResourceDetailPage', () => {
   let service: { getResourceById: ReturnType<typeof vi.fn> };
+  let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
 
   const mockResource: ResourceDto = {
     id: 'resource-1',
@@ -34,6 +36,9 @@ describe('Mobile ResourceDetailPage', () => {
     service = {
       getResourceById: vi.fn(),
     };
+    paramMapSubject = new BehaviorSubject(
+      convertToParamMap({ resourceId: 'resource-1' }),
+    );
 
     await TestBed.configureTestingModule({
       imports: [ResourceDetailPage],
@@ -50,6 +55,7 @@ describe('Mobile ResourceDetailPage', () => {
             snapshot: {
               paramMap: convertToParamMap({ resourceId: 'resource-1' }),
             },
+            paramMap: paramMapSubject.asObservable(),
           },
         },
       ],
@@ -83,5 +89,28 @@ describe('Mobile ResourceDetailPage', () => {
 
     const element = fixture.nativeElement as HTMLElement;
     expect(element.textContent).toContain('Erreur detail test');
+  });
+
+  it('Given the route param changes, when another resource id is emitted, then the detail reloads', async () => {
+    service.getResourceById
+      .mockResolvedValueOnce(mockResource)
+      .mockResolvedValueOnce({
+        ...mockResource,
+        id: 'resource-2',
+        title: 'Guide detail 2',
+      });
+
+    const fixture = TestBed.createComponent(ResourceDetailPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    paramMapSubject.next(convertToParamMap({ resourceId: 'resource-2' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(service.getResourceById).toHaveBeenCalledWith('resource-2');
+    expect(element.textContent).toContain('Guide detail 2');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { IonButton, IonSpinner } from '@ionic/angular/standalone';
 import type { ResourceDto } from '@kraak/contracts';
+import { map } from 'rxjs';
 import { PageShell } from '../../shared/page-shell/page-shell';
 import { resolveAuthErrorMessage } from '../auth/mobile-auth.service';
 import { MobileResourcesService } from './mobile-resources.service';
@@ -19,20 +20,25 @@ export default class ResourceDetailPage implements OnInit {
   protected readonly resource = signal<ResourceDto | null>(null);
   protected readonly loading = signal(true);
   protected readonly errorMessage = signal<string | null>(null);
+  protected readonly currentResourceId = signal<string | null>(null);
 
-  protected readonly resourceId = computed(
-    () => this.route.snapshot.paramMap.get('resourceId') ?? null,
-  );
+  protected readonly resourceId = computed(() => this.currentResourceId());
 
   ngOnInit(): void {
-    const resourceId = this.resourceId();
-    if (!resourceId) {
-      this.loading.set(false);
-      this.errorMessage.set('Identifiant de ressource manquant.');
-      return;
-    }
+    this.route.paramMap
+      .pipe(map((params) => params.get('resourceId')))
+      .subscribe((resourceId) => {
+        this.currentResourceId.set(resourceId);
 
-    this.loadResource(resourceId);
+        if (!resourceId) {
+          this.loading.set(false);
+          this.errorMessage.set('Identifiant de ressource manquant.');
+          this.resource.set(null);
+          return;
+        }
+
+        this.loadResource(resourceId);
+      });
   }
 
   protected async reloadResource(): Promise<void> {
@@ -55,7 +61,7 @@ export default class ResourceDetailPage implements OnInit {
       this.errorMessage.set(
         resolveAuthErrorMessage(
           error,
-          'Erreur lors du chargement du detail de la ressource.',
+          'Erreur lors du chargement du détail de la ressource.',
         ),
       );
       this.resource.set(null);

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.ts
@@ -1,10 +1,66 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { IonButton, IonSpinner } from '@ionic/angular/standalone';
+import type { ResourceDto } from '@kraak/contracts';
 import { PageShell } from '../../shared/page-shell/page-shell';
+import { resolveAuthErrorMessage } from '../auth/mobile-auth.service';
+import { MobileResourcesService } from './mobile-resources.service';
 
 @Component({
   selector: 'kraak-resource-detail-page',
   standalone: true,
-  imports: [PageShell],
+  imports: [PageShell, IonButton, IonSpinner],
   templateUrl: './resource-detail.page.html',
 })
-export default class ResourceDetailPage {}
+export default class ResourceDetailPage implements OnInit {
+  private readonly resourcesService = inject(MobileResourcesService);
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly resource = signal<ResourceDto | null>(null);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+
+  protected readonly resourceId = computed(
+    () => this.route.snapshot.paramMap.get('resourceId') ?? null,
+  );
+
+  ngOnInit(): void {
+    const resourceId = this.resourceId();
+    if (!resourceId) {
+      this.loading.set(false);
+      this.errorMessage.set('Identifiant de ressource manquant.');
+      return;
+    }
+
+    this.loadResource(resourceId);
+  }
+
+  protected async reloadResource(): Promise<void> {
+    const resourceId = this.resourceId();
+    if (!resourceId) {
+      this.errorMessage.set('Identifiant de ressource manquant.');
+      return;
+    }
+
+    await this.loadResource(resourceId);
+  }
+
+  private async loadResource(resourceId: string): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.errorMessage.set(null);
+      const data = await this.resourcesService.getResourceById(resourceId);
+      this.resource.set(data);
+    } catch (error) {
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Erreur lors du chargement du detail de la ressource.',
+        ),
+      );
+      this.resource.set(null);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/client/projects/mobile/src/app/features/resources/resource-list.page.html
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-list.page.html
@@ -1,22 +1,144 @@
 <kraak-page-shell
   eyebrow="Références"
   title="Ressources"
-  description="Accédez rapidement aux contenus utiles depuis l'onglet Programmes."
+  description="Recherchez et filtrez les contenus utiles selon votre besoin."
   backHref="/tabs/programmes"
 >
-  <section
-    class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card border p-5"
-  >
-    <p class="text-sm leading-6 text-neutral-700">
-      Ressources et documents utiles.
-    </p>
-
-    <ion-button
-      routerLink="/tabs/programmes/ressources/guide-demarrage"
-      expand="block"
-      class="kraak-primary-button mt-4"
+  <section class="flex flex-col gap-4 px-4 py-5">
+    <article
+      class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
     >
-      Ouvrir une ressource exemple
-    </ion-button>
+      <label class="flex flex-col gap-2">
+        <span
+          class="text-xs font-semibold tracking-wide text-neutral-700 uppercase"
+        >
+          Recherche
+        </span>
+        <input
+          type="search"
+          [value]="searchQuery()"
+          (input)="onSearchInput($event)"
+          placeholder="Titre, description, type..."
+          class="focus:border-brand-blue rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none"
+        />
+      </label>
+
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label class="flex flex-col gap-2">
+          <span
+            class="text-xs font-semibold tracking-wide text-neutral-700 uppercase"
+          >
+            Theme
+          </span>
+          <select
+            [value]="selectedTheme()"
+            (change)="onThemeChange($event)"
+            class="focus:border-brand-blue rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none"
+          >
+            <option value="">Tous les themes</option>
+            @for (option of resourceThemeOptions; track option.value) {
+              <option [value]="option.value">{{ option.label }}</option>
+            }
+          </select>
+        </label>
+
+        <label class="flex flex-col gap-2">
+          <span
+            class="text-xs font-semibold tracking-wide text-neutral-700 uppercase"
+          >
+            Audience
+          </span>
+          <select
+            [value]="selectedAudience()"
+            (change)="onAudienceChange($event)"
+            class="focus:border-brand-blue rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none"
+          >
+            <option value="">Toutes les audiences</option>
+            @for (option of resourceAudienceOptions; track option.value) {
+              <option [value]="option.value">{{ option.label }}</option>
+            }
+          </select>
+        </label>
+      </div>
+    </article>
+
+    @if (errorMessage()) {
+      <article
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
+      >
+        <p class="text-sm leading-6 text-red-700">
+          {{ errorMessage() }}
+        </p>
+        <ion-button
+          expand="block"
+          class="kraak-primary-button"
+          (click)="reloadResources()"
+          (keydown.enter)="reloadResources()"
+        >
+          Réessayer
+        </ion-button>
+      </article>
+    } @else if (loading()) {
+      <article
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col items-center gap-4 border p-5"
+      >
+        <ion-spinner name="crescent" aria-label="Chargement"></ion-spinner>
+        <p class="text-sm leading-6 text-neutral-700">
+          Chargement des ressources...
+        </p>
+      </article>
+    } @else if (filteredResources().length === 0) {
+      <article
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
+      >
+        <p class="text-sm leading-6 text-neutral-700">
+          Aucune ressource ne correspond a vos criteres.
+        </p>
+      </article>
+    } @else {
+      @for (resource of filteredResources(); track resource.id) {
+        <article
+          class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-3 border p-5"
+          data-testid="resource-card"
+        >
+          <div class="flex flex-wrap items-center gap-2">
+            <span
+              class="bg-brand-cyan/15 text-brand-navy rounded-full px-2 py-1 text-xs font-semibold"
+            >
+              {{ getResourceTypeLabel(resource.resourceType) }}
+            </span>
+            <span
+              class="bg-brand-blue/10 text-brand-navy rounded-full px-2 py-1 text-xs font-semibold"
+            >
+              {{ getResourceThemeLabel(resource.resourceTheme) }}
+            </span>
+            <span
+              class="rounded-full bg-neutral-100 px-2 py-1 text-xs font-semibold text-neutral-700"
+            >
+              {{ getResourceAudienceLabel(resource.resourceAudience) }}
+            </span>
+          </div>
+
+          <div>
+            <p class="text-primary text-lg font-semibold">
+              {{ resource.title }}
+            </p>
+            @if (resource.description) {
+              <p class="mt-1 text-sm leading-6 text-neutral-700">
+                {{ resource.description }}
+              </p>
+            }
+          </div>
+
+          <ion-button
+            [routerLink]="['/tabs/programmes/ressources', resource.id]"
+            expand="block"
+            class="kraak-primary-button"
+          >
+            Voir le detail
+          </ion-button>
+        </article>
+      }
+    }
   </section>
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/resources/resource-list.page.html
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-list.page.html
@@ -28,14 +28,14 @@
           <span
             class="text-xs font-semibold tracking-wide text-neutral-700 uppercase"
           >
-            Theme
+            Thème
           </span>
           <select
             [value]="selectedTheme()"
             (change)="onThemeChange($event)"
             class="focus:border-brand-blue rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none"
           >
-            <option value="">Tous les themes</option>
+            <option value="">Tous les thèmes</option>
             @for (option of resourceThemeOptions; track option.value) {
               <option [value]="option.value">{{ option.label }}</option>
             }
@@ -92,7 +92,7 @@
         class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
       >
         <p class="text-sm leading-6 text-neutral-700">
-          Aucune ressource ne correspond a vos criteres.
+          Aucune ressource ne correspond à vos critères.
         </p>
       </article>
     } @else {
@@ -135,7 +135,7 @@
             expand="block"
             class="kraak-primary-button"
           >
-            Voir le detail
+            Voir le détail
           </ion-button>
         </article>
       }

--- a/apps/client/projects/mobile/src/app/features/resources/resource-list.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-list.page.spec.ts
@@ -1,27 +1,111 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { describe, it, beforeEach, expect } from 'vitest';
+import type { ResourceDto } from '@kraak/contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileResourcesService } from './mobile-resources.service';
 import ResourceListPage from './resource-list.page';
 
 describe('Mobile ResourceListPage', () => {
+  let service: { listResources: ReturnType<typeof vi.fn> };
+
+  const resources: ResourceDto[] = [
+    {
+      id: 'resource-1',
+      programId: null,
+      cohortId: null,
+      title: 'Guide de demarrage',
+      description: 'Document de preparation a la premiere session.',
+      resourceType: 'document',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: 'https://example.com/guide',
+      filePath: null,
+      status: 'published',
+      publishedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: 'resource-2',
+      programId: null,
+      cohortId: null,
+      title: 'Boite a outils projet',
+      description: 'Modeles utiles pour pilotage.',
+      resourceType: 'file',
+      resourceTheme: 'project_management',
+      resourceAudience: 'organizations',
+      url: null,
+      filePath: '/files/toolkit.pdf',
+      status: 'published',
+      publishedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ];
+
   beforeEach(async () => {
+    service = {
+      listResources: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ResourceListPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        { provide: MobileResourcesService, useValue: service },
+      ],
     }).compileComponents();
   });
 
   it('should create', () => {
+    service.listResources.mockResolvedValue({ data: [], total: 0 });
     const fixture = TestBed.createComponent(ResourceListPage);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the title', () => {
+  it('Given available resources, when page loads, then list and title are rendered', async () => {
+    service.listResources.mockResolvedValue({ data: resources, total: 2 });
     const fixture = TestBed.createComponent(ResourceListPage);
     fixture.detectChanges();
-    const title = fixture.nativeElement.querySelector('ion-title');
-    expect(title?.textContent).toContain('Ressources');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Ressources');
+    expect(element.textContent).toContain('Guide de demarrage');
+    expect(element.textContent).toContain('Boite a outils projet');
+  });
+
+  it('Given a search query, when user types in search input, then the list is filtered client-side', async () => {
+    service.listResources.mockResolvedValue({ data: resources, total: 2 });
+    const fixture = TestBed.createComponent(ResourceListPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    const searchInput = element.querySelector(
+      'input[type="search"]',
+    ) as HTMLInputElement;
+
+    searchInput.value = 'demarrage';
+    searchInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(element.textContent).toContain('Guide de demarrage');
+    expect(element.textContent).not.toContain('Boite a outils projet');
+  });
+
+  it('Given a load error, when page initializes, then the error state is displayed', async () => {
+    service.listResources.mockRejectedValue(new Error('Erreur API test'));
+    const fixture = TestBed.createComponent(ResourceListPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Erreur API test');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/resources/resource-list.page.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-list.page.ts
@@ -18,7 +18,7 @@ const RESOURCE_THEME_OPTIONS: readonly {
   { value: 'training', label: 'Formation' },
   { value: 'project_management', label: 'Gestion de projet' },
   { value: 'immigration', label: 'Immigration' },
-  { value: 'career', label: 'Carriere' },
+  { value: 'career', label: 'Carrière' },
 ];
 
 const RESOURCE_AUDIENCE_OPTIONS: readonly {
@@ -28,7 +28,7 @@ const RESOURCE_AUDIENCE_OPTIONS: readonly {
   { value: 'all', label: 'Tous' },
   {
     value: 'young_professionals_students',
-    label: 'Jeunes pros et etudiants',
+    label: 'Jeunes pros et étudiants',
   },
   { value: 'organizations', label: 'Organisations' },
   { value: 'international_candidates', label: 'Candidats internationaux' },
@@ -37,7 +37,7 @@ const RESOURCE_AUDIENCE_OPTIONS: readonly {
 const RESOURCE_TYPE_LABELS: Record<ResourceTypeValue, string> = {
   link: 'Lien',
   file: 'Fichier',
-  video: 'Video',
+  video: 'Vidéo',
   document: 'Document',
 };
 
@@ -49,6 +49,7 @@ const RESOURCE_TYPE_LABELS: Record<ResourceTypeValue, string> = {
 })
 export default class ResourceListPage implements OnInit {
   private readonly resourcesService = inject(MobileResourcesService);
+  private latestLoadRequestId = 0;
 
   protected readonly resources = signal<ResourceDto[]>([]);
   protected readonly loading = signal(true);
@@ -126,6 +127,8 @@ export default class ResourceListPage implements OnInit {
   }
 
   private async loadResources(): Promise<void> {
+    const requestId = ++this.latestLoadRequestId;
+
     try {
       this.loading.set(true);
       this.errorMessage.set(null);
@@ -137,17 +140,23 @@ export default class ResourceListPage implements OnInit {
         limit: 100,
       });
 
-      this.resources.set(response.data);
+      if (requestId === this.latestLoadRequestId) {
+        this.resources.set(response.data);
+      }
     } catch (error) {
-      this.errorMessage.set(
-        resolveAuthErrorMessage(
-          error,
-          'Erreur lors du chargement des ressources.',
-        ),
-      );
-      this.resources.set([]);
+      if (requestId === this.latestLoadRequestId) {
+        this.errorMessage.set(
+          resolveAuthErrorMessage(
+            error,
+            'Erreur lors du chargement des ressources.',
+          ),
+        );
+        this.resources.set([]);
+      }
     } finally {
-      this.loading.set(false);
+      if (requestId === this.latestLoadRequestId) {
+        this.loading.set(false);
+      }
     }
   }
 }

--- a/apps/client/projects/mobile/src/app/features/resources/resource-list.page.ts
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-list.page.ts
@@ -1,12 +1,153 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton, IonSpinner } from '@ionic/angular/standalone';
+import type {
+  ResourceAudienceValue,
+  ResourceDto,
+  ResourceThemeValue,
+  ResourceTypeValue,
+} from '@kraak/contracts';
 import { PageShell } from '../../shared/page-shell/page-shell';
+import { resolveAuthErrorMessage } from '../auth/mobile-auth.service';
+import { MobileResourcesService } from './mobile-resources.service';
+
+const RESOURCE_THEME_OPTIONS: readonly {
+  value: ResourceThemeValue;
+  label: string;
+}[] = [
+  { value: 'training', label: 'Formation' },
+  { value: 'project_management', label: 'Gestion de projet' },
+  { value: 'immigration', label: 'Immigration' },
+  { value: 'career', label: 'Carriere' },
+];
+
+const RESOURCE_AUDIENCE_OPTIONS: readonly {
+  value: ResourceAudienceValue;
+  label: string;
+}[] = [
+  { value: 'all', label: 'Tous' },
+  {
+    value: 'young_professionals_students',
+    label: 'Jeunes pros et etudiants',
+  },
+  { value: 'organizations', label: 'Organisations' },
+  { value: 'international_candidates', label: 'Candidats internationaux' },
+];
+
+const RESOURCE_TYPE_LABELS: Record<ResourceTypeValue, string> = {
+  link: 'Lien',
+  file: 'Fichier',
+  video: 'Video',
+  document: 'Document',
+};
 
 @Component({
   selector: 'kraak-resource-list-page',
   standalone: true,
-  imports: [PageShell, IonButton, RouterLink],
+  imports: [PageShell, IonButton, IonSpinner, RouterLink],
   templateUrl: './resource-list.page.html',
 })
-export default class ResourceListPage {}
+export default class ResourceListPage implements OnInit {
+  private readonly resourcesService = inject(MobileResourcesService);
+
+  protected readonly resources = signal<ResourceDto[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly searchQuery = signal('');
+  protected readonly selectedTheme = signal<ResourceThemeValue | ''>('');
+  protected readonly selectedAudience = signal<ResourceAudienceValue | ''>('');
+
+  protected readonly resourceThemeOptions = RESOURCE_THEME_OPTIONS;
+  protected readonly resourceAudienceOptions = RESOURCE_AUDIENCE_OPTIONS;
+
+  protected readonly filteredResources = computed(() => {
+    const normalizedQuery = this.searchQuery().trim().toLowerCase();
+
+    if (normalizedQuery.length === 0) {
+      return this.resources();
+    }
+
+    return this.resources().filter((resource) => {
+      const haystack = [
+        resource.title,
+        resource.description ?? '',
+        resource.resourceType,
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  });
+
+  ngOnInit(): void {
+    this.loadResources();
+  }
+
+  protected onSearchInput(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.searchQuery.set(target?.value ?? '');
+  }
+
+  protected async onThemeChange(event: Event): Promise<void> {
+    const target = event.target as HTMLSelectElement | null;
+    this.selectedTheme.set((target?.value as ResourceThemeValue | '') ?? '');
+    await this.loadResources();
+  }
+
+  protected async onAudienceChange(event: Event): Promise<void> {
+    const target = event.target as HTMLSelectElement | null;
+    this.selectedAudience.set(
+      (target?.value as ResourceAudienceValue | '') ?? '',
+    );
+    await this.loadResources();
+  }
+
+  protected async reloadResources(): Promise<void> {
+    await this.loadResources();
+  }
+
+  protected getResourceThemeLabel(theme: ResourceThemeValue): string {
+    return (
+      this.resourceThemeOptions.find((option) => option.value === theme)
+        ?.label ?? theme
+    );
+  }
+
+  protected getResourceAudienceLabel(audience: ResourceAudienceValue): string {
+    return (
+      this.resourceAudienceOptions.find((option) => option.value === audience)
+        ?.label ?? audience
+    );
+  }
+
+  protected getResourceTypeLabel(type: ResourceTypeValue): string {
+    return RESOURCE_TYPE_LABELS[type];
+  }
+
+  private async loadResources(): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.errorMessage.set(null);
+
+      const response = await this.resourcesService.listResources({
+        resourceTheme: this.selectedTheme() || undefined,
+        resourceAudience: this.selectedAudience() || undefined,
+        page: 1,
+        limit: 100,
+      });
+
+      this.resources.set(response.data);
+    } catch (error) {
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Erreur lors du chargement des ressources.',
+        ),
+      );
+      this.resources.set([]);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}


### PR DESCRIPTION
## Parent epic

RES

## Description

Implémente l'écran mobile Ressources avec recherche et filtres (RES-03), en s'appuyant sur les endpoints RES-02.

## Scope livré

- Ajout d'un service mobile dédié: `MobileResourcesService`
  - liste des ressources avec filtres API (`resourceTheme`, `resourceAudience`, pagination)
  - récupération du détail ressource par `resourceId`
- Écran liste ressources mobile (`/tabs/programmes/ressources`)
  - état chargement / erreur / vide / résultats
  - recherche texte côté client (titre, description, type)
  - filtres thème + audience (UI + rechargement API)
  - navigation vers le détail depuis chaque carte
- Écran détail ressource mobile (`/tabs/programmes/ressources/:resourceId`)
  - chargement par `resourceId`
  - état chargement / erreur + retry
  - affichage des données principales et action d'ouverture de lien
- Tests
  - nouveaux tests service ressources mobile
  - mise à jour des tests liste et détail ressources

## Dependencies

- [x] MOB-02 (navigation shell tabs/stack utilisée)
- [x] RES-02 (consommation des endpoints `/resources` et `/resources/:id`)

## Validation evidence

- Hooks pré-push exécutés avec succès (lint + tests + e2e)
- Tests ciblés feature ressources passants:
  - `pnpm --dir apps/client ng test mobile --watch=false --include='projects/mobile/src/app/features/resources/**/*.spec.ts'`
- Suite mobile complète passante pendant le push
- Suite e2e web passante pendant le push

## Related

Closes #101
