### PR TITLE
[TASK][ANN-04] Ajouter notification push pour annonce prioritaire

### DIFF
--- a/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.spec.ts
@@ -1,6 +1,7 @@
 // apps\client\projects\mobile\src\app\core\mobile-push-notifications.service.spec.ts
 
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const pushNotificationsMock = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ import {
 describe('MobilePushNotificationsService', () => {
   const getPlatformMock = vi.fn();
   const originalPushNotificationsEnabled = environment.pushNotificationsEnabled;
+  const navigateByUrlMock = vi.fn();
 
   beforeEach(() => {
     getPlatformMock.mockReset();
@@ -38,8 +40,19 @@ describe('MobilePushNotificationsService', () => {
     pushNotificationsMock.requestPermissions.mockReset();
     pushNotificationsMock.addListener.mockReset();
     pushNotificationsMock.register.mockReset();
+    navigateByUrlMock.mockReset();
+    navigateByUrlMock.mockResolvedValue(true);
 
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            navigateByUrl: navigateByUrlMock,
+          },
+        },
+      ],
+    });
   });
 
   afterEach(() => {
@@ -211,6 +224,101 @@ describe('MobilePushNotificationsService', () => {
     expect(service.currentToken()).toBe('fcm-token-123');
     expect(service.currentStatus()).toBe('enabled');
     expect(service.currentReason()).toBe('fcm-registration-ready');
+  });
+
+  it('Given a high priority announcement push payload, when a notification is received, then the last priority push state is updated', async () => {
+    getPlatformMock.mockReturnValue('android');
+
+    pushNotificationsMock.checkPermissions.mockResolvedValue({
+      receive: 'granted',
+    });
+
+    const { listeners } = mockPushListeners();
+
+    pushNotificationsMock.register.mockImplementation(async () => {
+      listeners.get('registration')?.({
+        value: 'fcm-token-priority',
+      });
+    });
+
+    const service = TestBed.inject(MobilePushNotificationsService);
+    await service.initialize();
+
+    listeners.get('pushNotificationReceived')?.({
+      data: {
+        announcementId: 'ann-priority-01',
+        priority: 'high',
+      },
+    });
+
+    expect(service.lastPriorityAnnouncementPush()).toEqual({
+      announcementId: 'ann-priority-01',
+      priority: 'high',
+    });
+  });
+
+  it('Given a non-priority announcement push payload, when a notification is received, then no priority push state is stored', async () => {
+    getPlatformMock.mockReturnValue('android');
+
+    pushNotificationsMock.checkPermissions.mockResolvedValue({
+      receive: 'granted',
+    });
+
+    const { listeners } = mockPushListeners();
+
+    pushNotificationsMock.register.mockImplementation(async () => {
+      listeners.get('registration')?.({
+        value: 'fcm-token-priority-ignore',
+      });
+    });
+
+    const service = TestBed.inject(MobilePushNotificationsService);
+    await service.initialize();
+
+    listeners.get('pushNotificationReceived')?.({
+      data: {
+        announcementId: 'ann-normal-01',
+        priority: 'normal',
+      },
+    });
+
+    expect(service.lastPriorityAnnouncementPush()).toBeNull();
+  });
+
+  it('Given a critical announcement action payload, when the user taps the push notification, then the app navigates to the announcement detail route', async () => {
+    getPlatformMock.mockReturnValue('android');
+
+    pushNotificationsMock.checkPermissions.mockResolvedValue({
+      receive: 'granted',
+    });
+
+    const { listeners } = mockPushListeners();
+
+    pushNotificationsMock.register.mockImplementation(async () => {
+      listeners.get('registration')?.({
+        value: 'fcm-token-priority-action',
+      });
+    });
+
+    const service = TestBed.inject(MobilePushNotificationsService);
+    await service.initialize();
+
+    listeners.get('pushNotificationActionPerformed')?.({
+      notification: {
+        data: {
+          announcement_id: 'ann-critical-01',
+          priority: 'critical',
+        },
+      },
+    });
+
+    expect(service.lastPriorityAnnouncementPush()).toEqual({
+      announcementId: 'ann-critical-01',
+      priority: 'critical',
+    });
+    expect(navigateByUrlMock).toHaveBeenCalledWith(
+      '/tabs/annonces/ann-critical-01',
+    );
   });
 
   it('Given permission is prompted then granted, when registration succeeds, then the FCM token is exposed', async () => {

--- a/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.spec.ts
@@ -321,6 +321,65 @@ describe('MobilePushNotificationsService', () => {
     );
   });
 
+  it('Given an action payload without priority announcement data, when the user taps the notification, then no navigation is triggered', async () => {
+    getPlatformMock.mockReturnValue('android');
+
+    pushNotificationsMock.checkPermissions.mockResolvedValue({
+      receive: 'granted',
+    });
+
+    const { listeners } = mockPushListeners();
+
+    pushNotificationsMock.register.mockImplementation(async () => {
+      listeners.get('registration')?.({
+        value: 'fcm-token-priority-action-ignore',
+      });
+    });
+
+    const service = TestBed.inject(MobilePushNotificationsService);
+    await service.initialize();
+
+    listeners.get('pushNotificationActionPerformed')?.({
+      notification: {
+        data: {
+          announcementId: 123,
+          priority: 'critical',
+        },
+      },
+    });
+
+    expect(service.lastPriorityAnnouncementPush()).toBeNull();
+    expect(navigateByUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('Given a priority payload with an empty announcement id, when a notification is received, then the payload is ignored', async () => {
+    getPlatformMock.mockReturnValue('android');
+
+    pushNotificationsMock.checkPermissions.mockResolvedValue({
+      receive: 'granted',
+    });
+
+    const { listeners } = mockPushListeners();
+
+    pushNotificationsMock.register.mockImplementation(async () => {
+      listeners.get('registration')?.({
+        value: 'fcm-token-priority-empty-id',
+      });
+    });
+
+    const service = TestBed.inject(MobilePushNotificationsService);
+    await service.initialize();
+
+    listeners.get('pushNotificationReceived')?.({
+      data: {
+        announcementId: '   ',
+        priority: 'high',
+      },
+    });
+
+    expect(service.lastPriorityAnnouncementPush()).toBeNull();
+  });
+
   it('Given permission is prompted then granted, when registration succeeds, then the FCM token is exposed', async () => {
     getPlatformMock.mockReturnValue('ios');
 

--- a/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts
+++ b/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts
@@ -2,10 +2,13 @@
 
 import { inject, Injectable, signal } from '@angular/core';
 import {
+  type ActionPerformed,
+  type PushNotificationSchema,
   PushNotifications,
   type PermissionStatus,
   type Token,
 } from '@capacitor/push-notifications';
+import { Router } from '@angular/router';
 import { environment } from '../../environments/environment';
 
 const FCM_REGISTRATION_TIMEOUT_MS = 5000;
@@ -24,20 +27,32 @@ interface TokenResolutionResult {
   reason: string;
 }
 
+type AnnouncementPriority = 'high' | 'critical';
+
+interface PriorityAnnouncementPush {
+  announcementId: string;
+  priority: AnnouncementPriority;
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class MobilePushNotificationsService {
+  private readonly router = inject(Router, { optional: true });
   private readonly currentTokenState = signal<string | null>(null);
   private readonly currentStatusState =
     signal<PushInitializationStatus>('stub');
   private readonly currentReasonState = signal<string>('not-initialized');
+  private readonly lastPriorityAnnouncementPushState =
+    signal<PriorityAnnouncementPush | null>(null);
   private initializationPromise: Promise<PushInitializationResult> | null =
     null;
 
   readonly currentToken = this.currentTokenState.asReadonly();
   readonly currentStatus = this.currentStatusState.asReadonly();
   readonly currentReason = this.currentReasonState.asReadonly();
+  readonly lastPriorityAnnouncementPush =
+    this.lastPriorityAnnouncementPushState.asReadonly();
 
   initialize(): Promise<PushInitializationResult> {
     this.initializationPromise ??= this.initializeInternal();
@@ -113,11 +128,15 @@ export class MobilePushNotificationsService {
     );
     await PushNotifications.addListener(
       'pushNotificationReceived',
-      () => undefined,
+      (notification: PushNotificationSchema) => {
+        this.handlePriorityAnnouncementPush(notification.data);
+      },
     );
     await PushNotifications.addListener(
       'pushNotificationActionPerformed',
-      () => undefined,
+      (action: ActionPerformed) => {
+        this.handlePriorityAnnouncementAction(action);
+      },
     );
 
     try {
@@ -180,6 +199,66 @@ export class MobilePushNotificationsService {
 
   private buildStubToken(reason: string): string {
     return `stub-mobile-token-${environment.environmentName}-${reason}`;
+  }
+
+  private handlePriorityAnnouncementAction(action: ActionPerformed): void {
+    const matchedPush = this.resolvePriorityAnnouncementPush(
+      action.notification.data,
+    );
+
+    if (matchedPush === null) {
+      return;
+    }
+
+    this.lastPriorityAnnouncementPushState.set(matchedPush);
+    void this.router
+      ?.navigateByUrl(
+        `/tabs/annonces/${encodeURIComponent(matchedPush.announcementId)}`,
+      )
+      .catch(() => undefined);
+  }
+
+  private handlePriorityAnnouncementPush(data: unknown): void {
+    const matchedPush = this.resolvePriorityAnnouncementPush(data);
+
+    if (matchedPush !== null) {
+      this.lastPriorityAnnouncementPushState.set(matchedPush);
+    }
+  }
+
+  private resolvePriorityAnnouncementPush(
+    data: unknown,
+  ): PriorityAnnouncementPush | null {
+    if (data === null || typeof data !== 'object') {
+      return null;
+    }
+
+    let rawAnnouncementId: unknown;
+    if ('announcementId' in data) {
+      rawAnnouncementId = data.announcementId;
+    } else if ('announcement_id' in data) {
+      rawAnnouncementId = data.announcement_id;
+    }
+
+    const rawPriority = 'priority' in data ? data.priority : undefined;
+
+    if (typeof rawAnnouncementId !== 'string') {
+      return null;
+    }
+
+    if (rawPriority !== 'high' && rawPriority !== 'critical') {
+      return null;
+    }
+
+    const announcementId = rawAnnouncementId.trim();
+    if (announcementId.length === 0) {
+      return null;
+    }
+
+    return {
+      announcementId,
+      priority: rawPriority,
+    };
   }
 
   private resolveCapacitorPlatform(): string {

--- a/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts
+++ b/apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts
@@ -211,11 +211,11 @@ export class MobilePushNotificationsService {
     }
 
     this.lastPriorityAnnouncementPushState.set(matchedPush);
-    void this.router
-      ?.navigateByUrl(
-        `/tabs/annonces/${encodeURIComponent(matchedPush.announcementId)}`,
-      )
-      .catch(() => undefined);
+    const navigationPromise = this.router?.navigateByUrl(
+      `/tabs/annonces/${encodeURIComponent(matchedPush.announcementId)}`,
+    );
+
+    void navigationPromise?.catch(() => undefined);
   }
 
   private handlePriorityAnnouncementPush(data: unknown): void {

--- a/docs/runbooks/MOBILE_BUILD.md
+++ b/docs/runbooks/MOBILE_BUILD.md
@@ -149,7 +149,11 @@ Verification rapide :
 pnpm --filter @kraak/client test:mobile
 ```
 
-Note : le service est un wiring initial. L'envoi de notifications business et la navigation ciblee depuis une notification seront traites dans les taches suivantes.
+ANN-04 (notification push annonce prioritaire) ajoute sur ce wiring :
+
+- detection des payloads `priority` en `high` ou `critical` pour les annonces
+- conservation du dernier payload prioritaire recu via le signal `lastPriorityAnnouncementPush`
+- navigation automatique vers `/tabs/annonces/:announcementId` lors de l'action utilisateur sur la notification
 
 ---
 


### PR DESCRIPTION
## Summary
Implement ANN-04 using MOB-05 and ANN-02: detect priority announcement pushes (high/critical) and route to announcement detail.

## Changes
- Add robust payload parsing for announcementId/announcement_id + priority in mobile push service
- Store last matched priority push in lastPriorityAnnouncementPush
- Navigate to /tabs/annonces/:announcementId on push action
- Add unit tests for high/critical, non-priority ignore, and tap navigation
- Update mobile runbook documentation for ANN-04

## Dependencies
- MOB-05 satisfied via existing MobilePushNotificationsService wiring
- ANN-02 satisfied via existing announcements feed/detail flow and route

## Validation
- pnpm --filter @kraak/client test:mobile
- Pre-push hooks succeeded: mobile unit tests + Playwright E2E (14/14)

Closes #106
