### PR TITLE
[EPIC][DSH] Dashboard #152 - Proposer une page d'accueil participant avec synthese utile

### DIFF
--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
@@ -65,14 +65,18 @@
         </div>
         @if (!loading() && !errorMessage()) {
           <p class="text-sm font-medium text-slate-600">
-            {{ totalSummaryItems() }} éléments clés disponibles aujourd’hui.
+            {{ totalSummaryLabel() }}
           </p>
         }
       </div>
 
-      @if (loading() || errorMessage()) {
+      @if (loading()) {
         <p class="mt-4 text-sm leading-6 text-slate-600">
           La synthèse se met à jour avec vos dernières informations.
+        </p>
+      } @else if (errorMessage()) {
+        <p class="mt-4 text-sm leading-6 text-red-700">
+          La synthèse n'a pas pu être chargée pour le moment.
         </p>
       } @else {
         <div class="mt-5 grid gap-4 lg:grid-cols-[1.65fr_minmax(16rem,1fr)]">

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
@@ -24,13 +24,16 @@
         </div>
       </div>
 
-      <aside class="rounded-3xl bg-slate-950 p-5 text-white shadow-sm">
+      <aside
+        class="rounded-3xl bg-slate-950 p-5 text-white shadow-sm"
+        aria-labelledby="dashboard-attention-title"
+      >
         <p
           class="text-sm font-semibold tracking-[0.22em] text-cyan-200 uppercase"
         >
           Point d'attention
         </p>
-        <h2 class="mt-3 text-2xl font-semibold">
+        <h2 id="dashboard-attention-title" class="mt-3 text-2xl font-semibold">
           Rester aligné sur la prochaine étape
         </h2>
         <p class="mt-3 text-sm leading-6 text-slate-200">
@@ -38,6 +41,82 @@
           sessions et annonces récentes sont consolidés ici.
         </p>
       </aside>
+    </section>
+
+    <section
+      class="mt-8 rounded-[1.75rem] bg-white p-6 shadow-sm ring-1 ring-slate-200/80 sm:p-7"
+      aria-labelledby="dashboard-synthesis-title"
+    >
+      <div
+        class="flex flex-col gap-3 border-b border-slate-200/80 pb-4 sm:flex-row sm:items-end sm:justify-between"
+      >
+        <div>
+          <p
+            class="text-sm font-semibold tracking-[0.22em] text-slate-500 uppercase"
+          >
+            Accueil participant
+          </p>
+          <h2
+            id="dashboard-synthesis-title"
+            class="mt-2 text-2xl font-semibold text-slate-950"
+          >
+            Synthèse utile
+          </h2>
+        </div>
+        @if (!loading() && !errorMessage()) {
+          <p class="text-sm font-medium text-slate-600">
+            {{ totalSummaryItems() }} éléments clés disponibles aujourd’hui.
+          </p>
+        }
+      </div>
+
+      @if (loading() || errorMessage()) {
+        <p class="mt-4 text-sm leading-6 text-slate-600">
+          La synthèse se met à jour avec vos dernières informations.
+        </p>
+      } @else {
+        <div class="mt-5 grid gap-4 lg:grid-cols-[1.65fr_minmax(16rem,1fr)]">
+          <div class="grid gap-3 sm:grid-cols-3">
+            @for (indicator of summaryIndicators(); track indicator.id) {
+              <article
+                class="rounded-2xl bg-slate-50 p-4 ring-1 ring-slate-200/80"
+              >
+                <p
+                  class="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase"
+                >
+                  {{ indicator.label }}
+                </p>
+                <p class="mt-2 text-3xl font-semibold text-slate-950">
+                  {{ indicator.value }}
+                </p>
+                <p class="mt-2 text-xs leading-5 text-slate-600">
+                  {{ indicator.detail }}
+                </p>
+              </article>
+            }
+          </div>
+
+          <aside
+            class="rounded-2xl bg-slate-950 p-4 text-white ring-1 ring-slate-900"
+            aria-labelledby="dashboard-next-step-title"
+          >
+            <p
+              class="text-xs font-semibold tracking-[0.2em] text-cyan-200 uppercase"
+            >
+              Prochaine étape
+            </p>
+            <h3
+              id="dashboard-next-step-title"
+              class="mt-2 text-lg font-semibold"
+            >
+              Prochaine session
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-slate-200">
+              {{ nextSessionSummary() }}
+            </p>
+          </aside>
+        </div>
+      }
     </section>
 
     <section
@@ -61,13 +140,12 @@
           </h2>
         </div>
         @if (loading()) {
-          <span
+          <output
             class="text-sm font-medium tracking-[0.18em] text-slate-500 uppercase"
-            role="status"
             aria-live="polite"
           >
             Chargement…
-          </span>
+          </output>
         }
       </div>
 

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
@@ -124,6 +124,7 @@ describe('Web Participant Dashboard Page', () => {
       );
 
       expect(text).toContain('Mon dashboard');
+      expect(text).toContain('Synthèse utile');
       expect(text).toContain("Parcours d'intégration");
       expect(text).toContain('Atelier CV');
       expect(text).toContain('Rappel documents');
@@ -131,6 +132,22 @@ describe('Web Participant Dashboard Page', () => {
       expect(linkHrefs).toEqual(
         expect.arrayContaining(['/programmes', '/contact']),
       );
+    });
+
+    it('Given populated dashboard aggregate, When the page loads, Then it renders useful synthesis indicators and next step summary', async () => {
+      const fixture = TestBed.createComponent(DashboardPage);
+      configureDashboardClient(fixture, Promise.resolve(POPULATED_AGGREGATE));
+      await flush(fixture);
+
+      const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+      expect(text).toContain('Synthèse utile');
+      expect(text).toContain('Programmes actifs');
+      expect(text).toContain('Sessions à venir');
+      expect(text).toContain('Annonces récentes');
+      expect(text).toContain('3 éléments clés disponibles aujourd’hui.');
+      expect(text).toContain('Prochaine session');
+      expect(text).toContain('Atelier CV');
     });
 
     it('Given an empty dashboard aggregate, When the page loads, Then it renders the global empty state', async () => {

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
@@ -147,7 +147,18 @@ describe('Web Participant Dashboard Page', () => {
       expect(text).toContain('Annonces récentes');
       expect(text).toContain('3 éléments clés disponibles aujourd’hui.');
       expect(text).toContain('Prochaine session');
-      expect(text).toContain('Atelier CV');
+      expect(text).toContain('Atelier CV - ');
+    });
+
+    it('Given no upcoming sessions, When the page loads, Then it renders the no-session summary in next step', async () => {
+      const fixture = TestBed.createComponent(DashboardPage);
+      configureDashboardClient(fixture, Promise.resolve(EMPTY_AGGREGATE));
+      await flush(fixture);
+
+      const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+      expect(text).toContain('Prochaine session');
+      expect(text).toContain('Aucune session planifiée pour le moment.');
     });
 
     it('Given an empty dashboard aggregate, When the page loads, Then it renders the global empty state', async () => {

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
@@ -98,6 +98,13 @@ export default class DashboardPage implements OnInit {
       this.upcomingSessions().length +
       this.recentAnnouncements().length,
   );
+  readonly totalSummaryLabel = computed(() => {
+    const itemCount = this.totalSummaryItems();
+
+    return itemCount === 1
+      ? '1 élément clé disponible aujourd’hui.'
+      : `${itemCount} éléments clés disponibles aujourd’hui.`;
+  });
   readonly nextSessionSummary = computed(() => {
     const nextSession = this.upcomingSessions()[0];
     if (!nextSession) {
@@ -140,7 +147,6 @@ export default class DashboardPage implements OnInit {
       day: '2-digit',
       month: 'long',
       year: 'numeric',
-      timeZone: 'UTC',
     }).format(parsedDate);
   }
 }

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
@@ -14,6 +14,13 @@ interface DashboardQuickLink {
   readonly href: string;
 }
 
+interface DashboardSummaryIndicator {
+  readonly id: 'programs' | 'sessions' | 'announcements';
+  readonly label: string;
+  readonly value: string;
+  readonly detail: string;
+}
+
 const QUICK_LINKS: readonly DashboardQuickLink[] = [
   {
     label: 'Voir les programmes',
@@ -63,6 +70,42 @@ export default class DashboardPage implements OnInit {
   readonly recentAnnouncements = this.selectFromAggregate(
     'recentAnnouncements',
   );
+  readonly summaryIndicators = computed<readonly DashboardSummaryIndicator[]>(
+    () => [
+      {
+        id: 'programs',
+        label: 'Programmes actifs',
+        value: `${this.programs().length}`,
+        detail: 'Parcours en cours ou récemment activés',
+      },
+      {
+        id: 'sessions',
+        label: 'Sessions à venir',
+        value: `${this.upcomingSessions().length}`,
+        detail: 'Rappels des prochains rendez-vous',
+      },
+      {
+        id: 'announcements',
+        label: 'Annonces récentes',
+        value: `${this.recentAnnouncements().length}`,
+        detail: 'Informations récentes publiées par KRAAK',
+      },
+    ],
+  );
+  readonly totalSummaryItems = computed(
+    () =>
+      this.programs().length +
+      this.upcomingSessions().length +
+      this.recentAnnouncements().length,
+  );
+  readonly nextSessionSummary = computed(() => {
+    const nextSession = this.upcomingSessions()[0];
+    if (!nextSession) {
+      return 'Aucune session planifiée pour le moment.';
+    }
+
+    return `${nextSession.title} - ${this.formatDate(nextSession.startsAt)}`;
+  });
   readonly hasDashboardContent = computed(
     () =>
       this.programs().length > 0 ||
@@ -85,5 +128,19 @@ export default class DashboardPage implements OnInit {
       setData: (value) => this.dashboardState.set(value),
       setError: (value) => this.errorMessage.set(value),
     });
+  }
+
+  private formatDate(rawDate: string): string {
+    const parsedDate = new Date(rawDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return rawDate;
+    }
+
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }).format(parsedDate);
   }
 }


### PR DESCRIPTION
## Résumé\n- enrichit la page dashboard participant web avec une section "Synthèse utile"\n- ajoute des indicateurs clés (programmes, sessions, annonces) et une carte "Prochaine session"\n- améliore l'accessibilité de la vue (libellé d'aside, output live region)\n- couvre le nouveau comportement avec des tests unitaires dashboard\n\n## Validation\n- pnpm --filter @kraak/client run test:web\n\nCloses #152