### PR TITLE
[TASK][SUP-02] Integrer formulaire support dans mobile (#108)

### DIFF
--- a/apps/client/projects/mobile/src/app/features/support/mobile-support.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/support/mobile-support.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ContactFormDto } from '@kraak/contracts';
+import { MobileAuthService } from '../../features/auth/mobile-auth.service';
+import { MobileSupportService } from './mobile-support.service';
+
+const contactClientMock = { submit: vi.fn() };
+
+vi.mock('@kraak/api-client', () => ({
+  createApiClient: vi.fn(() => ({
+    contact: contactClientMock,
+  })),
+}));
+
+describe('MobileSupportService', () => {
+  const authServiceMock = {
+    currentSession: vi.fn(() => ({ accessToken: 'test-token' })),
+  };
+
+  beforeEach(() => {
+    contactClientMock.submit.mockReset();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MobileSupportService,
+        { provide: MobileAuthService, useValue: authServiceMock },
+      ],
+    });
+  });
+
+  it('should be created', () => {
+    const service = TestBed.inject(MobileSupportService);
+    expect(service).toBeTruthy();
+  });
+
+  it('Given a valid contact form payload, when submitContactForm is called, then it delegates to the contact client', async () => {
+    const service = TestBed.inject(MobileSupportService);
+    const payload: ContactFormDto = {
+      name: 'Alice Dupont',
+      email: 'alice@kraak.org',
+      subject: 'Problème de connexion',
+      message: 'Je ne parviens pas à accéder à mon espace participant.',
+      category: 'technical',
+    };
+
+    contactClientMock.submit.mockResolvedValue({
+      success: true,
+      message: 'Votre demande a bien été reçue.',
+    });
+
+    const result = await service.submitContactForm(payload);
+
+    expect(contactClientMock.submit).toHaveBeenCalledWith(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('Given a failing API call, when submitContactForm is called, then it propagates the error', async () => {
+    const service = TestBed.inject(MobileSupportService);
+    const payload: ContactFormDto = {
+      name: 'Bob Martin',
+      email: 'bob@kraak.org',
+      subject: 'Question programme',
+      message: 'Quand commence la prochaine session de formation ?',
+      category: 'program',
+    };
+
+    contactClientMock.submit.mockRejectedValue(new Error('Network error'));
+
+    await expect(service.submitContactForm(payload)).rejects.toThrow(
+      'Network error',
+    );
+  });
+});

--- a/apps/client/projects/mobile/src/app/features/support/mobile-support.service.ts
+++ b/apps/client/projects/mobile/src/app/features/support/mobile-support.service.ts
@@ -1,0 +1,23 @@
+import { inject, Injectable } from '@angular/core';
+import { createApiClient } from '@kraak/api-client';
+import type {
+  ContactFormDto,
+  ContactSubmissionResultDto,
+} from '@kraak/contracts';
+import { environment } from '../../../environments/environment';
+import { MobileAuthService } from '../../features/auth/mobile-auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MobileSupportService {
+  private readonly authService = inject(MobileAuthService);
+  private readonly client = createApiClient({
+    baseUrl: environment.apiBaseUrl,
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  });
+
+  submitContactForm(body: ContactFormDto): Promise<ContactSubmissionResultDto> {
+    return this.client.contact.submit(body);
+  }
+}

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.html
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.html
@@ -1,14 +1,143 @@
 <kraak-page-shell
   eyebrow="Support"
   title="Nouvelle demande"
-  description="Préparez votre demande d'accompagnement dans un écran dédié."
+  description="Décrivez votre besoin et notre équipe vous répondra dans les plus brefs délais."
   backHref="/tabs/support"
 >
   <section
-    class="rounded-card border-brand-blue/12 bg-brand-white shadow-card border p-5"
+    class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
   >
-    <p class="text-sm leading-6 text-neutral-700">
-      Le formulaire mobile sera branché ici dans la suite du parcours support.
-    </p>
+    <form
+      [formGroup]="form"
+      (ngSubmit)="submit()"
+      class="flex flex-col gap-4"
+      novalidate
+    >
+      <!-- Nom -->
+      <div class="flex flex-col gap-2">
+        <label
+          for="support-name"
+          class="text-sm font-semibold text-neutral-900"
+        >
+          Nom complet
+        </label>
+        <input
+          id="support-name"
+          type="text"
+          formControlName="name"
+          autocomplete="name"
+          placeholder="Alice Dupont"
+          class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
+        />
+        @if (form.controls.name.touched && form.controls.name.invalid) {
+          <p class="text-sm leading-6 text-rose-700">
+            Le nom est requis (2 à 80 caractères).
+          </p>
+        }
+      </div>
+
+      <!-- Email -->
+      <div class="flex flex-col gap-2">
+        <label
+          for="support-email"
+          class="text-sm font-semibold text-neutral-900"
+        >
+          Adresse email
+        </label>
+        <input
+          id="support-email"
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          placeholder="vous@kraak.org"
+          class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
+        />
+        @if (form.controls.email.touched && form.controls.email.invalid) {
+          <p class="text-sm leading-6 text-rose-700">
+            Saisissez une adresse email valide.
+          </p>
+        }
+      </div>
+
+      <!-- Catégorie -->
+      <div class="flex flex-col gap-2">
+        <label
+          for="support-category"
+          class="text-sm font-semibold text-neutral-900"
+        >
+          Catégorie
+        </label>
+        <select
+          id="support-category"
+          formControlName="category"
+          class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
+        >
+          @for (option of categoryOptions; track option.value) {
+            <option [value]="option.value">{{ option.label }}</option>
+          }
+        </select>
+      </div>
+
+      <!-- Objet -->
+      <div class="flex flex-col gap-2">
+        <label
+          for="support-subject"
+          class="text-sm font-semibold text-neutral-900"
+        >
+          Objet
+        </label>
+        <input
+          id="support-subject"
+          type="text"
+          formControlName="subject"
+          placeholder="Résumez votre demande en quelques mots"
+          class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
+        />
+        @if (form.controls.subject.touched && form.controls.subject.invalid) {
+          <p class="text-sm leading-6 text-rose-700">
+            L'objet est requis (3 à 120 caractères).
+          </p>
+        }
+      </div>
+
+      <!-- Message -->
+      <div class="flex flex-col gap-2">
+        <label
+          for="support-message"
+          class="text-sm font-semibold text-neutral-900"
+        >
+          Message
+        </label>
+        <textarea
+          id="support-message"
+          formControlName="message"
+          rows="5"
+          placeholder="Décrivez votre demande en détail…"
+          class="rounded-card border-brand-blue/12 focus:border-brand-blue resize-none border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
+        ></textarea>
+        @if (form.controls.message.touched && form.controls.message.invalid) {
+          <p class="text-sm leading-6 text-rose-700">
+            Le message est requis (10 à 2 000 caractères).
+          </p>
+        }
+      </div>
+
+      @if (errorMessage()) {
+        <p
+          class="rounded-card bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-700"
+        >
+          {{ errorMessage() }}
+        </p>
+      }
+
+      <ion-button
+        type="submit"
+        expand="block"
+        class="kraak-primary-button"
+        [disabled]="submitting()"
+      >
+        {{ submitting() ? 'Envoi en cours...' : 'Envoyer la demande' }}
+      </ion-button>
+    </form>
   </section>
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.spec.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
+import { ApiError } from '@kraak/api-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MobileSupportService } from './mobile-support.service';
 import SupportRequestPage from './support-request.page';
@@ -107,6 +108,30 @@ describe('Mobile SupportRequestPage', () => {
     await fixture.componentInstance.submit();
 
     expect(fixture.componentInstance.errorMessage()).toBeTruthy();
+    expect(navigateByUrlSpy).not.toHaveBeenCalled();
+  });
+
+  it('Given an API validation error payload, when submit is called, then the backend message is surfaced to the user', async () => {
+    const fixture = TestBed.createComponent(SupportRequestPage);
+    supportService.submitContactForm.mockRejectedValue(
+      new ApiError(400, 'Bad Request', {
+        errors: ['Le message doit contenir au moins 10 caractères.'],
+      }),
+    );
+
+    fixture.componentInstance.form.setValue({
+      name: 'Bob Martin',
+      email: 'bob@kraak.org',
+      subject: 'Question sur un programme',
+      message: 'Quand commence la prochaine session de formation ?',
+      category: 'program',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(fixture.componentInstance.errorMessage()).toBe(
+      'Le message doit contenir au moins 10 caractères.',
+    );
     expect(navigateByUrlSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.spec.ts
@@ -1,14 +1,38 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { provideRouter, Router } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileSupportService } from './mobile-support.service';
 import SupportRequestPage from './support-request.page';
 
 describe('Mobile SupportRequestPage', () => {
+  const supportService = {
+    submitContactForm: vi.fn(),
+  };
+
+  let router: Router;
+  let navigateByUrlSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(async () => {
+    supportService.submitContactForm.mockReset();
+    supportService.submitContactForm.mockResolvedValue({
+      success: true,
+      message: 'Votre demande a bien été reçue.',
+    });
+
     await TestBed.configureTestingModule({
       imports: [SupportRequestPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        provideRouter([]),
+        { provide: MobileSupportService, useValue: supportService },
+      ],
     }).compileComponents();
+
+    router = TestBed.inject(Router);
+    navigateByUrlSpy = vi
+      .spyOn(router, 'navigateByUrl')
+      .mockResolvedValue(true);
   });
 
   it('should create', () => {
@@ -22,5 +46,67 @@ describe('Mobile SupportRequestPage', () => {
 
     const title = fixture.nativeElement.querySelector('ion-title');
     expect(title?.textContent).toContain('Nouvelle demande');
+  });
+
+  it('Given the support request form, when the page renders, then all form fields are visible', () => {
+    const fixture = TestBed.createComponent(SupportRequestPage);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('#support-name')).toBeTruthy();
+    expect(element.querySelector('#support-email')).toBeTruthy();
+    expect(element.querySelector('#support-category')).toBeTruthy();
+    expect(element.querySelector('#support-subject')).toBeTruthy();
+    expect(element.querySelector('#support-message')).toBeTruthy();
+  });
+
+  it('Given a fully valid form, when submit is called, then the support service is called with trimmed values and the app navigates back', async () => {
+    const fixture = TestBed.createComponent(SupportRequestPage);
+    fixture.componentInstance.form.setValue({
+      name: '  Alice Dupont  ',
+      email: '  alice@kraak.org  ',
+      subject: 'Problème de connexion',
+      message: 'Je ne parviens pas à accéder à mon espace participant.',
+      category: 'technical',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(supportService.submitContactForm).toHaveBeenCalledWith({
+      name: 'Alice Dupont',
+      email: 'alice@kraak.org',
+      subject: 'Problème de connexion',
+      message: 'Je ne parviens pas à accéder à mon espace participant.',
+      category: 'technical',
+    });
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/tabs/support');
+  });
+
+  it('Given an invalid form (empty fields), when submit is called, then the service is not called', async () => {
+    const fixture = TestBed.createComponent(SupportRequestPage);
+
+    await fixture.componentInstance.submit();
+
+    expect(supportService.submitContactForm).not.toHaveBeenCalled();
+  });
+
+  it('Given a service error, when submit is called, then the error message is set and navigation does not occur', async () => {
+    const fixture = TestBed.createComponent(SupportRequestPage);
+    supportService.submitContactForm.mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    fixture.componentInstance.form.setValue({
+      name: 'Bob Martin',
+      email: 'bob@kraak.org',
+      subject: 'Question sur un programme',
+      message: 'Quand commence la prochaine session de formation ?',
+      category: 'program',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(fixture.componentInstance.errorMessage()).toBeTruthy();
+    expect(navigateByUrlSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.ts
@@ -6,7 +6,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { Router } from '@angular/router';
-import { IonButton, IonSelectOption } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular/standalone';
 import type { SupportCategoryValue } from '@kraak/contracts';
 import { ApiError } from '@kraak/api-client';
 import { PageShell } from '../../shared/page-shell/page-shell';
@@ -23,7 +23,7 @@ interface SupportRequestFormModel {
 @Component({
   selector: 'kraak-support-request-page',
   standalone: true,
-  imports: [PageShell, ReactiveFormsModule, IonButton, IonSelectOption],
+  imports: [PageShell, ReactiveFormsModule, IonButton],
   templateUrl: './support-request.page.html',
 })
 export default class SupportRequestPage {

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.ts
@@ -1,10 +1,130 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { Router } from '@angular/router';
+import { IonButton, IonSelectOption } from '@ionic/angular/standalone';
+import type { SupportCategoryValue } from '@kraak/contracts';
+import { ApiError } from '@kraak/api-client';
 import { PageShell } from '../../shared/page-shell/page-shell';
+import { MobileSupportService } from './mobile-support.service';
+
+interface SupportRequestFormModel {
+  name: FormControl<string>;
+  email: FormControl<string>;
+  subject: FormControl<string>;
+  message: FormControl<string>;
+  category: FormControl<SupportCategoryValue>;
+}
 
 @Component({
   selector: 'kraak-support-request-page',
   standalone: true,
-  imports: [PageShell],
+  imports: [PageShell, ReactiveFormsModule, IonButton, IonSelectOption],
   templateUrl: './support-request.page.html',
 })
-export default class SupportRequestPage {}
+export default class SupportRequestPage {
+  private readonly supportService = inject(MobileSupportService);
+  private readonly router = inject(Router);
+
+  readonly form = new FormGroup<SupportRequestFormModel>({
+    name: new FormControl('', {
+      nonNullable: true,
+      validators: [
+        Validators.required,
+        Validators.minLength(2),
+        Validators.maxLength(80),
+      ],
+    }),
+    email: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.email],
+    }),
+    subject: new FormControl('', {
+      nonNullable: true,
+      validators: [
+        Validators.required,
+        Validators.minLength(3),
+        Validators.maxLength(120),
+      ],
+    }),
+    message: new FormControl('', {
+      nonNullable: true,
+      validators: [
+        Validators.required,
+        Validators.minLength(10),
+        Validators.maxLength(2000),
+      ],
+    }),
+    category: new FormControl<SupportCategoryValue>('other', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  readonly submitting = signal(false);
+  readonly successMessage = signal<string | null>(null);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly categoryOptions: { value: SupportCategoryValue; label: string }[] = [
+    { value: 'technical', label: 'Problème technique' },
+    { value: 'program', label: 'Question sur un programme' },
+    { value: 'session', label: 'Question sur une session' },
+    { value: 'billing', label: 'Facturation' },
+    { value: 'other', label: 'Autre' },
+  ];
+
+  async submit(): Promise<void> {
+    normalizeTextControls(this.form);
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid || this.submitting()) {
+      return;
+    }
+
+    this.submitting.set(true);
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+
+    try {
+      const result = await this.supportService.submitContactForm(
+        this.form.getRawValue(),
+      );
+
+      this.successMessage.set(result.message);
+      this.form.reset({ category: 'other' });
+
+      await this.router.navigateByUrl('/tabs/support');
+    } catch (error) {
+      this.errorMessage.set(resolveSupportErrorMessage(error));
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+}
+
+function normalizeTextControls(
+  form: FormGroup<{
+    name: FormControl<string>;
+    email: FormControl<string>;
+    subject: FormControl<string>;
+    message: FormControl<string>;
+    category: FormControl<SupportCategoryValue>;
+  }>,
+): void {
+  const { name, email, subject, message } = form.controls;
+  name.setValue(name.getRawValue().trim());
+  email.setValue(email.getRawValue().trim());
+  subject.setValue(subject.getRawValue().trim());
+  message.setValue(message.getRawValue().trim());
+}
+
+function resolveSupportErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 400) {
+    return 'Les informations saisies sont invalides. Veuillez vérifier le formulaire.';
+  }
+  return 'Une erreur est survenue. Veuillez réessayer ultérieurement.';
+}

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.ts
@@ -66,7 +66,6 @@ export default class SupportRequestPage {
   });
 
   readonly submitting = signal(false);
-  readonly successMessage = signal<string | null>(null);
   readonly errorMessage = signal<string | null>(null);
 
   readonly categoryOptions: { value: SupportCategoryValue; label: string }[] = [
@@ -86,15 +85,11 @@ export default class SupportRequestPage {
     }
 
     this.submitting.set(true);
-    this.successMessage.set(null);
     this.errorMessage.set(null);
 
     try {
-      const result = await this.supportService.submitContactForm(
-        this.form.getRawValue(),
-      );
+      await this.supportService.submitContactForm(this.form.getRawValue());
 
-      this.successMessage.set(result.message);
       this.form.reset({ category: 'other' });
 
       await this.router.navigateByUrl('/tabs/support');
@@ -123,8 +118,91 @@ function normalizeTextControls(
 }
 
 function resolveSupportErrorMessage(error: unknown): string {
-  if (error instanceof ApiError && error.status === 400) {
-    return 'Les informations saisies sont invalides. Veuillez vérifier le formulaire.';
+  if (error instanceof ApiError) {
+    const body = error.body as
+      | {
+          message?: unknown;
+          errors?: unknown;
+        }
+      | undefined;
+
+    const message = readSupportErrorBody(body);
+
+    if (message !== null) {
+      return message;
+    }
+
+    if (typeof error.message === 'string' && error.message.trim() !== '') {
+      return error.message.trim();
+    }
+
+    if (error.status === 400) {
+      return 'Les informations saisies sont invalides. Veuillez vérifier le formulaire.';
+    }
   }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string' &&
+    error.message.trim() !== ''
+  ) {
+    return error.message.trim();
+  }
+
   return 'Une erreur est survenue. Veuillez réessayer ultérieurement.';
+}
+
+function readSupportErrorBody(
+  body:
+    | {
+        message?: unknown;
+        errors?: unknown;
+      }
+    | undefined,
+): string | null {
+  if (typeof body?.message === 'string' && body.message.trim() !== '') {
+    return body.message.trim();
+  }
+
+  if (typeof body?.errors === 'string' && body.errors.trim() !== '') {
+    return body.errors.trim();
+  }
+
+  if (Array.isArray(body?.errors)) {
+    const messages = body.errors
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => value.trim())
+      .filter((value) => value !== '');
+
+    if (messages.length > 0) {
+      return messages.join('\n');
+    }
+  }
+
+  if (body?.errors && typeof body.errors === 'object') {
+    const messages = Object.values(body.errors)
+      .flatMap((value) => {
+        if (typeof value === 'string') {
+          return [value];
+        }
+
+        if (Array.isArray(value)) {
+          return value.filter(
+            (item): item is string => typeof item === 'string',
+          );
+        }
+
+        return [];
+      })
+      .map((value) => value.trim())
+      .filter((value) => value !== '');
+
+    if (messages.length > 0) {
+      return messages.join('\n');
+    }
+  }
+
+  return null;
 }

--- a/packages/api-client/src/client.spec.ts
+++ b/packages/api-client/src/client.spec.ts
@@ -31,13 +31,14 @@ function baseConfig(overrides?: Partial<ApiClientConfig>): ApiClientConfig {
 // ---------------------------------------------------------------------------
 
 describe('createApiClient', () => {
-  it('retourne un objet avec les 13 groupes de ressources', () => {
+  it('retourne un objet avec les 14 groupes de ressources', () => {
     const client = createApiClient(baseConfig());
     const keys = Object.keys(client).sort((a, b) => a.localeCompare(b));
     expect(keys).toEqual([
       'announcements',
       'auth',
       'cohorts',
+      'contact',
       'dashboard',
       'enrollments',
       'notifications',
@@ -98,6 +99,11 @@ describe('createApiClient', () => {
   it('dashboard expose getAggregate', () => {
     const client = createApiClient(baseConfig());
     expect(typeof client.dashboard.getAggregate).toBe('function');
+  });
+
+  it('contact expose submit', () => {
+    const client = createApiClient(baseConfig());
+    expect(typeof client.contact.submit).toBe('function');
   });
 });
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -41,6 +41,8 @@ import type {
   ParticipantProgramListItemDto,
   MarkProgramSessionProgressRequestDto,
   MarkProgramSessionProgressResponseDto,
+  ContactFormDto,
+  ContactSubmissionResultDto,
 } from '@kraak/contracts';
 
 // ---------------------------------------------------------------------------
@@ -103,6 +105,13 @@ export interface AuthClient {
   getSession(options?: RequestOptions): Promise<AuthSessionContextDto>;
 }
 
+export interface ContactClient {
+  submit(
+    body: ContactFormDto,
+    options?: RequestOptions,
+  ): Promise<ContactSubmissionResultDto>;
+}
+
 export interface DashboardClient {
   getAggregate(options?: RequestOptions): Promise<DashboardAggregateDto>;
 }
@@ -126,6 +135,7 @@ export interface ParticipantProgramsClient {
 
 export interface ApiClient {
   auth: AuthClient;
+  contact: ContactClient;
   dashboard: DashboardClient;
   participantPrograms: ParticipantProgramsClient;
   users: FullResourceClient<AppUserDto, CreateAppUserDto, UpdateAppUserDto>;
@@ -322,6 +332,19 @@ function createAuthClient(config: ApiClientConfig): AuthClient {
   };
 }
 
+function createContactClient(config: ApiClientConfig): ContactClient {
+  return {
+    submit: (body, options?) =>
+      request<ContactSubmissionResultDto>(
+        config,
+        'POST',
+        '/support/contact',
+        body,
+        options,
+      ),
+  };
+}
+
 function createDashboardClient(config: ApiClientConfig): DashboardClient {
   return {
     getAggregate: (options?) =>
@@ -373,6 +396,7 @@ function createParticipantProgramsClient(
 export function createApiClient(config: ApiClientConfig): ApiClient {
   return {
     auth: createAuthClient(config),
+    contact: createContactClient(config),
     dashboard: createDashboardClient(config),
     participantPrograms: createParticipantProgramsClient(config),
     users: createFullResourceClient(config, '/users'),

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -2,6 +2,7 @@ export { createApiClient, ApiError } from './client.js';
 export type {
   ApiClient,
   AuthClient,
+  ContactClient,
   DashboardClient,
   ApiClientConfig,
   RequestOptions,


### PR DESCRIPTION
## Summary

Implements SUP-02 by wiring the mobile support request form to the existing support/contact API.

## Changes

- **Mobile support flow (`apps/client/projects/mobile`)**
  - Replaced the support request placeholder screen with a full reactive form.
  - Added fields for `name`, `email`, `category`, `subject`, and `message`.
  - Added client-side validation, trimmed input normalization, submit/loading/error state handling, and return navigation to the support hub after success.
  - Added `MobileSupportService` to encapsulate the mobile submission call.
  - Added and expanded unit specs for the service and support request page.

- **API client (`packages/api-client`)**
  - Added a `contact` client group with `submit()` mapped to `POST /support/contact`.
  - Exported the new `ContactClient` type.
  - Updated API client specs to cover the added client surface.

## Related

Closes #108
Depends on: MOB-02, SUP-01, AUT-04

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Mobile MVP functionality
- [x] Shared API client update

## Testing

- `pnpm --filter @kraak/api-client test`
- `pnpm ng test mobile --watch=false`
- Push hook validation passed:
  - `pnpm typecheck:web`
  - `pnpm typecheck:mobile`
  - `pnpm typecheck:api`
  - `prettier --check`
  - repo test pipeline including mobile tests and web Playwright E2E
