### PR TITLE
[TASK][ANN-03] Implementer flux annonces dans mobile dashboard/feed #105

### DIFF
--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.html
@@ -1,15 +1,58 @@
 <kraak-page-shell
   eyebrow="Annonce"
-  title="Détail de l'annonce"
+  [title]="pageTitle()"
   description="Consultez une annonce en restant dans la pile de l'onglet Annonces."
   backHref="/tabs/annonces"
 >
-  <section
-    class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card border p-5"
-  >
-    <p class="text-sm leading-6 text-neutral-700">
-      Le contenu détaillé de l'annonce et ses prochaines actions seront affichés
-      ici.
-    </p>
-  </section>
+  @if (errorMessage()) {
+    <section
+      class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
+    >
+      <p class="text-sm leading-6 text-red-700">
+        {{ errorMessage() }}
+      </p>
+
+      <ion-button
+        expand="block"
+        class="kraak-primary-button"
+        (click)="reloadAnnouncement()"
+        (keydown.enter)="reloadAnnouncement()"
+      >
+        Recharger cette annonce
+      </ion-button>
+    </section>
+  } @else if (loading()) {
+    <section
+      class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col items-center gap-4 border p-5"
+    >
+      <ion-spinner name="crescent" aria-label="Chargement"></ion-spinner>
+      <p class="text-sm leading-6 text-neutral-700">
+        Chargement de l'annonce...
+      </p>
+    </section>
+  } @else if (announcement(); as detail) {
+    <section
+      class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
+      data-testid="announcement-detail-card"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <span
+          class="bg-brand-cyan/15 text-brand-navy rounded-full px-2 py-1 text-xs font-semibold"
+        >
+          {{ getPriorityLabel(detail.priority) }}
+        </span>
+
+        @if (detail.publishedAt) {
+          <span
+            class="rounded-full bg-neutral-100 px-2 py-1 text-xs font-semibold text-neutral-700"
+          >
+            Publié le {{ detail.publishedAt | date: 'fullDate' }}
+          </span>
+        }
+      </div>
+
+      <p class="text-primary text-xl font-semibold">{{ detail.title }}</p>
+      <p class="text-sm leading-7 text-neutral-700">{{ detail.body }}</p>
+    </section>
+  }
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.spec.ts
@@ -1,26 +1,103 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import type { AnnouncementDto } from '@kraak/contracts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AnnouncementDetailPage from './announcement-detail.page';
+
+function configureAnnouncementsClient(
+  fixture: ReturnType<typeof TestBed.createComponent<AnnouncementDetailPage>>,
+  response: Promise<unknown>,
+): void {
+  const component = fixture.componentInstance as unknown as {
+    announcementsClient: { getById: (id: string) => Promise<unknown> };
+  };
+
+  component.announcementsClient = {
+    getById: vi.fn().mockImplementation(() => response),
+  };
+}
 
 describe('Mobile AnnouncementDetailPage', () => {
   beforeEach(async () => {
+    vi.restoreAllMocks();
+
     await TestBed.configureTestingModule({
       imports: [AnnouncementDetailPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({ announcementId: 'ann-001' }),
+            },
+          },
+        },
+      ],
     }).compileComponents();
   });
 
   it('should create', () => {
     const fixture = TestBed.createComponent(AnnouncementDetailPage);
+    configureAnnouncementsClient(
+      fixture,
+      Promise.resolve({
+        id: 'ann-001',
+      } satisfies Pick<AnnouncementDto, 'id'>),
+    );
+
+    fixture.detectChanges();
+
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given the Annonces stack, when the detail renders, then it keeps the expected shell title', () => {
+  it('Given an announcement id, when detail loads, then it renders announcement content', async () => {
     const fixture = TestBed.createComponent(AnnouncementDetailPage);
+    const announcement: AnnouncementDto = {
+      id: 'ann-001',
+      title: 'Session de suivi',
+      body: 'La session de suivi est deplacee au jeudi.',
+      priority: 'critical',
+      audienceType: 'all_participants',
+      programId: null,
+      cohortId: null,
+      status: 'published',
+      publishedAt: '2026-04-29T08:00:00.000Z',
+      createdByUserId: 'user-2',
+      createdAt: '2026-04-28T10:00:00.000Z',
+      updatedAt: '2026-04-29T08:10:00.000Z',
+    };
+
+    configureAnnouncementsClient(fixture, Promise.resolve(announcement));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
 
+    const element = fixture.nativeElement as HTMLElement;
     const title = fixture.nativeElement.querySelector('ion-title');
-    expect(title?.textContent).toContain("Détail de l'annonce");
+
+    expect(title?.textContent).toContain('Session de suivi');
+    expect(element.textContent).toContain(
+      'La session de suivi est deplacee au jeudi.',
+    );
+    expect(element.textContent).toContain('Critique');
+  });
+
+  it('Given a detail load error, when detail initializes, then it shows retry action', async () => {
+    const fixture = TestBed.createComponent(AnnouncementDetailPage);
+    configureAnnouncementsClient(
+      fixture,
+      Promise.reject(new Error('Erreur detail annonce test')),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Erreur detail annonce test');
+    expect(element.textContent).toContain('Recharger cette annonce');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.ts
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.ts
@@ -1,10 +1,86 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { DatePipe } from '@angular/common';
+import { IonButton, IonSpinner } from '@ionic/angular/standalone';
+import { createApiClient } from '@kraak/api-client';
+import type { AnnouncementDto } from '@kraak/contracts';
+import { environment } from '../../../environments/environment';
+import {
+  MobileAuthService,
+  resolveAuthErrorMessage,
+} from '../auth/mobile-auth.service';
 import { PageShell } from '../../shared/page-shell/page-shell';
 
 @Component({
   selector: 'kraak-announcement-detail-page',
   standalone: true,
-  imports: [PageShell],
+  imports: [PageShell, IonButton, IonSpinner, DatePipe],
   templateUrl: './announcement-detail.page.html',
 })
-export default class AnnouncementDetailPage {}
+export default class AnnouncementDetailPage implements OnInit {
+  private readonly authService = inject(MobileAuthService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly announcementsClient = createApiClient({
+    baseUrl: environment.apiBaseUrl,
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).announcements;
+
+  protected readonly announcement = signal<AnnouncementDto | null>(null);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly pageTitle = computed(() => {
+    const title = this.announcement()?.title;
+    return title && title.trim().length > 0 ? title : "Détail de l'annonce";
+  });
+
+  ngOnInit(): void {
+    void this.loadAnnouncement();
+  }
+
+  protected async reloadAnnouncement(): Promise<void> {
+    await this.loadAnnouncement();
+  }
+
+  protected getPriorityLabel(priority: AnnouncementDto['priority']): string {
+    switch (priority) {
+      case 'critical':
+        return 'Critique';
+      case 'high':
+        return 'Elevée';
+      case 'normal':
+        return 'Normale';
+      case 'low':
+        return 'Faible';
+    }
+  }
+
+  private async loadAnnouncement(): Promise<void> {
+    const announcementId = this.route.snapshot.paramMap.get('announcementId');
+
+    if (!announcementId) {
+      this.loading.set(false);
+      this.announcement.set(null);
+      this.errorMessage.set('Annonce introuvable.');
+      return;
+    }
+
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      const announcement =
+        await this.announcementsClient.getById(announcementId);
+      this.announcement.set(announcement);
+    } catch (error) {
+      this.announcement.set(null);
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          "Erreur lors du chargement de l'annonce.",
+        ),
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.html
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.html
@@ -3,19 +3,87 @@
   title="Annonces"
   description="Gardez un oeil sur les informations à relayer rapidement."
 >
-  <section
-    class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card border p-5"
-  >
-    <p class="text-sm leading-6 text-neutral-700">
-      Annonces et actualités à venir.
-    </p>
-
-    <ion-button
-      routerLink="/tabs/annonces/info-session"
-      expand="block"
-      class="kraak-primary-button mt-4"
+  @if (errorMessage()) {
+    <section
+      class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
     >
-      Lire une annonce exemple
-    </ion-button>
-  </section>
+      <p class="text-sm leading-6 text-red-700">
+        {{ errorMessage() }}
+      </p>
+
+      <ion-button
+        expand="block"
+        class="kraak-primary-button"
+        (click)="reloadAnnouncements()"
+        (keydown.enter)="reloadAnnouncements()"
+      >
+        Recharger le flux
+      </ion-button>
+    </section>
+  } @else if (loading()) {
+    <section
+      class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col items-center gap-4 border p-5"
+    >
+      <ion-spinner name="crescent" aria-label="Chargement"></ion-spinner>
+      <p class="text-sm leading-6 text-neutral-700">
+        Chargement des annonces...
+      </p>
+    </section>
+  } @else if (announcements().length === 0) {
+    <section
+      class="rounded-card border-brand-blue/12 bg-brand-white shadow-card border p-5"
+    >
+      <p class="text-sm leading-6 text-neutral-700">
+        Aucune annonce n'est disponible pour le moment.
+      </p>
+    </section>
+  } @else {
+    <section
+      class="rounded-card border-brand-cyan/18 bg-brand-white shadow-card border p-5"
+    >
+      <p class="text-sm leading-6 text-neutral-700">
+        {{ announcements().length }} annonce(s) visible(s) sur {{ total() }}.
+      </p>
+    </section>
+
+    @for (announcement of announcements(); track announcement.id) {
+      <section
+        class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-3 border p-5"
+        data-testid="announcement-card"
+      >
+        <div class="flex flex-wrap items-center gap-2">
+          <span
+            class="bg-brand-cyan/15 text-brand-navy rounded-full px-2 py-1 text-xs font-semibold"
+          >
+            {{ getPriorityLabel(announcement.priority) }}
+          </span>
+
+          @if (announcement.publishedAt) {
+            <span
+              class="rounded-full bg-neutral-100 px-2 py-1 text-xs font-semibold text-neutral-700"
+            >
+              Publié le {{ announcement.publishedAt | date: 'mediumDate' }}
+            </span>
+          }
+        </div>
+
+        <div>
+          <p class="text-primary text-lg font-semibold">
+            {{ announcement.title }}
+          </p>
+          <p class="mt-1 text-sm leading-6 text-neutral-700">
+            {{ announcement.body }}
+          </p>
+        </div>
+
+        <ion-button
+          [routerLink]="'/tabs/annonces/' + announcement.id"
+          expand="block"
+          class="kraak-primary-button"
+        >
+          Lire le détail
+        </ion-button>
+      </section>
+    }
+  }
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.spec.ts
@@ -1,11 +1,28 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import type { AnnouncementDto } from '@kraak/contracts';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { vi } from 'vitest';
 import AnnouncementListPage from './announcement-list.page';
+
+function configureAnnouncementsClient(
+  fixture: ReturnType<typeof TestBed.createComponent<AnnouncementListPage>>,
+  response: Promise<unknown>,
+): void {
+  const component = fixture.componentInstance as unknown as {
+    announcementsClient: { list: () => Promise<unknown> };
+  };
+
+  component.announcementsClient = {
+    list: vi.fn().mockImplementation(() => response),
+  };
+}
 
 describe('Mobile AnnouncementListPage', () => {
   beforeEach(async () => {
+    vi.restoreAllMocks();
+
     await TestBed.configureTestingModule({
       imports: [AnnouncementListPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -15,13 +32,69 @@ describe('Mobile AnnouncementListPage', () => {
 
   it('should create', () => {
     const fixture = TestBed.createComponent(AnnouncementListPage);
+    configureAnnouncementsClient(
+      fixture,
+      Promise.resolve({ data: [], total: 0 }),
+    );
+
+    fixture.detectChanges();
+
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the title', () => {
+  it('Given API announcements, when page loads, then it renders the feed and entry point to detail', async () => {
     const fixture = TestBed.createComponent(AnnouncementListPage);
+    const announcements: AnnouncementDto[] = [
+      {
+        id: 'ann-001',
+        title: 'Mise a jour importante',
+        body: 'Nouvelle information utile pour tous les participants.',
+        priority: 'high',
+        audienceType: 'all_participants',
+        programId: null,
+        cohortId: null,
+        status: 'published',
+        publishedAt: '2026-04-29T10:00:00.000Z',
+        createdByUserId: 'user-1',
+        createdAt: '2026-04-29T09:30:00.000Z',
+        updatedAt: '2026-04-29T09:45:00.000Z',
+      },
+    ];
+
+    configureAnnouncementsClient(
+      fixture,
+      Promise.resolve({ data: announcements, total: announcements.length }),
+    );
+
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
     const title = fixture.nativeElement.querySelector('ion-title');
+
     expect(title?.textContent).toContain('Annonces');
+    expect(element.textContent).toContain('Mise a jour importante');
+    expect(element.textContent).toContain(
+      'Nouvelle information utile pour tous les participants.',
+    );
+
+    expect(element.textContent).toContain('Lire le détail');
+  });
+
+  it('Given an API error, when page loads, then it shows an actionable error state', async () => {
+    const fixture = TestBed.createComponent(AnnouncementListPage);
+    configureAnnouncementsClient(
+      fixture,
+      Promise.reject(new Error('Erreur annonces test')),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Erreur annonces test');
+    expect(element.textContent).toContain('Recharger le flux');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.ts
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.ts
@@ -1,12 +1,120 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { IonButton } from '@ionic/angular/standalone';
+import { DatePipe } from '@angular/common';
+import { IonButton, IonSpinner } from '@ionic/angular/standalone';
+import { createApiClient } from '@kraak/api-client';
+import type { AnnouncementDto } from '@kraak/contracts';
+import { environment } from '../../../environments/environment';
+import {
+  MobileAuthService,
+  resolveAuthErrorMessage,
+} from '../auth/mobile-auth.service';
 import { PageShell } from '../../shared/page-shell/page-shell';
 
 @Component({
   selector: 'kraak-announcement-list-page',
   standalone: true,
-  imports: [PageShell, IonButton, RouterLink],
+  imports: [PageShell, IonButton, IonSpinner, RouterLink, DatePipe],
   templateUrl: './announcement-list.page.html',
 })
-export default class AnnouncementListPage {}
+export default class AnnouncementListPage implements OnInit {
+  private readonly authService = inject(MobileAuthService);
+  private latestLoadRequestId = 0;
+
+  private readonly announcementsClient = createApiClient({
+    baseUrl: environment.apiBaseUrl,
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).announcements;
+
+  protected readonly announcements = signal<AnnouncementDto[]>([]);
+  protected readonly total = signal(0);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    void this.loadAnnouncements();
+  }
+
+  protected async reloadAnnouncements(): Promise<void> {
+    await this.loadAnnouncements();
+  }
+
+  protected getPriorityLabel(priority: AnnouncementDto['priority']): string {
+    switch (priority) {
+      case 'critical':
+        return 'Critique';
+      case 'high':
+        return 'Elevée';
+      case 'normal':
+        return 'Normale';
+      case 'low':
+        return 'Faible';
+    }
+  }
+
+  private async loadAnnouncements(): Promise<void> {
+    const requestId = ++this.latestLoadRequestId;
+
+    try {
+      this.loading.set(true);
+      this.errorMessage.set(null);
+
+      const response = await this.announcementsClient.list();
+      const normalized = this.normalizeAnnouncementListResponse(response);
+
+      if (requestId === this.latestLoadRequestId) {
+        this.announcements.set(normalized.data);
+        this.total.set(normalized.total);
+      }
+    } catch (error) {
+      if (requestId === this.latestLoadRequestId) {
+        this.announcements.set([]);
+        this.total.set(0);
+        this.errorMessage.set(
+          resolveAuthErrorMessage(
+            error,
+            'Erreur lors du chargement des annonces.',
+          ),
+        );
+      }
+    } finally {
+      if (requestId === this.latestLoadRequestId) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  private normalizeAnnouncementListResponse(response: unknown): {
+    data: AnnouncementDto[];
+    total: number;
+  } {
+    if (Array.isArray(response)) {
+      return {
+        data: response as AnnouncementDto[],
+        total: response.length,
+      };
+    }
+
+    if (
+      response !== null &&
+      typeof response === 'object' &&
+      'data' in response &&
+      Array.isArray(response.data)
+    ) {
+      const total =
+        'total' in response && typeof response.total === 'number'
+          ? response.total
+          : response.data.length;
+
+      return {
+        data: response.data as AnnouncementDto[],
+        total,
+      };
+    }
+
+    return {
+      data: [],
+      total: 0,
+    };
+  }
+}

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
@@ -172,7 +172,15 @@
             </div>
 
             <div class="space-y-2">
-              <p class="kraak-overline">Annonces récentes</p>
+              <div class="flex items-center justify-between gap-3">
+                <p class="kraak-overline">Annonces récentes</p>
+                <a
+                  routerLink="/tabs/annonces"
+                  class="kraak-inline-link text-xs"
+                >
+                  Voir tout
+                </a>
+              </div>
               @if (recentAnnouncements.length === 0) {
                 <p class="text-sm leading-6 text-neutral-700">
                   Aucune annonce récente pour l'instant.
@@ -184,9 +192,12 @@
                     track announcement.id
                   ) {
                     <li class="rounded-xl border border-neutral-200/90 p-3">
-                      <p class="text-primary text-sm font-semibold">
+                      <a
+                        [routerLink]="'/tabs/annonces/' + announcement.id"
+                        class="text-primary text-sm font-semibold"
+                      >
                         {{ announcement.title }}
-                      </p>
+                      </a>
                       <p class="mt-1 text-xs leading-5 text-neutral-700">
                         {{ announcement.body }}
                       </p>

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.spec.ts
@@ -155,6 +155,12 @@ describe('Mobile HomePage', () => {
     expect(text).toContain("Parcours d'integration");
     expect(text).toContain('Atelier CV');
     expect(text).toContain('Rappel documents');
+
+    const element = fixture.nativeElement as HTMLElement;
+    const links = element.querySelectorAll('a');
+
+    expect(links.length).toBeGreaterThan(0);
+    expect(element.textContent).toContain('Voir tout');
   });
 
   it('Given an empty dashboard aggregate, when the page loads, then it renders a global empty state', async () => {


### PR DESCRIPTION
## Summary

Implements PRG-04 minimal progression marking for participant programs.

## Changes

- **Domain rules (`packages/domain`)**
  - Added minimal progression engine (`progress.ts`) with session eligibility checks, marker updates, and derived progress computation.
  - Added dedicated unit tests (`progress.spec.ts`).

- **Shared contracts (`packages/contracts`)**
  - Added progression DTOs and payloads:
    - `ProgramProgressDto`
    - `MarkProgramSessionProgressRequestDto`
    - `MarkProgramSessionProgressResponseDto`
  - Extended participant program list/detail DTOs with `progress`.
  - Added enum `ProgramProgressStatus`.

- **API (`apps/api`)**
  - Added payload validation in `programs.dto.ts` (+ tests).
  - Added endpoint `POST /programs/:programId/progress` with Swagger docs.
  - Implemented persistence and restitution of progression in `ProgramsService`.
  - Auto-completes enrollment status when all visible sessions are marked completed.

- **Mobile (`apps/client/projects/mobile`)**
  - Added service method `markSessionProgress(programId, sessionId, completed)`.
  - Added session-level action buttons to mark/unmark completion.
  - Added progression display in program list/detail pages.
  - Updated/extended related specs.

- **Data model / migration**
  - Added migration `20260429110000_add_enrollment_progress_markers.sql`:
    - `enrollment.progress_completed_session_ids`
    - `enrollment.progress_updated_at`
  - Updated product model doc to keep enrollment fields aligned.

## Related

Closes #97
Depends on: PRG-02, LIB-02

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] API + shared domain/contracts + mobile MVP functionality

## Testing

- `pnpm --filter @kraak/contracts test`
- `pnpm --filter @kraak/domain test`
- `pnpm --filter @kraak/api-client test`
- `pnpm --filter @kraak/api test -- programs`
- `pnpm --filter @kraak/client test:mobile`
