### PR TITLE
[TASK][ANN-02] Implementer endpoints annonces (feed + detail)

### DIFF
--- a/apps/api/src/announcements/announcements.controller.spec.ts
+++ b/apps/api/src/announcements/announcements.controller.spec.ts
@@ -1,0 +1,174 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException, NotFoundException } from '@nestjs/common';
+import type { AnnouncementDto } from '@kraak/contracts';
+import { AnnouncementsController } from './announcements.controller';
+import { AnnouncementsService } from './announcements.service';
+
+describe('AnnouncementsController', () => {
+  let controller: AnnouncementsController;
+
+  const mockListResponse = {
+    data: [
+      {
+        id: 'ann-001',
+        title: 'Important Update',
+        body: 'This is an important announcement for all participants',
+        priority: 'high',
+        audienceType: 'all_participants',
+        programId: null,
+        cohortId: null,
+        status: 'published',
+        publishedAt: '2026-04-20T10:00:00Z',
+        createdByUserId: 'user-001',
+        createdAt: '2026-04-19T10:00:00Z',
+        updatedAt: '2026-04-20T10:00:00Z',
+      } satisfies AnnouncementDto,
+    ],
+    total: 1,
+  };
+
+  const mockAnnouncement = mockListResponse.data[0];
+
+  const mockAnnouncementsService = {
+    listAnnouncements: jest.fn(),
+    getAnnouncementById: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnnouncementsController],
+      providers: [
+        {
+          provide: AnnouncementsService,
+          useValue: mockAnnouncementsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AnnouncementsController>(AnnouncementsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listAnnouncements', () => {
+    it('Given: valid authorization header, When: listAnnouncements called, Then: return list of announcements', async () => {
+      const authHeader = 'Bearer valid-token';
+      mockAnnouncementsService.listAnnouncements.mockResolvedValue(
+        mockListResponse,
+      );
+
+      const result = await controller.listAnnouncements(authHeader, 1, 20);
+
+      expect(result).toEqual(mockListResponse);
+      expect(mockAnnouncementsService.listAnnouncements).toHaveBeenCalledWith(
+        'valid-token',
+        1,
+        20,
+      );
+    });
+
+    it('Given: valid authorization header with pagination, When: listAnnouncements called, Then: apply pagination parameters', async () => {
+      const authHeader = 'Bearer valid-token';
+      mockAnnouncementsService.listAnnouncements.mockResolvedValue(
+        mockListResponse,
+      );
+
+      await controller.listAnnouncements(authHeader, 2, 50);
+
+      expect(mockAnnouncementsService.listAnnouncements).toHaveBeenCalledWith(
+        'valid-token',
+        2,
+        50,
+      );
+    });
+
+    it('Given: missing authorization header, When: listAnnouncements called, Then: throw UnauthorizedException', async () => {
+      await expect(controller.listAnnouncements(undefined)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('Given: invalid authorization header format, When: listAnnouncements called, Then: throw UnauthorizedException', async () => {
+      const authHeader = 'InvalidToken';
+
+      await expect(controller.listAnnouncements(authHeader)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('Given: malformed Bearer token, When: listAnnouncements called, Then: throw UnauthorizedException', async () => {
+      const authHeader = 'Bearer invalid token extra';
+
+      await expect(controller.listAnnouncements(authHeader)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('getAnnouncementById', () => {
+    it('Given: valid authorization header and announcement ID, When: getAnnouncementById called, Then: return announcement detail', async () => {
+      const authHeader = 'Bearer valid-token';
+      const announcementId = 'ann-001';
+
+      mockAnnouncementsService.getAnnouncementById.mockResolvedValue(
+        mockAnnouncement,
+      );
+
+      const result = await controller.getAnnouncementById(
+        announcementId,
+        authHeader,
+      );
+
+      expect(result).toEqual(mockAnnouncement);
+      expect(mockAnnouncementsService.getAnnouncementById).toHaveBeenCalledWith(
+        announcementId,
+        'valid-token',
+      );
+    });
+
+    it('Given: valid authorization but non-existent announcement ID, When: getAnnouncementById called, Then: throw NotFoundException', async () => {
+      const authHeader = 'Bearer valid-token';
+      const announcementId = 'non-existent';
+
+      mockAnnouncementsService.getAnnouncementById.mockRejectedValue(
+        new NotFoundException('Announcement not found'),
+      );
+
+      await expect(
+        controller.getAnnouncementById(announcementId, authHeader),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('Given: missing authorization header, When: getAnnouncementById called, Then: throw UnauthorizedException', async () => {
+      const announcementId = 'ann-001';
+
+      await expect(
+        controller.getAnnouncementById(announcementId, undefined),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('Given: invalid authorization header format, When: getAnnouncementById called, Then: throw UnauthorizedException', async () => {
+      const authHeader = 'InvalidToken';
+      const announcementId = 'ann-001';
+
+      await expect(
+        controller.getAnnouncementById(announcementId, authHeader),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('Given: unauthorized participant accessing announcement, When: getAnnouncementById called, Then: throw NotFoundException', async () => {
+      const authHeader = 'Bearer valid-token';
+      const announcementId = 'restricted-ann';
+
+      mockAnnouncementsService.getAnnouncementById.mockRejectedValue(
+        new NotFoundException('Announcement not found or not accessible'),
+      );
+
+      await expect(
+        controller.getAnnouncementById(announcementId, authHeader),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/announcements/announcements.controller.ts
+++ b/apps/api/src/announcements/announcements.controller.ts
@@ -1,0 +1,186 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  Headers,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import type { AnnouncementDto } from '@kraak/contracts';
+import { extractAccessToken } from '../auth/auth.dto';
+import { AnnouncementsService } from './announcements.service';
+
+const ANNOUNCEMENT_PRIORITY_ENUM = ['low', 'normal', 'high', 'critical'];
+const AUDIENCE_TYPE_ENUM = ['all_participants', 'program', 'cohort'];
+const PUBLICATION_STATUS_ENUM = ['draft', 'published', 'archived'];
+
+const ANNOUNCEMENT_SCHEMA = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    title: { type: 'string' },
+    body: { type: 'string' },
+    priority: {
+      type: 'string',
+      enum: ANNOUNCEMENT_PRIORITY_ENUM,
+    },
+    audienceType: {
+      type: 'string',
+      enum: AUDIENCE_TYPE_ENUM,
+    },
+    programId: { type: 'string', nullable: true },
+    cohortId: { type: 'string', nullable: true },
+    status: {
+      type: 'string',
+      enum: PUBLICATION_STATUS_ENUM,
+    },
+    publishedAt: {
+      type: 'string',
+      format: 'date-time',
+      nullable: true,
+    },
+    createdByUserId: { type: 'string' },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const ANNOUNCEMENT_LIST_SCHEMA = {
+  type: 'object',
+  properties: {
+    data: {
+      type: 'array',
+      items: ANNOUNCEMENT_SCHEMA,
+    },
+    total: { type: 'number' },
+  },
+};
+
+const apiErrorSchema = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', example: false },
+    message: { type: 'string' },
+  },
+};
+
+@ApiTags('Announcements')
+@Controller('announcements')
+export class AnnouncementsController {
+  constructor(private readonly announcementsService: AnnouncementsService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Lister les annonces accessibles au participant connecté',
+    description:
+      "Récupère une liste paginée d'annonces publiées filtrées selon le périmètre du participant (all_participants, program, cohort). Les résultats sont triés par priorité puis par date de publication décroissante.",
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Numéro de page (base 1, défaut: 1)',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: "Nombre d'articles par page (défaut: 20, max: 100)",
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Liste des annonces accessibles au participant',
+    schema: ANNOUNCEMENT_LIST_SCHEMA,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: "Session invalide ou header d'autorisation manquant",
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: 'Erreur serveur lors du chargement des annonces',
+    schema: apiErrorSchema,
+  })
+  async listAnnouncements(
+    @Headers('authorization') authorizationHeader?: string,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ): Promise<{ data: AnnouncementDto[]; total: number }> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.announcementsService.listAnnouncements(
+      accessToken.data,
+      page,
+      limit,
+    );
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: "Récupérer le détail d'une annonce",
+    description:
+      "Récupère les détails d'une annonce publiée spécifique, à condition que le participant ait accès à cette annonce selon son périmètre d'inscription.",
+  })
+  @ApiParam({
+    name: 'id',
+    description: "ID de l'annonce",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Détails de l'annonce",
+    schema: ANNOUNCEMENT_SCHEMA,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Annonce non trouvée ou non accessible',
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: "Session invalide ou header d'autorisation manquant",
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: "Erreur serveur lors du chargement de l'annonce",
+    schema: apiErrorSchema,
+  })
+  async getAnnouncementById(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<AnnouncementDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.announcementsService.getAnnouncementById(id, accessToken.data);
+  }
+}

--- a/apps/api/src/announcements/announcements.module.ts
+++ b/apps/api/src/announcements/announcements.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AnnouncementsController } from './announcements.controller';
+import { AnnouncementsService } from './announcements.service';
+import { SupabaseModule } from '../supabase/supabase.module';
+
+@Module({
+  imports: [SupabaseModule],
+  controllers: [AnnouncementsController],
+  providers: [AnnouncementsService],
+})
+export class AnnouncementsModule {}

--- a/apps/api/src/announcements/announcements.service.spec.ts
+++ b/apps/api/src/announcements/announcements.service.spec.ts
@@ -1,0 +1,350 @@
+import { NotFoundException } from '@nestjs/common';
+import type { AnnouncementDto } from '@kraak/contracts';
+import { AnnouncementsService } from './announcements.service';
+import { SupabaseService } from '../supabase/supabase.service';
+
+describe('AnnouncementsService', () => {
+  let service: AnnouncementsService;
+
+  const mockAnnouncement: AnnouncementDto = {
+    id: 'ann-001',
+    title: 'Important Update',
+    body: 'This is an important announcement for all participants',
+    priority: 'high',
+    audienceType: 'all_participants',
+    programId: null,
+    cohortId: null,
+    status: 'published',
+    publishedAt: '2026-04-20T10:00:00Z',
+    createdByUserId: 'user-001',
+    createdAt: '2026-04-19T10:00:00Z',
+    updatedAt: '2026-04-20T10:00:00Z',
+  };
+
+  const mockProgramAnnouncement: AnnouncementDto = {
+    id: 'ann-002',
+    title: 'Program Specific Notice',
+    body: 'This announcement is for a specific program',
+    priority: 'normal',
+    audienceType: 'program',
+    programId: 'prog-001',
+    cohortId: null,
+    status: 'published',
+    publishedAt: '2026-04-20T11:00:00Z',
+    createdByUserId: 'user-001',
+    createdAt: '2026-04-19T11:00:00Z',
+    updatedAt: '2026-04-20T11:00:00Z',
+  };
+
+  const mockAuthClient = {
+    auth: {
+      getUser: jest.fn(),
+    },
+  };
+
+  const mockSupabaseService = {
+    getAuthClient: jest.fn(() => mockAuthClient),
+    getClient: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AnnouncementsService(
+      mockSupabaseService as unknown as SupabaseService,
+    );
+  });
+
+  const createAsyncQuery = <TResult extends object>(
+    terminalResult: TResult,
+    options?: { withOrder?: boolean; withRange?: boolean; withIn?: boolean },
+  ) => {
+    const base = Promise.resolve(terminalResult) as Promise<TResult> & {
+      from?: ReturnType<typeof jest.fn>;
+      select?: ReturnType<typeof jest.fn>;
+      eq?: ReturnType<typeof jest.fn>;
+      in?: ReturnType<typeof jest.fn>;
+      order?: ReturnType<typeof jest.fn>;
+      range?: ReturnType<typeof jest.fn>;
+      single?: ReturnType<typeof jest.fn>;
+    };
+
+    base.select = jest.fn().mockReturnValue(base);
+    base.eq = jest.fn().mockReturnValue(base);
+
+    if (options?.withIn) {
+      base.in = jest.fn().mockReturnValue(base);
+    }
+
+    if (options?.withOrder) {
+      base.order = jest.fn().mockReturnValue(base);
+    }
+
+    if (options?.withRange) {
+      base.range = jest.fn().mockReturnValue(base);
+    }
+
+    if (terminalResult !== null && 'error' in terminalResult) {
+      base.single = jest.fn().mockReturnValue(base);
+    }
+
+    return base;
+  };
+
+  describe('listAnnouncements', () => {
+    it('Given: valid access token and enrolled participant, When: listAnnouncements called, Then: return filtered announcements', async () => {
+      const accessToken = 'valid-token';
+      const participantId = 'participant-001';
+      const userId = 'user-001';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: userId },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: participantId },
+        error: null,
+      });
+
+      const announcementsQuery = createAsyncQuery(
+        {
+          data: [
+            {
+              id: mockAnnouncement.id,
+              title: mockAnnouncement.title,
+              body: mockAnnouncement.body,
+              priority: mockAnnouncement.priority,
+              audience_type: mockAnnouncement.audienceType,
+              program_id: mockAnnouncement.programId,
+              cohort_id: mockAnnouncement.cohortId,
+              status: mockAnnouncement.status,
+              published_at: mockAnnouncement.publishedAt,
+              created_by_user_id: mockAnnouncement.createdByUserId,
+              created_at: mockAnnouncement.createdAt,
+              updated_at: mockAnnouncement.updatedAt,
+            },
+          ],
+          error: null,
+        },
+        { withOrder: true },
+      );
+
+      const enrollmentsQuery = createAsyncQuery(
+        {
+          data: [
+            {
+              program_id: 'prog-001',
+              cohort_id: null,
+            },
+          ],
+          error: null,
+        },
+        { withIn: true },
+      );
+
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+          if (table === 'announcement') {
+            return announcementsQuery;
+          }
+          if (table === 'enrollment') {
+            return enrollmentsQuery;
+          }
+        }),
+      });
+
+      const result = await service.listAnnouncements(accessToken, 1, 20);
+
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('total');
+      expect(result.data.length).toBeGreaterThan(0);
+      expect(mockAuthClient.auth.getUser).toHaveBeenCalledWith(accessToken);
+    });
+
+    it('Given: invalid access token, When: listAnnouncements called, Then: throw error', async () => {
+      const accessToken = 'invalid-token';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: new Error('Invalid token'),
+      });
+
+      await expect(service.listAnnouncements(accessToken)).rejects.toThrow();
+    });
+  });
+
+  describe('getAnnouncementById', () => {
+    it('Given: valid announcement ID and authorized participant, When: getAnnouncementById called, Then: return announcement detail', async () => {
+      const accessToken = 'valid-token';
+      const participantId = 'participant-001';
+      const userId = 'user-001';
+      const announcementId = 'ann-001';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: userId },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: participantId },
+        error: null,
+      });
+
+      const announcementQuery = createAsyncQuery({
+        data: {
+          id: mockAnnouncement.id,
+          title: mockAnnouncement.title,
+          body: mockAnnouncement.body,
+          priority: mockAnnouncement.priority,
+          audience_type: mockAnnouncement.audienceType,
+          program_id: mockAnnouncement.programId,
+          cohort_id: mockAnnouncement.cohortId,
+          status: mockAnnouncement.status,
+          published_at: mockAnnouncement.publishedAt,
+          created_by_user_id: mockAnnouncement.createdByUserId,
+          created_at: mockAnnouncement.createdAt,
+          updated_at: mockAnnouncement.updatedAt,
+        },
+        error: null,
+      });
+
+      const enrollmentQuery = createAsyncQuery(
+        {
+          data: [{ id: 'enrollment-001' }],
+          error: null,
+        },
+        { withIn: true },
+      );
+
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+          if (table === 'announcement') {
+            return announcementQuery;
+          }
+          if (table === 'enrollment') {
+            return enrollmentQuery;
+          }
+        }),
+      });
+
+      const result = await service.getAnnouncementById(
+        announcementId,
+        accessToken,
+      );
+
+      expect(result.id).toBe(announcementId);
+      expect(result.title).toBe(mockAnnouncement.title);
+      expect(mockAuthClient.auth.getUser).toHaveBeenCalledWith(accessToken);
+    });
+
+    it('Given: non-existent announcement ID, When: getAnnouncementById called, Then: throw NotFoundException', async () => {
+      const accessToken = 'valid-token';
+      const announcementId = 'non-existent';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: 'user-001' },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: 'participant-001' },
+        error: null,
+      });
+
+      const announcementQuery = createAsyncQuery({
+        data: null,
+        error: new Error('Not found'),
+      });
+
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+          if (table === 'announcement') {
+            return announcementQuery;
+          }
+        }),
+      });
+
+      await expect(
+        service.getAnnouncementById(announcementId, accessToken),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('Given: unauthorized participant, When: getAnnouncementById called, Then: throw NotFoundException', async () => {
+      const accessToken = 'valid-token';
+      const participantId = 'participant-001';
+      const userId = 'user-001';
+      const announcementId = 'ann-002';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: userId },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: participantId },
+        error: null,
+      });
+
+      const announcementQuery = createAsyncQuery({
+        data: {
+          id: mockProgramAnnouncement.id,
+          title: mockProgramAnnouncement.title,
+          body: mockProgramAnnouncement.body,
+          priority: mockProgramAnnouncement.priority,
+          audience_type: mockProgramAnnouncement.audienceType,
+          program_id: mockProgramAnnouncement.programId,
+          cohort_id: mockProgramAnnouncement.cohortId,
+          status: mockProgramAnnouncement.status,
+          published_at: mockProgramAnnouncement.publishedAt,
+          created_by_user_id: mockProgramAnnouncement.createdByUserId,
+          created_at: mockProgramAnnouncement.createdAt,
+          updated_at: mockProgramAnnouncement.updatedAt,
+        },
+        error: null,
+      });
+
+      const enrollmentQuery = createAsyncQuery(
+        {
+          data: [],
+          error: null,
+        },
+        { withIn: true },
+      );
+
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+          if (table === 'announcement') {
+            return announcementQuery;
+          }
+          if (table === 'enrollment') {
+            return enrollmentQuery;
+          }
+        }),
+      });
+
+      await expect(
+        service.getAnnouncementById(announcementId, accessToken),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/announcements/announcements.service.spec.ts
+++ b/apps/api/src/announcements/announcements.service.spec.ts
@@ -43,7 +43,7 @@ describe('AnnouncementsService', () => {
   };
 
   const mockSupabaseService = {
-    getAuthClient: jest.fn(() => mockAuthClient),
+    createAuthClient: jest.fn(() => mockAuthClient),
     getClient: jest.fn(),
   };
 

--- a/apps/api/src/announcements/announcements.service.ts
+++ b/apps/api/src/announcements/announcements.service.ts
@@ -1,0 +1,292 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import type {
+  AnnouncementDto,
+  AnnouncementPriorityValue,
+  PublicationStatusValue,
+} from '@kraak/contracts';
+import {
+  isMvpSupportedAnnouncementAudience,
+  sortAnnouncementsByPriority,
+} from '@kraak/domain';
+import { SupabaseService } from '../supabase/supabase.service';
+
+const ANNOUNCEMENT_SELECT_FIELDS =
+  'id, title, body, priority, audience_type, program_id, cohort_id, status, published_at, created_by_user_id, created_at, updated_at';
+
+type AnnouncementRow = {
+  id: string;
+  title: string;
+  body: string;
+  priority: AnnouncementPriorityValue;
+  audience_type: string;
+  program_id: string | null;
+  cohort_id: string | null;
+  status: PublicationStatusValue;
+  published_at: string | null;
+  created_by_user_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type EnrollmentRow = {
+  program_id: string;
+  cohort_id: string | null;
+};
+
+@Injectable()
+export class AnnouncementsService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  /**
+   * List announcements visible to the authenticated participant.
+   * Filters by participant's enrollment scope (all_participants, program, cohort).
+   * Results are ordered by priority and then by publishedAt descending.
+   * @param accessToken - The access token of the authenticated participant
+   * @param page - Page number (1-based, default: 1)
+   * @param limit - Items per page (default: 20, max: 100)
+   */
+  async listAnnouncements(
+    accessToken: string,
+    page?: number,
+    limit?: number,
+  ): Promise<{ data: AnnouncementDto[]; total: number }> {
+    const adminClient = this.supabaseService.getClient();
+    const paginationLimit = Math.min(limit ?? 20, 100);
+    const paginationPage = Math.max(page ?? 1, 1);
+
+    // Get participant ID from access token
+    const participantId = await this.resolveParticipantId(accessToken);
+    if (!participantId) {
+      throw new Error('Could not resolve participant ID from access token');
+    }
+
+    // Get all published announcements
+    const { data: allAnnouncements, error: announcementsError } =
+      await adminClient
+        .from('announcement')
+        .select(ANNOUNCEMENT_SELECT_FIELDS)
+        .eq('status', 'published')
+        .order('published_at', { ascending: false });
+
+    if (announcementsError) {
+      throw new Error(
+        `Failed to list announcements: ${announcementsError.message}`,
+      );
+    }
+
+    // Get participant's enrollments
+    const { data: enrollments, error: enrollmentsError } = await adminClient
+      .from('enrollment')
+      .select('program_id, cohort_id')
+      .eq('participant_id', participantId)
+      .in('status', ['pending', 'active', 'completed']);
+
+    if (enrollmentsError) {
+      throw new Error(`Failed to get enrollments: ${enrollmentsError.message}`);
+    }
+
+    // Filter announcements based on participant's scope
+    const visibleAnnouncements = this.filterAnnouncementsByScope(
+      (allAnnouncements ?? []) as AnnouncementRow[],
+      (enrollments ?? []) as EnrollmentRow[],
+    );
+
+    // Sort by priority and publishedAt
+    const sorted = sortAnnouncementsByPriority(
+      visibleAnnouncements.map((row) => this.mapAnnouncement(row)),
+    );
+
+    // Apply pagination
+    const offset = (paginationPage - 1) * paginationLimit;
+    const paginated = sorted.slice(offset, offset + paginationLimit);
+
+    return {
+      data: paginated,
+      total: sorted.length,
+    };
+  }
+
+  /**
+   * Get a single announcement by ID.
+   * Verifies that the participant has access to this announcement based on their enrollment scope.
+   * @param id - Announcement ID
+   * @param accessToken - The access token of the authenticated participant
+   */
+  async getAnnouncementById(
+    id: string,
+    accessToken: string,
+  ): Promise<AnnouncementDto> {
+    const adminClient = this.supabaseService.getClient();
+
+    // Get the announcement
+    const { data: announcementData, error: announcementError } =
+      await adminClient
+        .from('announcement')
+        .select(ANNOUNCEMENT_SELECT_FIELDS)
+        .eq('id', id)
+        .eq('status', 'published')
+        .single();
+
+    if (announcementError || !announcementData) {
+      throw new NotFoundException('Announcement not found or not published');
+    }
+
+    const announcement = announcementData as AnnouncementRow;
+
+    // Get participant ID from access token
+    const participantId = await this.resolveParticipantId(accessToken);
+    if (!participantId) {
+      throw new Error('Could not resolve participant ID from access token');
+    }
+
+    // Check if announcement is visible to participant
+    const isVisible = await this.isAnnouncementVisibleToParticipant(
+      announcement,
+      participantId,
+    );
+
+    if (!isVisible) {
+      throw new NotFoundException('Announcement not found or not accessible');
+    }
+
+    return this.mapAnnouncement(announcement);
+  }
+
+  /**
+   * Filter announcements based on participant's enrollment scope.
+   * A participant can see:
+   * 1. Announcements targeting all_participants
+   * 2. Announcements for their enrolled programs
+   * 3. Announcements for their enrolled cohorts
+   */
+  private filterAnnouncementsByScope(
+    announcements: AnnouncementRow[],
+    enrollments: EnrollmentRow[],
+  ): AnnouncementRow[] {
+    if (!isMvpSupportedAnnouncementAudience('all_participants')) {
+      throw new Error('Invalid audience type');
+    }
+
+    const enrolledProgramIds = new Set(enrollments.map((e) => e.program_id));
+    const enrolledCohortIds = new Set(
+      enrollments.map((e) => e.cohort_id).filter((c) => c !== null),
+    );
+
+    return announcements.filter((announcement) => {
+      if (!isMvpSupportedAnnouncementAudience(announcement.audience_type)) {
+        return false;
+      }
+
+      if (announcement.audience_type === 'all_participants') {
+        return true;
+      }
+
+      if (
+        announcement.audience_type === 'program' &&
+        announcement.program_id &&
+        enrolledProgramIds.has(announcement.program_id)
+      ) {
+        return true;
+      }
+
+      return (
+        announcement.audience_type === 'cohort' &&
+        announcement.cohort_id !== null &&
+        enrolledCohortIds.has(announcement.cohort_id)
+      );
+    });
+  }
+
+  /**
+   * Check if an announcement is visible to a participant.
+   */
+  private async isAnnouncementVisibleToParticipant(
+    announcement: AnnouncementRow,
+    participantId: string,
+  ): Promise<boolean> {
+    if (!isMvpSupportedAnnouncementAudience(announcement.audience_type)) {
+      return false;
+    }
+
+    if (announcement.audience_type === 'all_participants') {
+      return true;
+    }
+
+    const adminClient = this.supabaseService.getClient();
+
+    // Get participant's enrollments
+    let query = adminClient
+      .from('enrollment')
+      .select('id')
+      .eq('participant_id', participantId)
+      .in('status', ['pending', 'active', 'completed']);
+
+    if (announcement.audience_type === 'program' && announcement.program_id) {
+      query = query.eq('program_id', announcement.program_id);
+    } else if (
+      announcement.audience_type === 'cohort' &&
+      announcement.cohort_id
+    ) {
+      query = query.eq('cohort_id', announcement.cohort_id);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error(`Failed to verify announcement access: ${error.message}`);
+    }
+
+    return (data?.length ?? 0) > 0;
+  }
+
+  /**
+   * Resolve participant ID from access token using auth.getUser()
+   */
+  private async resolveParticipantId(
+    accessToken: string,
+  ): Promise<string | null> {
+    const authClient = this.supabaseService.getAuthClient();
+
+    const { data, error } = await authClient.auth.getUser(accessToken);
+
+    if (error || !data.user) {
+      return null;
+    }
+
+    const userId = data.user.id;
+
+    // Get participant linked to this user
+    const adminClient = this.supabaseService.getClient();
+    const { data: participantData, error: participantError } = await adminClient
+      .from('participant')
+      .select('id')
+      .eq('user_id', userId)
+      .single();
+
+    if (participantError || !participantData) {
+      return null;
+    }
+
+    return participantData.id;
+  }
+
+  /**
+   * Map database row to DTO.
+   */
+  private mapAnnouncement(row: AnnouncementRow): AnnouncementDto {
+    return {
+      id: row.id,
+      title: row.title,
+      body: row.body,
+      priority: row.priority,
+      audienceType: row.audience_type,
+      programId: row.program_id,
+      cohortId: row.cohort_id,
+      status: row.status,
+      publishedAt: row.published_at,
+      createdByUserId: row.created_by_user_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/apps/api/src/announcements/announcements.service.ts
+++ b/apps/api/src/announcements/announcements.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import type {
   AnnouncementDto,
   AnnouncementPriorityValue,
+  AudienceTypeValue,
   PublicationStatusValue,
 } from '@kraak/contracts';
 import {
@@ -18,7 +19,7 @@ type AnnouncementRow = {
   title: string;
   body: string;
   priority: AnnouncementPriorityValue;
-  audience_type: string;
+  audience_type: AudienceTypeValue;
   program_id: string | null;
   cohort_id: string | null;
   status: PublicationStatusValue;
@@ -245,7 +246,7 @@ export class AnnouncementsService {
   private async resolveParticipantId(
     accessToken: string,
   ): Promise<string | null> {
-    const authClient = this.supabaseService.getAuthClient();
+    const authClient = this.supabaseService.createAuthClient();
 
     const { data, error } = await authClient.auth.getUser(accessToken);
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AnnouncementsModule } from './announcements/announcements.module';
 import { AuthModule } from './auth/auth.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { ProgramsModule } from './programs/programs.module';
@@ -18,6 +19,7 @@ import { SupportModule } from './support/support.module';
     }),
     SupabaseModule,
     AuthModule,
+    AnnouncementsModule,
     DashboardModule,
     ProgramsModule,
     ResourcesModule,

--- a/packages/domain/src/announcements.ts
+++ b/packages/domain/src/announcements.ts
@@ -140,3 +140,34 @@ export function getAnnouncementPriorityWeight(
 
   return index;
 }
+
+export interface AnnouncementForSorting {
+  priority: AnnouncementPriorityValue;
+  publishedAt: string | null;
+}
+
+/**
+ * Sort announcements by priority (descending) and then by publishedAt (descending).
+ * Higher priority announcements come first, then by most recent publication date.
+ */
+export function sortAnnouncementsByPriority<T extends AnnouncementForSorting>(
+  announcements: T[],
+): T[] {
+  return [...announcements].sort((a, b) => {
+    const priorityWeightA = getAnnouncementPriorityWeight(a.priority);
+    const priorityWeightB = getAnnouncementPriorityWeight(b.priority);
+
+    if (priorityWeightA !== priorityWeightB) {
+      return priorityWeightA - priorityWeightB;
+    }
+
+    if (!a.publishedAt || !b.publishedAt) {
+      return 0;
+    }
+
+    const dateA = new Date(a.publishedAt).getTime();
+    const dateB = new Date(b.publishedAt).getTime();
+
+    return dateB - dateA;
+  });
+}


### PR DESCRIPTION
## Summary
Implements ANN-02 announcement API endpoints (feed + detail) for participant scope-aware visibility.

## Changes
- Added announcements module with two endpoints:
  - GET /announcements (paginated feed)
  - GET /announcements/:id (detail)
- Implemented scope filtering by audience + participant enrollments:
  - all_participants
  - program
  - cohort
- Added participant access verification from bearer token via Supabase auth.
- Added sorting helper in domain package: priority then published date.
- Wired module into app module.
- Added unit tests for service and controller.
- Fixed typing and auth client integration issues discovered in pre-push checks.

## Validation
- apps/api announcements tests: 15/15 passing.
- Repo pre-push pipeline passed (typecheck, lint, tests, e2e).

## Related
- Closes #104
- Depends on: SET-02, LIB-01, AUT-02, ANN-01
