### PR TITLE
[TASK][WEB-02] Track conversion CTA clicks on website

### DIFF
--- a/apps/client/projects/web/src/app/features/about/about.page.html
+++ b/apps/client/projects/web/src/app/features/about/about.page.html
@@ -91,4 +91,5 @@
   body="Contactez-nous pour découvrir comment KRAAK peut vous accompagner."
   ctaLabel="Nous contacter"
   ctaLink="/contact"
+  ctaContext="about_main_cta"
 />

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -230,6 +230,7 @@
   body="Prenez contact avec notre équipe pour explorer vos opportunités."
   ctaLabel="Demander une consultation"
   ctaLink="/contact"
+  ctaContext="home_main_cta"
 />
 
 <!-- Teaser contact -->

--- a/apps/client/projects/web/src/app/features/programs/programs.page.html
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.html
@@ -135,4 +135,5 @@
   body="Les places sont limitées. Postulez dès maintenant et lancez votre parcours avec KRAAK."
   ctaLabel="S'inscrire maintenant"
   ctaLink="/contact"
+  ctaContext="programs_main_cta"
 />

--- a/apps/client/projects/web/src/app/features/services/services.page.html
+++ b/apps/client/projects/web/src/app/features/services/services.page.html
@@ -153,4 +153,5 @@
   body="Prenez rendez-vous pour une consultation gratuite et découvrez comment KRAAK peut vous accompagner."
   ctaLabel="Demander une consultation"
   ctaLink="/contact"
+  ctaContext="services_main_cta"
 />

--- a/apps/client/projects/web/src/app/shared/cta-banner/cta-banner.html
+++ b/apps/client/projects/web/src/app/shared/cta-banner/cta-banner.html
@@ -29,6 +29,7 @@
               [routerLink]="ctaLink"
               [label]="ctaLabel"
               [attr.aria-label]="ctaLabel"
+              (click)="onCtaClick()"
               class="kr-button-contrast mt-8 text-sm"
               severity="contrast"
             ></a>

--- a/apps/client/projects/web/src/app/shared/cta-banner/cta-banner.spec.ts
+++ b/apps/client/projects/web/src/app/shared/cta-banner/cta-banner.spec.ts
@@ -1,14 +1,26 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
+import { AnalyticsService } from '../../core/analytics/analytics.service';
+
 import { CtaBanner } from './cta-banner';
 
 describe('CtaBanner', () => {
+  let analyticsService: Pick<AnalyticsService, 'trackEvent'>;
+
   beforeEach(async () => {
+    analyticsService = {
+      trackEvent: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [CtaBanner],
       providers: [provideRouter([])],
-    }).compileComponents();
+    })
+      .overrideProvider(AnalyticsService, {
+        useValue: analyticsService,
+      })
+      .compileComponents();
   });
 
   it('should render a PrimeNG card surface and CTA button', () => {
@@ -26,5 +38,25 @@ describe('CtaBanner', () => {
 
     expect(element.querySelector('.p-card')).toBeTruthy();
     expect(element.querySelector('.p-button')).toBeTruthy();
+  });
+
+  it('should track a conversion event when the CTA click handler is triggered', () => {
+    const fixture = TestBed.createComponent(CtaBanner);
+    fixture.componentRef.setInput('heading', 'Parlons de votre projet');
+    fixture.componentRef.setInput('ctaLabel', 'Nous contacter');
+    fixture.componentRef.setInput('ctaLink', '/contact');
+    fixture.componentRef.setInput('ctaContext', 'home_hero');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onCtaClick();
+
+    expect(analyticsService.trackEvent).toHaveBeenCalledWith(
+      'conversion_cta_click',
+      {
+        cta_context: 'home_hero',
+        cta_label: 'Nous contacter',
+        cta_link: '/contact',
+      },
+    );
   });
 });

--- a/apps/client/projects/web/src/app/shared/cta-banner/cta-banner.ts
+++ b/apps/client/projects/web/src/app/shared/cta-banner/cta-banner.ts
@@ -1,7 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
 import { Card } from 'primeng/card';
+
+import { AnalyticsService } from '../../core/analytics/analytics.service';
 
 @Component({
   selector: 'kraak-cta-banner',
@@ -10,8 +12,30 @@ import { Card } from 'primeng/card';
   templateUrl: './cta-banner.html',
 })
 export class CtaBanner {
+  private readonly analyticsService = inject(AnalyticsService);
+
   @Input({ required: true }) heading = '';
   @Input() body = '';
   @Input() ctaLabel = '';
   @Input() ctaLink = '';
+  @Input() ctaContext = '';
+
+  onCtaClick(): void {
+    if (!this.ctaLabel || !this.ctaLink) {
+      return;
+    }
+
+    this.analyticsService.trackEvent(
+      'conversion_cta_click',
+      this.buildTrackingPayload(),
+    );
+  }
+
+  private buildTrackingPayload(): Record<string, string> {
+    return {
+      cta_context: this.ctaContext || 'unknown',
+      cta_label: this.ctaLabel,
+      cta_link: this.ctaLink,
+    };
+  }
 }


### PR DESCRIPTION
## Resume

- ajoute le tracking analytics des clics CTA conversion via le composant partage `kraak-cta-banner`
- ajoute un contexte CTA explicite sur les pages marketing cles (Accueil, A propos, Services, Programmes)
- couvre le comportement avec un test unitaire dedie

## Validation

- `pnpm --dir apps/client test:web`
- `pnpm --dir apps/client lint`
- `pnpm --dir apps/client build:web`
- hook pre-push execute: typecheck + lint + tests workspace + Playwright E2E

Closes #151
