### PR TITLE
fix(api): harden announcements pagination

### DIFF
--- a/apps/api/src/announcements/announcements.service.spec.ts
+++ b/apps/api/src/announcements/announcements.service.spec.ts
@@ -176,6 +176,93 @@ describe('AnnouncementsService', () => {
 
       await expect(service.listAnnouncements(accessToken)).rejects.toThrow();
     });
+
+    it('Given: invalid pagination values, When: listAnnouncements called, Then: fallback pagination defaults are applied', async () => {
+      const accessToken = 'valid-token';
+      const participantId = 'participant-001';
+      const userId = 'user-001';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: userId },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: participantId },
+        error: null,
+      });
+
+      const announcementsQuery = createAsyncQuery(
+        {
+          data: [
+            {
+              id: 'ann-001',
+              title: 'A1',
+              body: 'Body 1',
+              priority: 'high',
+              audience_type: 'all_participants',
+              program_id: null,
+              cohort_id: null,
+              status: 'published',
+              published_at: '2026-04-20T10:00:00Z',
+              created_by_user_id: 'user-001',
+              created_at: '2026-04-19T10:00:00Z',
+              updated_at: '2026-04-20T10:00:00Z',
+            },
+            {
+              id: 'ann-002',
+              title: 'A2',
+              body: 'Body 2',
+              priority: 'normal',
+              audience_type: 'all_participants',
+              program_id: null,
+              cohort_id: null,
+              status: 'published',
+              published_at: '2026-04-20T09:00:00Z',
+              created_by_user_id: 'user-001',
+              created_at: '2026-04-19T09:00:00Z',
+              updated_at: '2026-04-20T09:00:00Z',
+            },
+          ],
+          error: null,
+        },
+        { withOrder: true },
+      );
+
+      const enrollmentsQuery = createAsyncQuery(
+        {
+          data: [],
+          error: null,
+        },
+        { withIn: true },
+      );
+
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+          if (table === 'announcement') {
+            return announcementsQuery;
+          }
+          if (table === 'enrollment') {
+            return enrollmentsQuery;
+          }
+        }),
+      });
+
+      const result = await service.listAnnouncements(
+        accessToken,
+        Number.NaN,
+        -5,
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].id).toBe('ann-001');
+    });
   });
 
   describe('getAnnouncementById', () => {

--- a/apps/api/src/announcements/announcements.service.ts
+++ b/apps/api/src/announcements/announcements.service.ts
@@ -52,8 +52,8 @@ export class AnnouncementsService {
     limit?: number,
   ): Promise<{ data: AnnouncementDto[]; total: number }> {
     const adminClient = this.supabaseService.getClient();
-    const paginationLimit = Math.min(limit ?? 20, 100);
-    const paginationPage = Math.max(page ?? 1, 1);
+    const paginationLimit = this.resolvePaginationLimit(limit);
+    const paginationPage = this.resolvePaginationPage(page);
 
     // Get participant ID from access token
     const participantId = await this.resolveParticipantId(accessToken);
@@ -105,6 +105,26 @@ export class AnnouncementsService {
       data: paginated,
       total: sorted.length,
     };
+  }
+
+  private resolvePaginationLimit(limit?: number): number {
+    const parsedLimit = Number(limit);
+
+    if (!Number.isFinite(parsedLimit) || parsedLimit < 1) {
+      return 20;
+    }
+
+    return Math.min(Math.floor(parsedLimit), 100);
+  }
+
+  private resolvePaginationPage(page?: number): number {
+    const parsedPage = Number(page);
+
+    if (!Number.isFinite(parsedPage) || parsedPage < 1) {
+      return 1;
+    }
+
+    return Math.floor(parsedPage);
   }
 
   /**


### PR DESCRIPTION
## Resume
- securise la pagination des endpoints annonces cote service (parametres page/limit)
- applique des valeurs par defaut robustes pour les valeurs invalides
- ajoute un test de non-regression ANN pour les parametres de pagination invalides

## Validation
- pnpm --filter @kraak/api test -- announcements.service.spec.ts announcements.controller.spec.ts integration/critical-modules.integration.spec.ts
- hooks de push executes avec succes: format, lint, tests libs/api/client + e2e

Refs #155
