### PR TITLE
[TASK][SUP-05] Ajouter suivi et statut basique des demandes support

### DIFF
--- a/apps/api/src/support/support-requests.controller.spec.ts
+++ b/apps/api/src/support/support-requests.controller.spec.ts
@@ -1,0 +1,102 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SupportRequestsController } from './support-requests.controller';
+import { SupportService } from './support.service';
+
+describe('SupportRequestsController', () => {
+  let controller: SupportRequestsController;
+
+  const supportService = {
+    listSupportRequests: jest.fn(),
+    updateSupportRequestStatus: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    supportService.listSupportRequests.mockReset();
+    supportService.updateSupportRequestStatus.mockReset();
+
+    supportService.listSupportRequests.mockResolvedValue([
+      {
+        id: 'req-1',
+        userId: 'user-1',
+        participantId: 'participant-1',
+        subject: 'Connexion impossible',
+        message: 'Je ne peux plus acceder a mon espace.',
+        status: 'open',
+        category: 'technical',
+        assignedToUserId: null,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        updatedAt: '2026-04-29T10:00:00.000Z',
+      },
+    ]);
+
+    supportService.updateSupportRequestStatus.mockResolvedValue({
+      id: 'req-1',
+      userId: 'user-1',
+      participantId: 'participant-1',
+      subject: 'Connexion impossible',
+      message: 'Je ne peux plus acceder a mon espace.',
+      status: 'in_progress',
+      category: 'technical',
+      assignedToUserId: 'admin-1',
+      createdAt: '2026-04-29T10:00:00.000Z',
+      updatedAt: '2026-04-29T10:05:00.000Z',
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SupportRequestsController],
+      providers: [
+        {
+          provide: SupportService,
+          useValue: supportService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SupportRequestsController>(
+      SupportRequestsController,
+    );
+  });
+
+  it('devrait etre defini', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('Given un header Bearer valide, When la liste est demandee, Then le token est transmis au service', async () => {
+    await controller.list('Bearer access-token');
+
+    expect(supportService.listSupportRequests).toHaveBeenCalledWith(
+      'access-token',
+    );
+  });
+
+  it('Given un header absent, When la liste est demandee, Then une UnauthorizedException est renvoyee', async () => {
+    await expect(controller.list(undefined)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('Given un payload de statut valide, When updateStatus est appele, Then le service est invoque avec token et payload normalise', async () => {
+    await controller.updateStatus(
+      'req-1',
+      { status: ' in_progress ' },
+      'Bearer access-token',
+    );
+
+    expect(supportService.updateSupportRequestStatus).toHaveBeenCalledWith(
+      'req-1',
+      { status: 'in_progress' },
+      'access-token',
+    );
+  });
+
+  it('Given un payload invalide, When updateStatus est appele, Then une BadRequestException est renvoyee', async () => {
+    await expect(
+      controller.updateStatus(
+        'req-1',
+        { status: 'pending' },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/api/src/support/support-requests.controller.ts
+++ b/apps/api/src/support/support-requests.controller.ts
@@ -1,0 +1,173 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Headers,
+  Param,
+  Patch,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { SupportRequestDto } from '@kraak/contracts';
+import { extractAccessToken } from '../auth/auth.dto';
+import { validateSupportStatusUpdatePayload } from './support.dto';
+import { SupportService } from './support.service';
+
+const apiErrorSchema = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', example: false },
+    message: { type: 'string' },
+    errors: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+const supportRequestSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'userId',
+    'participantId',
+    'subject',
+    'message',
+    'status',
+    'category',
+    'assignedToUserId',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    userId: { type: 'string' },
+    participantId: { type: 'string', nullable: true },
+    subject: { type: 'string' },
+    message: { type: 'string' },
+    status: {
+      type: 'string',
+      enum: ['open', 'in_progress', 'resolved', 'closed'],
+    },
+    category: {
+      type: 'string',
+      enum: ['technical', 'program', 'session', 'billing', 'other'],
+    },
+    assignedToUserId: { type: 'string', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+@ApiTags('Support')
+@Controller('support/requests')
+export class SupportRequestsController {
+  constructor(private readonly supportService: SupportService) {}
+
+  @Get()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Lister les demandes de support et leur statut' })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste des demandes de support récupérée',
+    schema: {
+      type: 'array',
+      items: supportRequestSchema,
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Session invalide ou header Authorization manquant',
+    schema: apiErrorSchema,
+  })
+  async list(
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<SupportRequestDto[]> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.supportService.listSupportRequests(accessToken.data);
+  }
+
+  @Patch(':id/status')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: "Mettre à jour le statut d'une demande de support",
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['status'],
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['open', 'in_progress', 'resolved', 'closed'],
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Statut mis à jour avec succès',
+    schema: supportRequestSchema,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Payload invalide',
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Session invalide ou header Authorization manquant',
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Transition non autorisée ou droits insuffisants',
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Demande introuvable',
+    schema: apiErrorSchema,
+  })
+  async updateStatus(
+    @Param('id') requestId: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<SupportRequestDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const payload = validateSupportStatusUpdatePayload(body);
+
+    if (!payload.valid) {
+      throw new BadRequestException({
+        success: false,
+        errors: payload.errors,
+      });
+    }
+
+    return this.supportService.updateSupportRequestStatus(
+      requestId,
+      payload.data,
+      accessToken.data,
+    );
+  }
+}

--- a/apps/api/src/support/support.controller.spec.ts
+++ b/apps/api/src/support/support.controller.spec.ts
@@ -59,13 +59,16 @@ describe('SupportController', () => {
       message: '  Bonjour, je souhaite en savoir plus sur vos services.  ',
     });
 
-    expect(supportService.submitContact).toHaveBeenCalledWith({
-      name: 'Alice Dupont',
-      email: 'alice@exemple.com',
-      subject: 'Demande de renseignements',
-      message: 'Bonjour, je souhaite en savoir plus sur vos services.',
-      category: 'other',
-    });
+    expect(supportService.submitContact).toHaveBeenCalledWith(
+      {
+        name: 'Alice Dupont',
+        email: 'alice@exemple.com',
+        subject: 'Demande de renseignements',
+        message: 'Bonjour, je souhaite en savoir plus sur vos services.',
+        category: 'other',
+      },
+      undefined,
+    );
   });
 
   // Given un payload invalide

--- a/apps/api/src/support/support.controller.ts
+++ b/apps/api/src/support/support.controller.ts
@@ -2,12 +2,14 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Headers,
   HttpCode,
   HttpStatus,
   Post,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { ContactSubmissionResultDto } from '@kraak/contracts';
+import { extractAccessToken } from '../auth/auth.dto';
 import { SupportService } from './support.service';
 import { validateContactForm } from './support.dto';
 
@@ -46,6 +48,19 @@ export class SupportController {
       properties: {
         success: { type: 'boolean', example: true },
         message: { type: 'string' },
+        requestId: {
+          type: 'string',
+          nullable: true,
+          description:
+            'Identifiant de suivi, présent quand la demande est soumise avec une session authentifiée.',
+        },
+        requestStatus: {
+          type: 'string',
+          nullable: true,
+          enum: ['open', 'in_progress', 'resolved', 'closed'],
+          description:
+            'Statut de suivi initial, présent quand la demande est tracée.',
+        },
       },
     },
   })
@@ -59,7 +74,10 @@ export class SupportController {
       },
     },
   })
-  async submit(@Body() body: unknown): Promise<ContactSubmissionResultDto> {
+  async submit(
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ContactSubmissionResultDto> {
     const validation = validateContactForm(body);
 
     if (!validation.valid) {
@@ -69,6 +87,11 @@ export class SupportController {
       });
     }
 
-    return this.supportService.submitContact(validation.data);
+    const token = extractAccessToken(authorizationHeader);
+
+    return this.supportService.submitContact(
+      validation.data,
+      token.valid ? token.data : undefined,
+    );
   }
 }

--- a/apps/api/src/support/support.dto.spec.ts
+++ b/apps/api/src/support/support.dto.spec.ts
@@ -1,4 +1,7 @@
-import { validateContactForm } from './support.dto';
+import {
+  validateContactForm,
+  validateSupportStatusUpdatePayload,
+} from './support.dto';
 
 describe('validateContactForm', () => {
   // Given un corps de requête valide
@@ -55,6 +58,30 @@ describe('validateContactForm', () => {
     expect(validateContactForm(null)).toEqual({
       valid: false,
       errors: ['Corps de requête invalide.'],
+    });
+  });
+});
+
+describe('validateSupportStatusUpdatePayload', () => {
+  it('Given un payload de statut valide, When la validation est appliquée, Then le statut normalisé est renvoyé', () => {
+    const result = validateSupportStatusUpdatePayload({
+      status: ' in_progress ',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        status: 'in_progress',
+      },
+    });
+  });
+
+  it('Given un statut invalide, When la validation est appliquée, Then une erreur explicite est renvoyée', () => {
+    const result = validateSupportStatusUpdatePayload({ status: 'pending' });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Le statut de la demande de support est invalide.'],
     });
   });
 });

--- a/apps/api/src/support/support.dto.ts
+++ b/apps/api/src/support/support.dto.ts
@@ -1,4 +1,8 @@
-import type { ContactFormDto } from '@kraak/contracts';
+import type {
+  ContactFormDto,
+  SupportRequestStatusValue,
+  UpdateSupportRequestStatusDto,
+} from '@kraak/contracts';
 
 type ContactCategory = ContactFormDto['category'];
 
@@ -16,12 +20,33 @@ export type ContactFormValidationResult =
   | ContactFormValidationSuccess
   | ContactFormValidationFailure;
 
+type SupportStatusUpdateValidationSuccess = {
+  valid: true;
+  data: UpdateSupportRequestStatusDto;
+};
+
+type SupportStatusUpdateValidationFailure = {
+  valid: false;
+  errors: string[];
+};
+
+export type SupportStatusUpdateValidationResult =
+  | SupportStatusUpdateValidationSuccess
+  | SupportStatusUpdateValidationFailure;
+
 const supportCategories: Set<ContactCategory> = new Set([
   'technical',
   'program',
   'session',
   'billing',
   'other',
+]);
+
+const supportRequestStatuses: Set<SupportRequestStatusValue> = new Set([
+  'open',
+  'in_progress',
+  'resolved',
+  'closed',
 ]);
 
 function readTrimmedString(value: unknown): string {
@@ -34,6 +59,12 @@ function isValidEmail(email: string): boolean {
 
 function isSupportCategory(value: string): value is ContactCategory {
   return supportCategories.has(value as ContactCategory);
+}
+
+function isSupportRequestStatus(
+  value: string,
+): value is SupportRequestStatusValue {
+  return supportRequestStatuses.has(value as SupportRequestStatusValue);
 }
 
 function validateName(name: string, errors: string[]): void {
@@ -112,6 +143,30 @@ export function validateContactForm(
       message,
       category:
         rawCategory && isSupportCategory(rawCategory) ? rawCategory : 'other',
+    },
+  };
+}
+
+export function validateSupportStatusUpdatePayload(
+  body: unknown,
+): SupportStatusUpdateValidationResult {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { valid: false, errors: ['Corps de requête invalide.'] };
+  }
+
+  const status = readTrimmedString((body as Record<string, unknown>)['status']);
+
+  if (!status || !isSupportRequestStatus(status)) {
+    return {
+      valid: false,
+      errors: ['Le statut de la demande de support est invalide.'],
+    };
+  }
+
+  return {
+    valid: true,
+    data: {
+      status,
     },
   };
 }

--- a/apps/api/src/support/support.module.ts
+++ b/apps/api/src/support/support.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { SupportRequestsController } from './support-requests.controller';
 import { SupportController } from './support.controller';
 import { SupportService } from './support.service';
 
 @Module({
-  controllers: [SupportController],
+  imports: [SupabaseModule],
+  controllers: [SupportController, SupportRequestsController],
   providers: [SupportService],
 })
 export class SupportModule {}

--- a/apps/api/src/support/support.service.spec.ts
+++ b/apps/api/src/support/support.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { ForbiddenException } from '@nestjs/common';
+import { SupabaseService } from '../supabase/supabase.service';
 import { SupportService } from './support.service';
 
 const sendMock = jest.fn();
@@ -12,15 +14,71 @@ jest.mock('resend', () => ({
   })),
 }));
 
+function createQueryChain<T>(
+  result: { data: T; error: unknown },
+  operations: {
+    onEq?: (column: string, value: unknown) => void;
+  } = {},
+): {
+  select: jest.Mock;
+  eq: jest.Mock;
+  order: jest.Mock;
+  limit: jest.Mock;
+  maybeSingle: jest.Mock;
+} {
+  const chain = {
+    select: jest.fn(),
+    eq: jest.fn(),
+    order: jest.fn(),
+    limit: jest.fn(),
+    maybeSingle: jest.fn(),
+  };
+
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockImplementation((column: string, value: unknown) => {
+    operations.onEq?.(column, value);
+    return chain;
+  });
+  chain.order.mockReturnValue(chain);
+  chain.limit.mockReturnValue(chain);
+  chain.maybeSingle.mockResolvedValue(result);
+
+  Object.assign(chain, {
+    then: (resolve: (value: { data: T; error: unknown }) => unknown) =>
+      Promise.resolve(result).then(resolve),
+    catch: (reject: (reason: unknown) => unknown) =>
+      Promise.resolve(result).catch(reject),
+    finally: (handler: () => void) => Promise.resolve(result).finally(handler),
+  });
+
+  return chain;
+}
+
 describe('SupportService', () => {
   let service: SupportService;
   const configService = {
     get: jest.fn(),
   };
 
+  const authGetUserMock = jest.fn();
+  const fromMock = jest.fn();
+
+  const supabaseService = {
+    createAuthClient: jest.fn(() => ({
+      auth: {
+        getUser: authGetUserMock,
+      },
+    })),
+    getClient: jest.fn(() => ({
+      from: fromMock,
+    })),
+  };
+
   beforeEach(async () => {
     sendMock.mockReset();
     configService.get.mockReset();
+    authGetUserMock.mockReset();
+    fromMock.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -28,6 +86,10 @@ describe('SupportService', () => {
         {
           provide: ConfigService,
           useValue: configService,
+        },
+        {
+          provide: SupabaseService,
+          useValue: supabaseService,
         },
       ],
     }).compile();
@@ -39,10 +101,7 @@ describe('SupportService', () => {
     expect(service).toBeDefined();
   });
 
-  // Given un DTO de contact/support valide
-  // When on soumet la demande
-  // Then le service envoie un email transactionnel et renvoie un accusé de réception
-  it('Given une demande valide et une configuration email active, When submitContact est appelé, Then un email transactionnel est envoyé', async () => {
+  it('Given une demande valide et une configuration email active, When submitContact est appelé sans session, Then un email transactionnel est envoyé et la réponse reste positive', async () => {
     configService.get.mockImplementation((key: string) => {
       if (key === 'RESEND_API_KEY') return 're_test_key';
       if (key === 'CONTACT_TO_EMAIL') return 'contact@kraak.org';
@@ -64,6 +123,8 @@ describe('SupportService', () => {
       success: true,
       message:
         'Votre message a bien été reçu. Nous vous répondrons dans les plus brefs délais.',
+      requestId: undefined,
+      requestStatus: undefined,
     });
 
     expect(sendMock).toHaveBeenCalledWith({
@@ -75,55 +136,151 @@ describe('SupportService', () => {
     });
   });
 
-  // Given une configuration email absente
-  // When on soumet la demande
-  // Then le service conserve un accusé de réception sans appel externe
-  it('Given une configuration email absente, When submitContact est appelé, Then la réponse reste positive sans envoi externe', async () => {
+  it('Given une session authentifiée, When submitContact est appelé, Then une demande support avec statut open est stockée et renvoyée', async () => {
     configService.get.mockReturnValue(undefined);
 
+    authGetUserMock.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'app_user') {
+        return createQueryChain({
+          data: { id: 'user-1', role: 'participant' },
+          error: null,
+        });
+      }
+
+      if (table === 'participant') {
+        return createQueryChain({ data: { id: 'participant-1' }, error: null });
+      }
+
+      if (table === 'support_request') {
+        return {
+          insert: jest.fn(() => ({
+            select: jest.fn(() => ({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: {
+                  id: 'req-1',
+                  user_id: 'user-1',
+                  participant_id: 'participant-1',
+                  subject: 'Sujet test',
+                  message: 'Message test détaillé',
+                  status: 'open',
+                  category: 'technical',
+                  assigned_to_user_id: null,
+                  created_at: '2026-04-29T10:00:00.000Z',
+                  updated_at: '2026-04-29T10:00:00.000Z',
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
     await expect(
-      service.submitContact({
-        name: 'Alice Dupont',
-        email: 'alice@exemple.com',
-        subject: 'Renseignements',
-        message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
-        category: 'other',
-      }),
+      service.submitContact(
+        {
+          name: 'Alice Dupont',
+          email: 'alice@exemple.com',
+          subject: 'Sujet test',
+          message: 'Message test détaillé',
+          category: 'technical',
+        },
+        'access-token',
+      ),
     ).resolves.toEqual({
       success: true,
       message:
         'Votre message a bien été reçu. Nous vous répondrons dans les plus brefs délais.',
+      requestId: 'req-1',
+      requestStatus: 'open',
     });
-
-    expect(sendMock).not.toHaveBeenCalled();
   });
 
-  // Given une configuration email active
-  // When Resend échoue
-  // Then le service remonte une erreur serveur explicite
-  it('Given une configuration email active, When Resend échoue, Then une erreur serveur est renvoyée', async () => {
-    configService.get.mockImplementation((key: string) => {
-      if (key === 'RESEND_API_KEY') return 're_test_key';
-      if (key === 'CONTACT_TO_EMAIL') return 'contact@kraak.org';
-      return undefined;
+  it('Given un participant authentifié, When listSupportRequests est appelé, Then seules ses demandes sont renvoyées', async () => {
+    configService.get.mockReturnValue(undefined);
+    authGetUserMock.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
     });
 
-    sendMock.mockRejectedValue(new Error('network failure'));
+    let eqFilter: { column: string; value: unknown } | null = null;
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'app_user') {
+        return createQueryChain({
+          data: { id: 'user-1', role: 'participant' },
+          error: null,
+        });
+      }
+
+      if (table === 'support_request') {
+        return createQueryChain(
+          {
+            data: [
+              {
+                id: 'req-1',
+                user_id: 'user-1',
+                participant_id: 'participant-1',
+                subject: 'Sujet test',
+                message: 'Message test détaillé',
+                status: 'open',
+                category: 'technical',
+                assigned_to_user_id: null,
+                created_at: '2026-04-29T10:00:00.000Z',
+                updated_at: '2026-04-29T10:00:00.000Z',
+              },
+            ],
+            error: null,
+          },
+          {
+            onEq: (column, value) => {
+              eqFilter = { column, value };
+            },
+          },
+        );
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    const results = await service.listSupportRequests('access-token');
+
+    expect(eqFilter).toEqual({ column: 'user_id', value: 'user-1' });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe('open');
+  });
+
+  it('Given un participant, When updateSupportRequestStatus est appelé, Then une erreur de droits est renvoyée', async () => {
+    configService.get.mockReturnValue(undefined);
+    authGetUserMock.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'app_user') {
+        return createQueryChain({
+          data: { id: 'user-1', role: 'participant' },
+          error: null,
+        });
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
 
     await expect(
-      service.submitContact({
-        name: 'Alice Dupont',
-        email: 'alice@exemple.com',
-        subject: 'Renseignements',
-        message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
-        category: 'technical',
-      }),
-    ).rejects.toMatchObject({
-      response: {
-        success: false,
-        message:
-          "Votre demande a été reçue, mais l'envoi de notification a échoué. Veuillez réessayer.",
-      },
-    });
+      service.updateSupportRequestStatus(
+        'req-1',
+        { status: 'in_progress' },
+        'access-token',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 });

--- a/apps/api/src/support/support.service.ts
+++ b/apps/api/src/support/support.service.ts
@@ -1,30 +1,286 @@
 import {
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   Logger,
+  NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type {
   ContactFormDto,
   ContactSubmissionResultDto,
+  SupportRequestDto,
+  SupportRequestStatusValue,
+  UpdateSupportRequestStatusDto,
 } from '@kraak/contracts';
 import { Resend } from 'resend';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type UserRole = 'participant' | 'admin' | 'trainer';
+
+type SessionUserContext = {
+  userId: string;
+  role: UserRole;
+};
+
+type SupportRequestRow = {
+  id: string;
+  user_id: string;
+  participant_id: string | null;
+  subject: string;
+  message: string;
+  status: SupportRequestStatusValue;
+  category: ContactFormDto['category'];
+  assigned_to_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ParticipantRow = {
+  id: string;
+};
+
+const allowedStatusTransitions: Record<
+  SupportRequestStatusValue,
+  SupportRequestStatusValue[]
+> = {
+  open: ['in_progress', 'closed'],
+  in_progress: ['resolved', 'closed'],
+  resolved: ['closed'],
+  closed: [],
+};
 
 @Injectable()
 export class SupportService {
   private readonly logger = new Logger(SupportService.name);
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly supabaseService: SupabaseService,
+  ) {}
 
   async submitContact(
     dto: ContactFormDto,
+    accessToken?: string,
   ): Promise<ContactSubmissionResultDto> {
+    let trackingRequest: SupportRequestDto | null = null;
+
+    if (accessToken) {
+      trackingRequest = await this.createTrackedSupportRequest(
+        dto,
+        accessToken,
+      );
+    }
+
     await this.sendTransactionalEmail(dto);
 
     return {
       success: true,
       message:
         'Votre message a bien été reçu. Nous vous répondrons dans les plus brefs délais.',
+      requestId: trackingRequest?.id,
+      requestStatus: trackingRequest?.status,
+    };
+  }
+
+  async listSupportRequests(accessToken: string): Promise<SupportRequestDto[]> {
+    const sessionUser = await this.resolveSessionUser(accessToken);
+    const adminClient = this.supabaseService.getClient();
+    let query = adminClient
+      .from('support_request')
+      .select(
+        'id, user_id, participant_id, subject, message, status, category, assigned_to_user_id, created_at, updated_at',
+      )
+      .order('created_at', { ascending: false })
+      .limit(50);
+
+    if (sessionUser.role === 'participant') {
+      query = query.eq('user_id', sessionUser.userId);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les demandes de support.',
+      });
+    }
+
+    return ((data as SupportRequestRow[] | null) ?? []).map((row) =>
+      this.mapSupportRequest(row),
+    );
+  }
+
+  async updateSupportRequestStatus(
+    requestId: string,
+    payload: UpdateSupportRequestStatusDto,
+    accessToken: string,
+  ): Promise<SupportRequestDto> {
+    const sessionUser = await this.resolveSessionUser(accessToken);
+
+    if (sessionUser.role === 'participant') {
+      throw new ForbiddenException({
+        success: false,
+        message:
+          "Vous ne pouvez pas modifier le statut d'une demande de support.",
+      });
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data: existing, error: readError } = await adminClient
+      .from('support_request')
+      .select(
+        'id, user_id, participant_id, subject, message, status, category, assigned_to_user_id, created_at, updated_at',
+      )
+      .eq('id', requestId)
+      .maybeSingle();
+
+    if (readError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de lire la demande de support.',
+      });
+    }
+
+    if (!existing) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Demande de support introuvable.',
+      });
+    }
+
+    const currentStatus = (existing as SupportRequestRow).status;
+
+    if (currentStatus !== payload.status) {
+      const nextAllowed = allowedStatusTransitions[currentStatus];
+
+      if (!nextAllowed.includes(payload.status)) {
+        throw new BadTransitionException(currentStatus, payload.status);
+      }
+    }
+
+    const { data: updated, error: updateError } = await adminClient
+      .from('support_request')
+      .update({
+        status: payload.status,
+        assigned_to_user_id: sessionUser.userId,
+      })
+      .eq('id', requestId)
+      .select(
+        'id, user_id, participant_id, subject, message, status, category, assigned_to_user_id, created_at, updated_at',
+      )
+      .maybeSingle();
+
+    if (updateError || !updated) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de mettre à jour le statut de la demande.',
+      });
+    }
+
+    return this.mapSupportRequest(updated as SupportRequestRow);
+  }
+
+  private async createTrackedSupportRequest(
+    dto: ContactFormDto,
+    accessToken: string,
+  ): Promise<SupportRequestDto> {
+    const sessionUser = await this.resolveSessionUser(accessToken);
+    const participantId = await this.resolveParticipantId(sessionUser.userId);
+    const adminClient = this.supabaseService.getClient();
+
+    const { data, error } = await adminClient
+      .from('support_request')
+      .insert({
+        user_id: sessionUser.userId,
+        participant_id: participantId,
+        subject: dto.subject,
+        message: dto.message,
+        category: dto.category,
+        status: 'open',
+      })
+      .select(
+        'id, user_id, participant_id, subject, message, status, category, assigned_to_user_id, created_at, updated_at',
+      )
+      .maybeSingle();
+
+    if (error || !data) {
+      throw new InternalServerErrorException({
+        success: false,
+        message:
+          'Votre demande a été reçue mais son suivi est indisponible pour le moment.',
+      });
+    }
+
+    return this.mapSupportRequest(data as SupportRequestRow);
+  }
+
+  private async resolveSessionUser(
+    accessToken: string,
+  ): Promise<SessionUserContext> {
+    const authClient = this.supabaseService.createAuthClient();
+    const { data: authData, error: authError } =
+      await authClient.auth.getUser(accessToken);
+
+    if (authError || !authData.user) {
+      throw new UnauthorizedException({
+        success: false,
+        message: 'La session est invalide ou expirée.',
+      });
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data: appUser, error: appUserError } = await adminClient
+      .from('app_user')
+      .select('id, role')
+      .eq('id', authData.user.id)
+      .maybeSingle();
+
+    if (appUserError || !appUser) {
+      throw new UnauthorizedException({
+        success: false,
+        message: 'Impossible de résoudre le profil utilisateur courant.',
+      });
+    }
+
+    return {
+      userId: authData.user.id,
+      role: (appUser as { role: UserRole }).role,
+    };
+  }
+
+  private async resolveParticipantId(userId: string): Promise<string | null> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('participant')
+      .select('id')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de résoudre le participant associé.',
+      });
+    }
+
+    return (data as ParticipantRow | null)?.id ?? null;
+  }
+
+  private mapSupportRequest(row: SupportRequestRow): SupportRequestDto {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      participantId: row.participant_id,
+      subject: row.subject,
+      message: row.message,
+      status: row.status,
+      category: row.category,
+      assignedToUserId: row.assigned_to_user_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
     };
   }
 
@@ -94,5 +350,17 @@ export class SupportService {
     };
 
     return labels[category];
+  }
+}
+
+class BadTransitionException extends ForbiddenException {
+  constructor(
+    fromStatus: SupportRequestStatusValue,
+    toStatus: SupportRequestStatusValue,
+  ) {
+    super({
+      success: false,
+      message: `Transition de statut invalide: ${fromStatus} -> ${toStatus}.`,
+    });
   }
 }

--- a/apps/client/projects/mobile/src/app/features/support/mobile-support.service.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/support/mobile-support.service.spec.ts
@@ -74,4 +74,34 @@ describe('MobileSupportService', () => {
       'Network error',
     );
   });
+
+  it('Given an authenticated mobile user, when listMyRequests is called, then it fetches support request statuses', async () => {
+    const service = TestBed.inject(MobileSupportService);
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: 'req-1',
+          userId: 'user-1',
+          participantId: 'participant-1',
+          subject: 'Connexion impossible',
+          message: 'Je ne peux plus accéder à mon espace.',
+          status: 'open',
+          category: 'technical',
+          assignedToUserId: null,
+          createdAt: '2026-04-29T10:00:00.000Z',
+          updatedAt: '2026-04-29T10:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await service.listMyRequests();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/support/requests');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('open');
+  });
 });

--- a/apps/client/projects/mobile/src/app/features/support/mobile-support.service.ts
+++ b/apps/client/projects/mobile/src/app/features/support/mobile-support.service.ts
@@ -3,6 +3,7 @@ import { createApiClient } from '@kraak/api-client';
 import type {
   ContactFormDto,
   ContactSubmissionResultDto,
+  SupportRequestDto,
 } from '@kraak/contracts';
 import { environment } from '../../../environments/environment';
 import { MobileAuthService } from '../../features/auth/mobile-auth.service';
@@ -19,5 +20,9 @@ export class MobileSupportService {
 
   submitContactForm(body: ContactFormDto): Promise<ContactSubmissionResultDto> {
     return this.client.contact.submit(body);
+  }
+
+  listMyRequests(): Promise<SupportRequestDto[]> {
+    return this.client.contact.listMine();
   }
 }

--- a/apps/client/projects/mobile/src/app/features/support/support.page.html
+++ b/apps/client/projects/mobile/src/app/features/support/support.page.html
@@ -18,4 +18,42 @@
       Démarrer une demande
     </ion-button>
   </section>
+
+  <section
+    class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
+  >
+    <p class="text-sm font-semibold text-neutral-900">Suivi de vos demandes</p>
+
+    @if (loading()) {
+      <p class="text-sm leading-6 text-neutral-700">
+        Chargement des statuts en cours...
+      </p>
+    } @else if (errorMessage()) {
+      <p
+        class="rounded-card bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-700"
+      >
+        {{ errorMessage() }}
+      </p>
+    } @else if (requests().length === 0) {
+      <p class="text-sm leading-6 text-neutral-700">
+        Aucune demande de support enregistrée pour le moment.
+      </p>
+    } @else {
+      <ul class="flex flex-col gap-3">
+        @for (request of requests(); track request.id) {
+          <li class="rounded-card border-brand-blue/12 border px-4 py-3">
+            <p class="text-sm font-semibold text-neutral-900">
+              {{ request.subject }}
+            </p>
+            <p class="text-xs text-neutral-600">
+              Statut: {{ getStatusLabel(request.status) }}
+            </p>
+            <p class="text-xs text-neutral-500">
+              Mis à jour le {{ request.updatedAt | date: 'dd/MM/yyyy HH:mm' }}
+            </p>
+          </li>
+        }
+      </ul>
+    }
+  </section>
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/support/support.page.spec.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support.page.spec.ts
@@ -1,15 +1,26 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileSupportService } from './mobile-support.service';
 import SupportPage from './support.page';
-import { describe, it, beforeEach, expect } from 'vitest';
 
 describe('Mobile SupportPage', () => {
+  const supportService = {
+    listMyRequests: vi.fn(),
+  };
+
   beforeEach(async () => {
+    supportService.listMyRequests.mockReset();
+    supportService.listMyRequests.mockResolvedValue([]);
+
     await TestBed.configureTestingModule({
       imports: [SupportPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        { provide: MobileSupportService, useValue: supportService },
+      ],
     }).compileComponents();
   });
 
@@ -23,5 +34,33 @@ describe('Mobile SupportPage', () => {
     fixture.detectChanges();
     const title = fixture.nativeElement.querySelector('ion-title');
     expect(title?.textContent).toContain('Support');
+  });
+
+  it('Given support requests exist, when page initializes, then it shows tracked status labels', async () => {
+    supportService.listMyRequests.mockResolvedValue([
+      {
+        id: 'req-1',
+        userId: 'user-1',
+        participantId: 'participant-1',
+        subject: 'Connexion impossible',
+        message: 'Je ne peux plus accéder à mon espace.',
+        status: 'in_progress',
+        category: 'technical',
+        assignedToUserId: null,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        updatedAt: '2026-04-29T10:10:00.000Z',
+      },
+    ]);
+
+    const fixture = TestBed.createComponent(SupportPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('Suivi de vos demandes');
+    expect(element.textContent).toContain('Connexion impossible');
+    expect(element.textContent).toContain('En cours');
   });
 });

--- a/apps/client/projects/mobile/src/app/features/support/support.page.ts
+++ b/apps/client/projects/mobile/src/app/features/support/support.page.ts
@@ -1,12 +1,55 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { IonButton } from '@ionic/angular/standalone';
+import type {
+  SupportRequestDto,
+  SupportRequestStatusValue,
+} from '@kraak/contracts';
 import { PageShell } from '../../shared/page-shell/page-shell';
+import { MobileSupportService } from './mobile-support.service';
 
 @Component({
   selector: 'kraak-support-page',
   standalone: true,
-  imports: [PageShell, IonButton, RouterLink],
+  imports: [PageShell, IonButton, RouterLink, DatePipe],
   templateUrl: './support.page.html',
 })
-export default class SupportPage {}
+export default class SupportPage implements OnInit {
+  private readonly supportService = inject(MobileSupportService);
+
+  readonly loading = signal(true);
+  readonly requests = signal<SupportRequestDto[]>([]);
+  readonly errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    void this.loadRequests();
+  }
+
+  getStatusLabel(status: SupportRequestStatusValue): string {
+    const labels: Record<SupportRequestStatusValue, string> = {
+      open: 'Ouverte',
+      in_progress: 'En cours',
+      resolved: 'Résolue',
+      closed: 'Clôturée',
+    };
+
+    return labels[status];
+  }
+
+  private async loadRequests(): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      const data = await this.supportService.listMyRequests();
+      this.requests.set(data);
+    } catch {
+      this.errorMessage.set(
+        'Impossible de charger le suivi de vos demandes pour le moment.',
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -43,6 +43,7 @@ import type {
   MarkProgramSessionProgressResponseDto,
   ContactFormDto,
   ContactSubmissionResultDto,
+  UpdateSupportRequestStatusDto,
 } from '@kraak/contracts';
 
 // ---------------------------------------------------------------------------
@@ -110,6 +111,12 @@ export interface ContactClient {
     body: ContactFormDto,
     options?: RequestOptions,
   ): Promise<ContactSubmissionResultDto>;
+  listMine(options?: RequestOptions): Promise<SupportRequestDto[]>;
+  updateStatus(
+    requestId: string,
+    body: UpdateSupportRequestStatusDto,
+    options?: RequestOptions,
+  ): Promise<SupportRequestDto>;
 }
 
 export interface DashboardClient {
@@ -339,6 +346,22 @@ function createContactClient(config: ApiClientConfig): ContactClient {
         config,
         'POST',
         '/support/contact',
+        body,
+        options,
+      ),
+    listMine: (options?) =>
+      request<SupportRequestDto[]>(
+        config,
+        'GET',
+        '/support/requests',
+        undefined,
+        options,
+      ),
+    updateStatus: (requestId, body, options?) =>
+      request<SupportRequestDto>(
+        config,
+        'PATCH',
+        `/support/requests/${requestId}/status`,
         body,
         options,
       ),

--- a/packages/contracts/src/dto.spec.ts
+++ b/packages/contracts/src/dto.spec.ts
@@ -5,6 +5,7 @@ import type {
   UpdateAppUserDto,
   ContactFormDto,
   ContactSubmissionResultDto,
+  UpdateSupportRequestStatusDto,
   ParticipantDto,
   CreateParticipantDto,
   UpdateParticipantDto,
@@ -98,9 +99,22 @@ describe('ContactSubmissionResultDto', () => {
     expectTypeOf<ContactSubmissionResultDto>()
       .toHaveProperty('message')
       .toBeString();
+    expectTypeOf<ContactSubmissionResultDto>()
+      .toHaveProperty('requestId')
+      .toEqualTypeOf<string | undefined>();
+    expectTypeOf<ContactSubmissionResultDto>()
+      .toHaveProperty('requestStatus')
+      .toEqualTypeOf<SupportRequestStatusValue | undefined>();
   });
 });
 
+describe('UpdateSupportRequestStatusDto', () => {
+  it('should expose the minimal status transition payload', () => {
+    expectTypeOf<UpdateSupportRequestStatusDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<SupportRequestStatusValue>();
+  });
+});
 // ---------------------------------------------------------------------------
 // Dashboard
 // ---------------------------------------------------------------------------

--- a/packages/contracts/src/dto.ts
+++ b/packages/contracts/src/dto.ts
@@ -33,6 +33,12 @@ export interface ContactFormDto {
 export interface ContactSubmissionResultDto {
   success: boolean;
   message: string;
+  requestId?: string;
+  requestStatus?: SupportRequestStatusValue;
+}
+
+export interface UpdateSupportRequestStatusDto {
+  status: SupportRequestStatusValue;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implemente SUP-05: suivi et statut basique des demandes support.

## Changes

- API support:
  - persistance d'une demande `support_request` lors de la soumission authentifiee
  - extension de la reponse `POST /support/contact` avec metadata de suivi (`requestId`, `requestStatus`)
  - nouvel endpoint `GET /support/requests` pour consultation des statuts
  - nouvel endpoint `PATCH /support/requests/:id/status` pour transitions de statut minimales
  - transitions minimales appliquees: `open -> in_progress|closed`, `in_progress -> resolved|closed`, `resolved -> closed`
  - restriction role: mise a jour de statut reservee aux roles non participant (coherent AUT-05)

- Contrats partages:
  - `ContactSubmissionResultDto` enrichi avec champs optionnels de suivi
  - ajout `UpdateSupportRequestStatusDto`
  - client API etendu (`contact.listMine`, `contact.updateStatus`)

- Mobile:
  - `MobileSupportService.listMyRequests()`
  - page Support affiche maintenant la liste des demandes et leur statut

- Tests:
  - nouveaux tests controller/service/DTO sur API support
  - nouveaux tests mobile service + page support
  - tests contrats DTO mis a jour

## Dependencies

- SUP-01: satisfait (endpoint support existant et reutilise)
- AUT-05: satisfait (controle minimal par role pour transitions de statut)

## Validation Evidence

- `pnpm --filter @kraak/api test -- src/support/support.dto.spec.ts src/support/support.controller.spec.ts src/support/support-requests.controller.spec.ts src/support/support.service.spec.ts`
- `pnpm --filter @kraak/contracts test -- src/dto.spec.ts`
- `pnpm --dir apps/client test:mobile --include=projects/mobile/src/app/features/support/**/*.spec.ts`
- hooks git executes ont aussi valide:
  - lint + format workspace
  - tests mobile complets
  - e2e web (14/14)

## Related

Closes #111
