### PR TITLE
feat(auth): secure and consistent web/mobile auth flow

### DIFF
--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -6,13 +6,18 @@ import {
 
 describe('Web routes', () => {
   const paths = routes.map((r) => r.path);
+  const marketingPaths = ['', 'a-propos', 'services', 'programmes', 'contact'];
 
   it('should define all public marketing routes', () => {
-    expect(paths).toContain('');
-    expect(paths).toContain('a-propos');
-    expect(paths).toContain('services');
-    expect(paths).toContain('programmes');
-    expect(paths).toContain('contact');
+    for (const path of marketingPaths) {
+      expect(paths).toContain(path);
+    }
+  });
+
+  it('should define public auth routes', () => {
+    expect(paths).toContain('connexion');
+    expect(paths).toContain('inscription');
+    expect(paths).toContain('mot-de-passe-oublie');
   });
 
   it('should have a wildcard fallback redirecting to home', () => {
@@ -31,8 +36,8 @@ describe('Web routes', () => {
   });
 
   it('should attach a title and SEO metadata to every public marketing route', () => {
-    const pageRoutes = routes.filter(
-      (r) => r.path !== '**' && r.path !== 'participant',
+    const pageRoutes = routes.filter((route) =>
+      marketingPaths.includes(route.path ?? ''),
     );
 
     for (const route of pageRoutes) {

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -27,6 +27,21 @@ const buildMarketingRoute = (
 export const routes: Routes = [
   buildMarketingRoute('', () => import('./features/home/home.page')),
   buildMarketingRoute('a-propos', () => import('./features/about/about.page')),
+  {
+    path: 'connexion',
+    title: 'Connexion | KRAAK',
+    loadComponent: () => import('./features/auth/sign-in.page'),
+  },
+  {
+    path: 'inscription',
+    title: 'Inscription | KRAAK',
+    loadComponent: () => import('./features/auth/sign-up.page'),
+  },
+  {
+    path: 'mot-de-passe-oublie',
+    title: 'Mot de passe oublié | KRAAK',
+    loadComponent: () => import('./features/auth/password-reset.page'),
+  },
   buildMarketingRoute(
     'services',
     () => import('./features/services/services.page'),

--- a/apps/client/projects/web/src/app/core/auth/auth.guard.spec.ts
+++ b/apps/client/projects/web/src/app/core/auth/auth.guard.spec.ts
@@ -67,13 +67,13 @@ describe('authGuard (web)', () => {
       });
     });
 
-    it('when the guard is triggered, then the user is redirected to the home page', () => {
+    it('when the guard is triggered, then the user is redirected to the sign-in page', () => {
       const result = TestBed.runInInjectionContext(() =>
         authGuard(buildRoute(), buildState()),
       );
 
       const router = TestBed.inject(Router);
-      expect(result).toEqual(router.createUrlTree(['/']));
+      expect(result).toEqual(router.createUrlTree(['/connexion']));
     });
   });
 });
@@ -114,13 +114,13 @@ describe('authChildGuard (web)', () => {
       });
     });
 
-    it('when the child guard is triggered, then the user is redirected to the home page', () => {
+    it('when the child guard is triggered, then the user is redirected to the sign-in page', () => {
       const result = TestBed.runInInjectionContext(() =>
         authChildGuard(buildRoute(), buildState()),
       );
 
       const router = TestBed.inject(Router);
-      expect(result).toEqual(router.createUrlTree(['/']));
+      expect(result).toEqual(router.createUrlTree(['/connexion']));
     });
   });
 });
@@ -161,13 +161,13 @@ describe('participantRoleGuard (web)', () => {
       });
     });
 
-    it('when the participant role guard is triggered, then the user is redirected to home', () => {
+    it('when the participant role guard is triggered, then the user is redirected to sign-in', () => {
       const result = TestBed.runInInjectionContext(() =>
         participantRoleGuard(buildRoute(), buildState()),
       );
 
       const router = TestBed.inject(Router);
-      expect(result).toEqual(router.createUrlTree(['/']));
+      expect(result).toEqual(router.createUrlTree(['/connexion']));
     });
   });
 });
@@ -228,13 +228,13 @@ describe('adminRoleGuard (web)', () => {
       });
     });
 
-    it('when the admin role guard is triggered, then the user is redirected to home', () => {
+    it('when the admin role guard is triggered, then the user is redirected to sign-in', () => {
       const result = TestBed.runInInjectionContext(() =>
         adminRoleGuard(buildRoute(), buildState()),
       );
 
       const router = TestBed.inject(Router);
-      expect(result).toEqual(router.createUrlTree(['/']));
+      expect(result).toEqual(router.createUrlTree(['/connexion']));
     });
   });
 });

--- a/apps/client/projects/web/src/app/core/auth/auth.guard.ts
+++ b/apps/client/projects/web/src/app/core/auth/auth.guard.ts
@@ -15,7 +15,7 @@ export const authGuard: CanActivateFn = () => {
     return true;
   }
 
-  return router.createUrlTree(['/']);
+  return router.createUrlTree(['/connexion']);
 };
 
 export const authChildGuard: CanActivateChildFn = authGuard;
@@ -26,14 +26,14 @@ function canAccessRole(
   ...roles: UserRoleValue[]
 ): true | ReturnType<Router['createUrlTree']> {
   if (!authService.isAuthenticated()) {
-    return router.createUrlTree(['/']);
+    return router.createUrlTree(['/connexion']);
   }
 
   if (authService.hasRole(...roles)) {
     return true;
   }
 
-  return router.createUrlTree(['/']);
+  return router.createUrlTree(['/connexion']);
 }
 
 export const participantRoleGuard: CanActivateFn = () => {

--- a/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
+++ b/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
@@ -6,7 +6,7 @@ import {
   PLATFORM_ID,
   signal,
 } from '@angular/core';
-import { createApiClient } from '@kraak/api-client';
+import { ApiError, createApiClient } from '@kraak/api-client';
 import type {
   AuthProfileDto,
   AuthSessionBundleDto,
@@ -176,4 +176,42 @@ export class WebAuthService {
       return null;
     }
   }
+}
+
+export function resolveAuthErrorMessage(
+  error: unknown,
+  fallbackMessage: string,
+): string {
+  if (error instanceof ApiError && isObjectRecord(error.body)) {
+    const body = error.body;
+
+    if (
+      'message' in body &&
+      typeof body['message'] === 'string' &&
+      body['message'].trim().length > 0
+    ) {
+      return body['message'];
+    }
+
+    if ('errors' in body && Array.isArray(body['errors'])) {
+      const firstError = body['errors'].find(
+        (value: unknown): value is string =>
+          typeof value === 'string' && value.trim().length > 0,
+      );
+
+      if (firstError) {
+        return firstError;
+      }
+    }
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }

--- a/apps/client/projects/web/src/app/features/auth/password-reset.page.html
+++ b/apps/client/projects/web/src/app/features/auth/password-reset.page.html
@@ -1,0 +1,74 @@
+<main class="min-h-screen bg-slate-50 py-12 sm:py-16">
+  <div class="mx-auto w-full max-w-xl px-4 sm:px-6">
+    <section
+      class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+    >
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+      >
+        Espace participant
+      </p>
+      <h1 class="mt-3 text-3xl font-semibold text-slate-950">
+        Reinitialiser mon mot de passe
+      </h1>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Entrez votre email pour recevoir un lien de reinitialisation.
+      </p>
+
+      <form
+        [formGroup]="form"
+        (ngSubmit)="submit()"
+        class="mt-6 flex flex-col gap-4"
+        novalidate
+      >
+        <div class="flex flex-col gap-2">
+          <label
+            for="web-password-reset-email"
+            class="text-sm font-semibold text-slate-900"
+          >
+            Adresse email
+          </label>
+          <input
+            id="web-password-reset-email"
+            type="email"
+            formControlName="email"
+            autocomplete="email"
+            placeholder="vous@kraak.org"
+            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+          />
+          @if (form.controls.email.touched && form.controls.email.invalid) {
+            <p class="text-sm leading-6 text-rose-700">
+              Saisissez une adresse email valide.
+            </p>
+          }
+        </div>
+
+        @if (errorMessage()) {
+          <p
+            class="rounded-xl bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-700"
+          >
+            {{ errorMessage() }}
+          </p>
+        }
+
+        @if (successMessage()) {
+          <p
+            class="rounded-xl bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-700"
+          >
+            {{ successMessage() }}
+          </p>
+        }
+
+        <button type="submit" class="btn btn-primary" [disabled]="submitting()">
+          {{ submitting() ? 'Envoi en cours...' : "Envoyer l'email" }}
+        </button>
+      </form>
+
+      <div class="mt-5 border-t border-slate-200 pt-4 text-sm font-semibold">
+        <a routerLink="/connexion" class="text-brand-blue hover:underline">
+          Retour a la connexion
+        </a>
+      </div>
+    </section>
+  </div>
+</main>

--- a/apps/client/projects/web/src/app/features/auth/password-reset.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/password-reset.page.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebAuthService } from '../../core/auth/web-auth.service';
+import PasswordResetPage from './password-reset.page';
+
+describe('Web PasswordResetPage', () => {
+  const authService = {
+    requestPasswordReset: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    authService.requestPasswordReset.mockReset();
+    authService.requestPasswordReset.mockResolvedValue({
+      success: true,
+      message:
+        'Si cette adresse existe, un email de reinitialisation vient d etre envoye.',
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [PasswordResetPage],
+      providers: [
+        provideRouter([]),
+        { provide: WebAuthService, useValue: authService },
+      ],
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(PasswordResetPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given a valid email, when the form is submitted, then the reset request is sent and a success message is displayed', async () => {
+    const fixture = TestBed.createComponent(PasswordResetPage);
+    fixture.componentInstance.form.setValue({
+      email: '  alice@example.com  ',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(authService.requestPasswordReset).toHaveBeenCalledWith({
+      email: 'alice@example.com',
+    });
+    expect(fixture.componentInstance.successMessage()).toContain('email');
+  });
+});

--- a/apps/client/projects/web/src/app/features/auth/password-reset.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/password-reset.page.ts
@@ -1,0 +1,75 @@
+import { Component, inject, signal } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import {
+  WebAuthService,
+  resolveAuthErrorMessage,
+} from '../../core/auth/web-auth.service';
+
+interface PasswordResetFormModel {
+  email: FormControl<string>;
+}
+
+@Component({
+  selector: 'kraak-web-password-reset-page',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink],
+  templateUrl: './password-reset.page.html',
+})
+export default class PasswordResetPage {
+  private readonly authService = inject(WebAuthService);
+
+  readonly form = new FormGroup<PasswordResetFormModel>({
+    email: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.email],
+    }),
+  });
+  readonly successMessage = signal<string | null>(null);
+  readonly errorMessage = signal<string | null>(null);
+  readonly submitting = signal(false);
+
+  async submit(): Promise<void> {
+    normalizeTextControl(this.form.controls.email);
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid || this.submitting()) {
+      return;
+    }
+
+    this.submitting.set(true);
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+
+    try {
+      const { email } = this.form.getRawValue();
+      const response = await this.authService.requestPasswordReset({
+        email: normalizeRequiredText(email),
+      });
+
+      this.successMessage.set(response.message);
+    } catch (error) {
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          "Impossible d'envoyer l'email de reinitialisation.",
+        ),
+      );
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+}
+
+function normalizeRequiredText(value: string): string {
+  return value.trim();
+}
+
+function normalizeTextControl(control: FormControl<string>): void {
+  control.setValue(normalizeRequiredText(control.getRawValue()));
+}

--- a/apps/client/projects/web/src/app/features/auth/sign-in.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-in.page.html
@@ -1,0 +1,97 @@
+<main class="min-h-screen bg-slate-50 py-12 sm:py-16">
+  <div class="mx-auto w-full max-w-xl px-4 sm:px-6">
+    <section
+      class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+    >
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+      >
+        Espace participant
+      </p>
+      <h1 class="mt-3 text-3xl font-semibold text-slate-950">Connexion</h1>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Connectez-vous pour retrouver votre dashboard, vos programmes et vos
+        annonces.
+      </p>
+
+      <form
+        [formGroup]="form"
+        (ngSubmit)="submit()"
+        class="mt-6 flex flex-col gap-4"
+        novalidate
+      >
+        <div class="flex flex-col gap-2">
+          <label
+            for="web-sign-in-email"
+            class="text-sm font-semibold text-slate-900"
+          >
+            Adresse email
+          </label>
+          <input
+            id="web-sign-in-email"
+            type="email"
+            formControlName="email"
+            autocomplete="email"
+            placeholder="vous@kraak.org"
+            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+          />
+          @if (form.controls.email.touched && form.controls.email.invalid) {
+            <p class="text-sm leading-6 text-rose-700">
+              Saisissez une adresse email valide.
+            </p>
+          }
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label
+            for="web-sign-in-password"
+            class="text-sm font-semibold text-slate-900"
+          >
+            Mot de passe
+          </label>
+          <input
+            id="web-sign-in-password"
+            type="password"
+            formControlName="password"
+            autocomplete="current-password"
+            placeholder="Minimum 8 caracteres"
+            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+          />
+          @if (
+            form.controls.password.touched && form.controls.password.invalid
+          ) {
+            <p class="text-sm leading-6 text-rose-700">
+              Votre mot de passe doit contenir au moins 8 caracteres.
+            </p>
+          }
+        </div>
+
+        @if (errorMessage()) {
+          <p
+            class="rounded-xl bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-700"
+          >
+            {{ errorMessage() }}
+          </p>
+        }
+
+        <button type="submit" class="btn btn-primary" [disabled]="submitting()">
+          {{ submitting() ? 'Connexion en cours...' : 'Se connecter' }}
+        </button>
+      </form>
+
+      <div
+        class="mt-5 flex flex-col gap-2 border-t border-slate-200 pt-4 text-sm font-semibold"
+      >
+        <a routerLink="/inscription" class="text-brand-blue hover:underline">
+          Creer un compte
+        </a>
+        <a
+          routerLink="/mot-de-passe-oublie"
+          class="text-brand-blue hover:underline"
+        >
+          Mot de passe oublie
+        </a>
+      </div>
+    </section>
+  </div>
+</main>

--- a/apps/client/projects/web/src/app/features/auth/sign-in.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-in.page.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebAuthService } from '../../core/auth/web-auth.service';
+import SignInPage from './sign-in.page';
+
+describe('Web SignInPage', () => {
+  const authService = {
+    signIn: vi.fn(),
+  };
+
+  let router: Router;
+  let navigateByUrlSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    authService.signIn.mockReset();
+    authService.signIn.mockResolvedValue(undefined);
+
+    await TestBed.configureTestingModule({
+      imports: [SignInPage],
+      providers: [
+        provideRouter([]),
+        { provide: WebAuthService, useValue: authService },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    navigateByUrlSpy = vi
+      .spyOn(router, 'navigateByUrl')
+      .mockResolvedValue(true);
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(SignInPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the web auth flow, when the page renders, then the login form and auth links are visible', () => {
+    const fixture = TestBed.createComponent(SignInPage);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('form')).toBeTruthy();
+    expect(element.textContent).toContain('Connexion');
+    expect(element.textContent).toContain('Creer un compte');
+    expect(element.textContent).toContain('Mot de passe oublie');
+  });
+
+  it('Given valid credentials, when the form is submitted, then the auth service is called and the app navigates to the participant dashboard', async () => {
+    const fixture = TestBed.createComponent(SignInPage);
+    fixture.componentInstance.form.setValue({
+      email: '  alice@example.com  ',
+      password: 'motdepasse-securise',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(authService.signIn).toHaveBeenCalledWith({
+      email: 'alice@example.com',
+      password: 'motdepasse-securise',
+    });
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/participant/dashboard');
+  });
+});

--- a/apps/client/projects/web/src/app/features/auth/sign-in.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-in.page.ts
@@ -1,0 +1,81 @@
+import { Component, inject, signal } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import {
+  WebAuthService,
+  resolveAuthErrorMessage,
+} from '../../core/auth/web-auth.service';
+
+interface SignInFormModel {
+  email: FormControl<string>;
+  password: FormControl<string>;
+}
+
+@Component({
+  selector: 'kraak-web-sign-in-page',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink],
+  templateUrl: './sign-in.page.html',
+})
+export default class SignInPage {
+  private readonly authService = inject(WebAuthService);
+  private readonly router = inject(Router);
+
+  readonly form = new FormGroup<SignInFormModel>({
+    email: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.email],
+    }),
+    password: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(8)],
+    }),
+  });
+  readonly errorMessage = signal<string | null>(null);
+  readonly submitting = signal(false);
+
+  async submit(): Promise<void> {
+    normalizeTextControl(this.form.controls.email);
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid || this.submitting()) {
+      return;
+    }
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      const { email, password } = this.form.getRawValue();
+
+      await this.authService.signIn({
+        email: normalizeRequiredText(email),
+        password,
+      });
+
+      await this.router.navigateByUrl('/participant/dashboard');
+    } catch (error) {
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Impossible de vous connecter pour le moment.',
+        ),
+      );
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+}
+
+function normalizeRequiredText(value: string): string {
+  return value.trim();
+}
+
+function normalizeTextControl(control: FormControl<string>): void {
+  control.setValue(normalizeRequiredText(control.getRawValue()));
+}

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.html
@@ -1,0 +1,143 @@
+<main class="min-h-screen bg-slate-50 py-12 sm:py-16">
+  <div class="mx-auto w-full max-w-xl px-4 sm:px-6">
+    <section
+      class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+    >
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+      >
+        Espace participant
+      </p>
+      <h1 class="mt-3 text-3xl font-semibold text-slate-950">
+        Creer un compte
+      </h1>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Ouvrez votre espace KRAAK pour suivre vos programmes et vos prochaines
+        sessions.
+      </p>
+
+      <form
+        [formGroup]="form"
+        (ngSubmit)="submit()"
+        class="mt-6 flex flex-col gap-4"
+        novalidate
+      >
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div class="flex flex-col gap-2">
+            <label
+              for="web-sign-up-first-name"
+              class="text-sm font-semibold text-slate-900"
+            >
+              Prenom
+            </label>
+            <input
+              id="web-sign-up-first-name"
+              type="text"
+              formControlName="firstName"
+              autocomplete="given-name"
+              class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+            />
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <label
+              for="web-sign-up-last-name"
+              class="text-sm font-semibold text-slate-900"
+            >
+              Nom
+            </label>
+            <input
+              id="web-sign-up-last-name"
+              type="text"
+              formControlName="lastName"
+              autocomplete="family-name"
+              class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+            />
+          </div>
+        </div>
+
+        @if (
+          (form.controls.firstName.touched &&
+            form.controls.firstName.invalid) ||
+          (form.controls.lastName.touched && form.controls.lastName.invalid)
+        ) {
+          <p class="text-sm leading-6 text-rose-700">
+            Renseignez votre prenom et votre nom.
+          </p>
+        }
+
+        <div class="flex flex-col gap-2">
+          <label
+            for="web-sign-up-email"
+            class="text-sm font-semibold text-slate-900"
+          >
+            Adresse email
+          </label>
+          <input
+            id="web-sign-up-email"
+            type="email"
+            formControlName="email"
+            autocomplete="email"
+            placeholder="vous@kraak.org"
+            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+          />
+          @if (form.controls.email.touched && form.controls.email.invalid) {
+            <p class="text-sm leading-6 text-rose-700">
+              Saisissez une adresse email valide.
+            </p>
+          }
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label
+            for="web-sign-up-password"
+            class="text-sm font-semibold text-slate-900"
+          >
+            Mot de passe
+          </label>
+          <input
+            id="web-sign-up-password"
+            type="password"
+            formControlName="password"
+            autocomplete="new-password"
+            placeholder="Minimum 8 caracteres"
+            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
+          />
+          @if (
+            form.controls.password.touched && form.controls.password.invalid
+          ) {
+            <p class="text-sm leading-6 text-rose-700">
+              Le mot de passe doit contenir au moins 8 caracteres.
+            </p>
+          }
+        </div>
+
+        @if (errorMessage()) {
+          <p
+            class="rounded-xl bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-700"
+          >
+            {{ errorMessage() }}
+          </p>
+        }
+
+        @if (successMessage()) {
+          <p
+            class="rounded-xl bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-700"
+          >
+            {{ successMessage() }}
+          </p>
+        }
+
+        <button type="submit" class="btn btn-primary" [disabled]="submitting()">
+          {{ submitting() ? 'Creation en cours...' : 'Creer mon compte' }}
+        </button>
+      </form>
+
+      <div class="mt-5 border-t border-slate-200 pt-4 text-sm font-semibold">
+        <a routerLink="/connexion" class="text-brand-blue hover:underline">
+          Deja un compte ? Se connecter
+        </a>
+      </div>
+    </section>
+  </div>
+</main>

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebAuthService } from '../../core/auth/web-auth.service';
+import SignUpPage from './sign-up.page';
+
+describe('Web SignUpPage', () => {
+  const authService = {
+    signUp: vi.fn(),
+  };
+
+  let router: Router;
+  let navigateByUrlSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    authService.signUp.mockReset();
+    authService.signUp.mockResolvedValue({
+      message: 'Votre compte a ete cree.',
+      requiresEmailConfirmation: true,
+      session: null,
+      profile: null,
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [SignUpPage],
+      providers: [
+        provideRouter([]),
+        { provide: WebAuthService, useValue: authService },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    navigateByUrlSpy = vi
+      .spyOn(router, 'navigateByUrl')
+      .mockResolvedValue(true);
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(SignUpPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given valid signup data, when the form is submitted, then the auth service receives normalized values', async () => {
+    const fixture = TestBed.createComponent(SignUpPage);
+    fixture.componentInstance.form.setValue({
+      firstName: '  Alice  ',
+      lastName: '  Dupont  ',
+      email: '  alice@example.com  ',
+      password: 'motdepasse-securise',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(authService.signUp).toHaveBeenCalledWith({
+      firstName: 'Alice',
+      lastName: 'Dupont',
+      email: 'alice@example.com',
+      password: 'motdepasse-securise',
+    });
+    expect(navigateByUrlSpy).not.toHaveBeenCalled();
+    expect(fixture.componentInstance.successMessage()).toBe(
+      'Votre compte a ete cree.',
+    );
+  });
+
+  it('Given a signup response with an active session, when submit resolves, then the app navigates to the participant dashboard', async () => {
+    authService.signUp.mockResolvedValueOnce({
+      message: 'Bienvenue',
+      requiresEmailConfirmation: false,
+      session: {
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        expiresIn: 3600,
+        expiresAt: '2026-05-01T12:00:00.000Z',
+        tokenType: 'bearer',
+      },
+      profile: {
+        appUser: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          role: 'participant',
+          firstName: 'Alice',
+          lastName: 'Dupont',
+          phone: null,
+          preferredContactChannel: null,
+          isActive: true,
+          createdAt: '2026-05-01T12:00:00.000Z',
+          updatedAt: '2026-05-01T12:00:00.000Z',
+        },
+        participant: null,
+      },
+    });
+
+    const fixture = TestBed.createComponent(SignUpPage);
+    fixture.componentInstance.form.setValue({
+      firstName: 'Alice',
+      lastName: 'Dupont',
+      email: 'alice@example.com',
+      password: 'motdepasse-securise',
+    });
+
+    await fixture.componentInstance.submit();
+
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/participant/dashboard');
+  });
+});

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.ts
@@ -1,0 +1,102 @@
+import { Component, inject, signal } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import {
+  WebAuthService,
+  resolveAuthErrorMessage,
+} from '../../core/auth/web-auth.service';
+
+interface SignUpFormModel {
+  firstName: FormControl<string>;
+  lastName: FormControl<string>;
+  email: FormControl<string>;
+  password: FormControl<string>;
+}
+
+@Component({
+  selector: 'kraak-web-sign-up-page',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink],
+  templateUrl: './sign-up.page.html',
+})
+export default class SignUpPage {
+  private readonly authService = inject(WebAuthService);
+  private readonly router = inject(Router);
+
+  readonly form = new FormGroup<SignUpFormModel>({
+    firstName: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(80)],
+    }),
+    lastName: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(80)],
+    }),
+    email: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.email],
+    }),
+    password: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(8)],
+    }),
+  });
+  readonly errorMessage = signal<string | null>(null);
+  readonly successMessage = signal<string | null>(null);
+  readonly submitting = signal(false);
+
+  async submit(): Promise<void> {
+    normalizeTextControl(this.form.controls.firstName);
+    normalizeTextControl(this.form.controls.lastName);
+    normalizeTextControl(this.form.controls.email);
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid || this.submitting()) {
+      return;
+    }
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    try {
+      const { firstName, lastName, email, password } = this.form.getRawValue();
+
+      const response = await this.authService.signUp({
+        firstName: normalizeRequiredText(firstName),
+        lastName: normalizeRequiredText(lastName),
+        email: normalizeRequiredText(email),
+        password,
+      });
+
+      if (response.session && response.profile) {
+        await this.router.navigateByUrl('/participant/dashboard');
+        return;
+      }
+
+      this.successMessage.set(response.message);
+    } catch (error) {
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Impossible de creer le compte pour le moment.',
+        ),
+      );
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+}
+
+function normalizeRequiredText(value: string): string {
+  return value.trim();
+}
+
+function normalizeTextControl(control: FormControl<string>): void {
+  control.setValue(normalizeRequiredText(control.getRawValue()));
+}

--- a/apps/client/tests/e2e/participant-core-journey.spec.ts
+++ b/apps/client/tests/e2e/participant-core-journey.spec.ts
@@ -1,14 +1,15 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Parcours coeur participant - orientation web', () => {
-  test('Given un visiteur non authentifie, When il tente l acces dashboard participant, Then il est redirige vers l accueil et oriente vers des pages publiques', async ({
+  test('Given un visiteur non authentifie, When il tente l acces dashboard participant, Then il est redirige vers la connexion et oriente vers des pages publiques', async ({
     page,
   }) => {
     await page.goto('/participant/dashboard');
 
-    await expect(page).toHaveURL(/\/$/);
-    await expect(page).toHaveTitle('KRAAK | Développez votre potentiel');
-    await expect(page.getByRole('banner')).toContainText('KRAAK');
+    await expect(page).toHaveURL(/\/connexion$/);
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Connexion' }),
+    ).toBeVisible();
 
     await page.goto('/programmes');
     await expect(

--- a/apps/client/tests/e2e/participant-dashboard.spec.ts
+++ b/apps/client/tests/e2e/participant-dashboard.spec.ts
@@ -4,15 +4,17 @@ import { expect, test } from '@playwright/test';
 // Given/When/Then : un visiteur non authentifié ne doit pas voir le dashboard.
 
 test.describe('Dashboard web participant — protection de route', () => {
-  test(`Given un visiteur non authentifié, When il navigue vers /participant/dashboard, Then la route est protégée et redirige vers l'accueil`, async ({
+  test(`Given un visiteur non authentifié, When il navigue vers /participant/dashboard, Then la route est protégée et redirige vers la connexion`, async ({
     page,
   }) => {
     await page.goto('/participant/dashboard');
 
-    // Le guard participant redirige vers l'accueil quand l'utilisateur n'est
+    // Le guard participant redirige vers la connexion quand l'utilisateur n'est
     // pas authentifié comme participant.
-    await expect(page).toHaveURL(/\/$/);
-    await expect(page).toHaveTitle('KRAAK | Développez votre potentiel');
+    await expect(page).toHaveURL(/\/connexion$/);
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Connexion' }),
+    ).toBeVisible();
   });
 
   test(`Given un visiteur non authentifié, When il navigue vers /participant, Then la redirection vers le dashboard reste protégée`, async ({
@@ -20,7 +22,7 @@ test.describe('Dashboard web participant — protection de route', () => {
   }) => {
     await page.goto('/participant');
 
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/connexion$/);
   });
 
   test(`Given un visiteur non authentifié, When il tente d'accéder à /participant/dashboard, Then la vue privée n'est pas affichée`, async ({
@@ -28,9 +30,10 @@ test.describe('Dashboard web participant — protection de route', () => {
   }) => {
     await page.goto('/participant/dashboard');
 
-    await expect(page).toHaveURL(/\/$/);
-    await expect(page).toHaveTitle('KRAAK | Développez votre potentiel');
-    await expect(page.getByRole('banner')).toContainText('KRAAK');
+    await expect(page).toHaveURL(/\/connexion$/);
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Connexion' }),
+    ).toBeVisible();
     await expect(
       page.getByRole('heading', {
         level: 1,


### PR DESCRIPTION
## Summary
Implement web auth parity for Epic AUT (#150) with secure, explicit unauthenticated redirection and complete auth UI flow.

## Changes
- Add web auth pages:
  - /connexion
  - /inscription
  - /mot-de-passe-oublie
- Add form validation and API wiring for sign-in, sign-up, and password-reset.
- Add reusable web auth API error resolver to surface backend validation and auth errors.
- Update web protected-route guards to redirect unauthenticated users to /connexion.
- Update route specs and guard specs to cover new auth routes and redirect behavior.
- Update participant e2e scenarios to assert the new redirect target (/connexion).

## Validation
- pnpm --dir apps/client test:web
- pnpm --dir apps/client exec playwright test tests/e2e/participant-dashboard.spec.ts tests/e2e/participant-core-journey.spec.ts

## Related
Closes #150
