### PR TITLE
feat(mobile): make Ionic/Capacitor shell module-ready

### DIFF
--- a/apps/client/projects/mobile/src/app/app.routes.spec.ts
+++ b/apps/client/projects/mobile/src/app/app.routes.spec.ts
@@ -4,6 +4,7 @@ import {
   participantRoleChildGuard,
   participantRoleGuard,
 } from './core/auth/auth.guard';
+import { MOBILE_SHELL_SECTIONS } from './core/navigation/mobile-shell.config';
 
 describe('Mobile routes', () => {
   const topPaths = routes.map((r) => r.path);
@@ -37,12 +38,10 @@ describe('Mobile routes', () => {
   it('Given the participant shell, when the tabs route loads, then it exposes only the four frozen MVP tabs', () => {
     const tabsRoute = routes.find((r) => r.path === 'tabs');
     const childPaths = tabsRoute?.children?.map((c) => c.path);
+    const sectionPaths = MOBILE_SHELL_SECTIONS.map((section) => section.path);
 
     expect(childPaths).not.toContain('ressources');
-    expect(childPaths).toContain('accueil');
-    expect(childPaths).toContain('programmes');
-    expect(childPaths).toContain('annonces');
-    expect(childPaths).toContain('support');
+    expect(childPaths).toEqual([...sectionPaths, '']);
   });
 
   it('Given the Programmes tab, when nested content opens, then all detail routes stay inside the stack', () => {

--- a/apps/client/projects/mobile/src/app/app.routes.ts
+++ b/apps/client/projects/mobile/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import {
   participantRoleChildGuard,
   participantRoleGuard,
 } from './core/auth/auth.guard';
+import { MOBILE_SHELL_CHILD_ROUTES } from './core/navigation/mobile-shell.config';
 
 export const routes: Routes = [
   {
@@ -28,69 +29,7 @@ export const routes: Routes = [
     canActivate: [participantRoleGuard],
     canActivateChild: [participantRoleChildGuard],
     children: [
-      {
-        path: 'accueil',
-        loadComponent: () => import('./features/dashboard/home.page'),
-      },
-      {
-        path: 'programmes',
-        children: [
-          {
-            path: '',
-            loadComponent: () =>
-              import('./features/programs/program-list.page'),
-          },
-          {
-            path: 'ressources',
-            loadComponent: () =>
-              import('./features/resources/resource-list.page'),
-          },
-          {
-            path: 'ressources/:resourceId',
-            loadComponent: () =>
-              import('./features/resources/resource-detail.page'),
-          },
-          {
-            path: ':programId/sessions/:sessionId',
-            loadComponent: () =>
-              import('./features/programs/session-detail.page'),
-          },
-          {
-            path: ':programId',
-            loadComponent: () =>
-              import('./features/programs/program-detail.page'),
-          },
-        ],
-      },
-      {
-        path: 'annonces',
-        children: [
-          {
-            path: '',
-            loadComponent: () =>
-              import('./features/announcements/announcement-list.page'),
-          },
-          {
-            path: ':announcementId',
-            loadComponent: () =>
-              import('./features/announcements/announcement-detail.page'),
-          },
-        ],
-      },
-      {
-        path: 'support',
-        children: [
-          {
-            path: '',
-            loadComponent: () => import('./features/support/support.page'),
-          },
-          {
-            path: 'demande',
-            loadComponent: () =>
-              import('./features/support/support-request.page'),
-          },
-        ],
-      },
+      ...MOBILE_SHELL_CHILD_ROUTES,
       { path: '', redirectTo: 'accueil', pathMatch: 'full' },
     ],
   },

--- a/apps/client/projects/mobile/src/app/core/navigation/mobile-shell.config.spec.ts
+++ b/apps/client/projects/mobile/src/app/core/navigation/mobile-shell.config.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MOBILE_PRIMARY_TABS,
+  MOBILE_SHELL_CHILD_ROUTES,
+  MOBILE_SHELL_SECTIONS,
+} from './mobile-shell.config';
+
+describe('mobile shell config', () => {
+  it('Given the frozen MVP shell, when primary tabs are computed, then it keeps the four expected entries', () => {
+    expect(MOBILE_PRIMARY_TABS).toEqual([
+      {
+        label: 'Accueil',
+        tab: 'accueil',
+        href: '/tabs/accueil',
+        icon: 'home-outline',
+      },
+      {
+        label: 'Programmes',
+        tab: 'programmes',
+        href: '/tabs/programmes',
+        icon: 'book-outline',
+      },
+      {
+        label: 'Annonces',
+        tab: 'annonces',
+        href: '/tabs/annonces',
+        icon: 'megaphone-outline',
+      },
+      {
+        label: 'Support',
+        tab: 'support',
+        href: '/tabs/support',
+        icon: 'help-circle-outline',
+      },
+    ]);
+  });
+
+  it('Given the module registry, when shell child routes are generated, then each section keeps its nested stack routes', () => {
+    const sectionPaths = MOBILE_SHELL_SECTIONS.map((section) => section.path);
+    const routePaths = MOBILE_SHELL_CHILD_ROUTES.map((route) => route.path);
+
+    expect(routePaths).toEqual(sectionPaths);
+
+    const programRoute = MOBILE_SHELL_CHILD_ROUTES.find(
+      (route) => route.path === 'programmes',
+    );
+
+    expect(programRoute?.children?.map((child) => child.path)).toEqual([
+      '',
+      'ressources',
+      'ressources/:resourceId',
+      ':programId/sessions/:sessionId',
+      ':programId',
+    ]);
+  });
+});

--- a/apps/client/projects/mobile/src/app/core/navigation/mobile-shell.config.ts
+++ b/apps/client/projects/mobile/src/app/core/navigation/mobile-shell.config.ts
@@ -1,0 +1,134 @@
+import type { Route } from '@angular/router';
+
+interface MobileShellChildRouteConfig {
+  readonly path: string;
+  readonly loadComponent: Route['loadComponent'];
+}
+
+export interface MobileShellSectionConfig {
+  readonly path: string;
+  readonly tab?: {
+    readonly label: string;
+    readonly tab: string;
+    readonly href: string;
+    readonly icon: string;
+  };
+  readonly children: readonly MobileShellChildRouteConfig[];
+}
+
+export const MOBILE_SHELL_SECTIONS: readonly MobileShellSectionConfig[] = [
+  {
+    path: 'accueil',
+    tab: {
+      label: 'Accueil',
+      tab: 'accueil',
+      href: '/tabs/accueil',
+      icon: 'home-outline',
+    },
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('../../features/dashboard/home.page'),
+      },
+    ],
+  },
+  {
+    path: 'programmes',
+    tab: {
+      label: 'Programmes',
+      tab: 'programmes',
+      href: '/tabs/programmes',
+      icon: 'book-outline',
+    },
+    children: [
+      {
+        path: '',
+        loadComponent: () =>
+          import('../../features/programs/program-list.page'),
+      },
+      {
+        path: 'ressources',
+        loadComponent: () =>
+          import('../../features/resources/resource-list.page'),
+      },
+      {
+        path: 'ressources/:resourceId',
+        loadComponent: () =>
+          import('../../features/resources/resource-detail.page'),
+      },
+      {
+        path: ':programId/sessions/:sessionId',
+        loadComponent: () =>
+          import('../../features/programs/session-detail.page'),
+      },
+      {
+        path: ':programId',
+        loadComponent: () =>
+          import('../../features/programs/program-detail.page'),
+      },
+    ],
+  },
+  {
+    path: 'annonces',
+    tab: {
+      label: 'Annonces',
+      tab: 'annonces',
+      href: '/tabs/annonces',
+      icon: 'megaphone-outline',
+    },
+    children: [
+      {
+        path: '',
+        loadComponent: () =>
+          import('../../features/announcements/announcement-list.page'),
+      },
+      {
+        path: ':announcementId',
+        loadComponent: () =>
+          import('../../features/announcements/announcement-detail.page'),
+      },
+    ],
+  },
+  {
+    path: 'support',
+    tab: {
+      label: 'Support',
+      tab: 'support',
+      href: '/tabs/support',
+      icon: 'help-circle-outline',
+    },
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('../../features/support/support.page'),
+      },
+      {
+        path: 'demande',
+        loadComponent: () =>
+          import('../../features/support/support-request.page'),
+      },
+    ],
+  },
+] as const;
+
+export const MOBILE_PRIMARY_TABS = MOBILE_SHELL_SECTIONS.flatMap((section) =>
+  section.tab
+    ? [
+        {
+          label: section.tab.label,
+          tab: section.tab.tab,
+          href: section.tab.href,
+          icon: section.tab.icon,
+        },
+      ]
+    : [],
+);
+
+export const MOBILE_SHELL_CHILD_ROUTES: readonly Route[] =
+  MOBILE_SHELL_SECTIONS.map((section) => ({
+    path: section.path,
+    children: section.children.map((childRoute) => ({
+      path: childRoute.path,
+      loadComponent: childRoute.loadComponent,
+    })),
+  }));

--- a/apps/client/projects/mobile/src/app/layouts/tabs/tabs.layout.spec.ts
+++ b/apps/client/projects/mobile/src/app/layouts/tabs/tabs.layout.spec.ts
@@ -10,6 +10,7 @@ import {
   IonTabs,
 } from '@ionic/angular/standalone';
 import { describe, it, beforeEach, expect } from 'vitest';
+import { MOBILE_PRIMARY_TABS } from '../../core/navigation/mobile-shell.config';
 import { TabsLayout } from './tabs.layout';
 
 describe('TabsLayout', () => {
@@ -52,7 +53,7 @@ describe('TabsLayout', () => {
     const fixture = TestBed.createComponent(TabsLayout);
     fixture.detectChanges();
     const buttons = fixture.nativeElement.querySelectorAll('ion-tab-button');
-    expect(buttons.length).toBe(4);
+    expect(buttons.length).toBe(MOBILE_PRIMARY_TABS.length);
   });
 
   it('should display correct tab labels', () => {
@@ -71,11 +72,6 @@ describe('TabsLayout', () => {
     const fixture = TestBed.createComponent(TabsLayout);
     const hrefs = fixture.componentInstance['tabs'].map((tab) => tab.href);
 
-    expect(hrefs).toEqual([
-      '/tabs/accueil',
-      '/tabs/programmes',
-      '/tabs/annonces',
-      '/tabs/support',
-    ]);
+    expect(hrefs).toEqual(MOBILE_PRIMARY_TABS.map((tab) => tab.href));
   });
 });

--- a/apps/client/projects/mobile/src/app/layouts/tabs/tabs.layout.ts
+++ b/apps/client/projects/mobile/src/app/layouts/tabs/tabs.layout.ts
@@ -14,6 +14,7 @@ import {
   megaphoneOutline,
   helpCircleOutline,
 } from 'ionicons/icons';
+import { MOBILE_PRIMARY_TABS } from '../../core/navigation/mobile-shell.config';
 
 interface MobileTabLink {
   readonly label: string;
@@ -43,30 +44,5 @@ addIcons({
   templateUrl: './tabs.layout.html',
 })
 export class TabsLayout {
-  protected readonly tabs: MobileTabLink[] = [
-    {
-      label: 'Accueil',
-      tab: 'accueil',
-      href: '/tabs/accueil',
-      icon: 'home-outline',
-    },
-    {
-      label: 'Programmes',
-      tab: 'programmes',
-      href: '/tabs/programmes',
-      icon: 'book-outline',
-    },
-    {
-      label: 'Annonces',
-      tab: 'annonces',
-      href: '/tabs/annonces',
-      icon: 'megaphone-outline',
-    },
-    {
-      label: 'Support',
-      tab: 'support',
-      href: '/tabs/support',
-      icon: 'help-circle-outline',
-    },
-  ];
+  protected readonly tabs: MobileTabLink[] = MOBILE_PRIMARY_TABS;
 }


### PR DESCRIPTION
## Résumé
- centralise la définition du shell mobile (sections/tabs/children routes) dans une config unique
- dérive les routes `tabs` et la barre d'onglets depuis cette source de vérité
- ajoute des tests dédiés pour sécuriser l'ossature module-ready

## Pourquoi
Cette ossature réduit le couplage: l'ajout d'un futur module mobile passe par une entrée de registre plutôt que des modifications dispersées dans plusieurs fichiers shell.

## Validation
- `pnpm --dir apps/client ng test mobile --watch=false --include='projects/mobile/src/app/app.routes.spec.ts' --include='projects/mobile/src/app/layouts/tabs/tabs.layout.spec.ts' --include='projects/mobile/src/app/core/navigation/mobile-shell.config.spec.ts'`
- `pnpm --dir apps/client ng lint mobile`
- `pnpm --dir apps/client build:mobile`
- hooks pre-push exécutés: typecheck + format:check + lint + tests libs/api/client + Playwright E2E

Closes #149
