### PR TITLE
test(client): fiabiliser les navigations E2E analytics/programs

### DIFF
--- a/apps/client/tests/e2e/analytics.spec.ts
+++ b/apps/client/tests/e2e/analytics.spec.ts
@@ -7,7 +7,10 @@ test.describe('Analytics — gating GA4', () => {
   test(`Given aucun identifiant GA4 configuré, When la page d'accueil se charge, Then aucun loader gtag.js n'est injecté`, async ({
     page,
   }) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(
+      page.getByRole('link', { name: 'Nous contacter' }).first(),
+    ).toBeVisible();
 
     await expect(
       page.locator('script[data-kraak-analytics="loader"]'),
@@ -28,7 +31,7 @@ test.describe('Analytics — gating GA4', () => {
       }
     });
 
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
     await page.getByRole('link', { name: 'Nous contacter' }).first().waitFor();
 
     expect(gtagRequests).toEqual([]);

--- a/apps/client/tests/e2e/programs.spec.ts
+++ b/apps/client/tests/e2e/programs.spec.ts
@@ -2,7 +2,10 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Page programmes - parcours vitrine', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/programmes');
+    await page.goto('/programmes', { waitUntil: 'domcontentloaded' });
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Nos programmes' }),
+    ).toBeVisible();
   });
 
   test('Given la page Programmes, When elle se charge, Then le titre principal et les trois parcours sont visibles', async ({


### PR DESCRIPTION
## Résumé\nMini correctif anti-flaky ciblé sur les timeouts de navigation E2E observés sur analytics/programs.\n\n## Changements\n- analytics.spec.ts: navigation via domcontentloaded + readiness check (CTA visible)\n- programs.spec.ts: beforeEach via domcontentloaded + readiness check (H1 visible)\n\n## Validation\n- Playwright ciblé: analytics + programs -> 5 passed\n- Hooks repo au commit/push: typecheck, lint, tests, e2e globaux -> pass\n\n## Risque\nFaible: changement localisé aux tests E2E, sans impact runtime applicatif.