### PR TITLE
[TASK][QAT-04] E2E Given/When/Then parcours coeur participant

### DIFF
--- a/apps/client/tests/e2e/participant-core-journey.spec.ts
+++ b/apps/client/tests/e2e/participant-core-journey.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Parcours coeur participant - orientation web', () => {
+  test('Given un visiteur non authentifie, When il tente l acces dashboard participant, Then il est redirige vers l accueil et oriente vers des pages publiques', async ({
+    page,
+  }) => {
+    await page.goto('/participant/dashboard');
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveTitle('KRAAK | Développez votre potentiel');
+    await expect(page.getByRole('banner')).toContainText('KRAAK');
+
+    await page.goto('/programmes');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Nos programmes' }),
+    ).toBeVisible();
+
+    await page.goto('/contact');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Contactez-nous' }),
+    ).toBeVisible();
+  });
+
+  test('Given un visiteur en parcours participant, When il soumet une demande de contact, Then il recoit un message de confirmation', async ({
+    page,
+  }) => {
+    await page.route('**/contact', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          message:
+            'Votre message a bien été envoyé. Nous vous répondrons dans les plus brefs délais.',
+        }),
+      });
+    });
+
+    await page.goto('/contact');
+
+    const nameField = page.getByRole('textbox', { name: 'Nom complet' });
+    const emailField = page.getByRole('textbox', { name: 'Adresse e-mail' });
+    const subjectField = page.getByRole('textbox', { name: 'Objet' });
+    const messageField = page.getByRole('textbox', { name: 'Message' });
+
+    await expect(async () => {
+      await nameField.fill('Aline Kouassi');
+      await emailField.fill('aline@exemple.com');
+      await subjectField.fill("Demande d'accompagnement");
+      await messageField.fill(
+        'Bonjour, je souhaite etre guidee sur les prochaines etapes.',
+      );
+
+      await expect(nameField).toHaveValue('Aline Kouassi', { timeout: 500 });
+      await expect(emailField).toHaveValue('aline@exemple.com', {
+        timeout: 500,
+      });
+      await expect(subjectField).toHaveValue("Demande d'accompagnement", {
+        timeout: 500,
+      });
+      await expect(messageField).toHaveValue(
+        'Bonjour, je souhaite etre guidee sur les prochaines etapes.',
+        { timeout: 500 },
+      );
+
+      await page.getByRole('button', { name: 'Envoyer le message' }).click();
+
+      await expect(
+        page.getByText(
+          'Votre message a bien été envoyé. Nous vous répondrons dans les plus brefs délais.',
+        ),
+      ).toBeVisible({ timeout: 10_000 });
+    }).toPass({ timeout: 60_000 });
+  });
+});

--- a/apps/client/tests/e2e/participant-dashboard.spec.ts
+++ b/apps/client/tests/e2e/participant-dashboard.spec.ts
@@ -22,4 +22,20 @@ test.describe('Dashboard web participant — protection de route', () => {
 
     await expect(page).toHaveURL(/\/$/);
   });
+
+  test(`Given un visiteur non authentifié, When il tente d'accéder à /participant/dashboard, Then la vue privée n'est pas affichée`, async ({
+    page,
+  }) => {
+    await page.goto('/participant/dashboard');
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveTitle('KRAAK | Développez votre potentiel');
+    await expect(page.getByRole('banner')).toContainText('KRAAK');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: /Bonjour .* vue d'ensemble/,
+      }),
+    ).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Résumé\n- Ajoute des scénarios E2E Given/When/Then pour le parcours coeur participant côté web\n- Renforce la couverture de protection d'accès dashboard participant\n- Ajoute un scénario parcours participant orienté programmes/contact avec soumission de contact mockée\n\n## Validation\n- pnpm --filter @kraak/client e2e\n\n## Référence\n- Closes #115