### PR TITLE
fix(infra): compile @kraak/domain and @kraak/contracts to JS for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Construire les packages workspace
+        run: pnpm -r --filter "./packages/**" build
+
       - name: Build web (production SSR)
         run: pnpm build:web
 
@@ -85,6 +88,9 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Construire les packages workspace
+        run: pnpm -r --filter "./packages/**" build
 
       - name: Exécuter les tests unitaires
         run: pnpm test:unit
@@ -143,6 +149,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Construire les packages workspace
+        run: pnpm -r --filter "./packages/**" build
+
       - name: Installer les navigateurs Playwright
         run: pnpm --filter @kraak/client exec playwright install --with-deps chromium
 
@@ -180,6 +189,9 @@ jobs:
           java-version: '21'
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Construire les packages workspace
+        run: pnpm -r --filter "./packages/**" build
 
       - name: Build mobile & sync Android
         run: pnpm build:debug:android

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        run: pnpm -r --filter "./packages/**" build
+
       - name: Run tests with coverage
         run: pnpm test:coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ tmp/
 apps/client/projects/mobile/public/assets/runtime-config.js
 apps/client/projects/web/public/assets/runtime-config.js
 apps/client/android/
+
+.vercel
+.env*.local

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,8 +32,7 @@ COPY tsconfig.base.json ./
 COPY apps/api/ apps/api/
 COPY packages/contracts/ packages/contracts/
 COPY packages/domain/ packages/domain/
-RUN pnpm --filter @kraak/contracts --filter @kraak/domain build && \
-    pnpm --filter @kraak/api build && \
+RUN pnpm --filter @kraak/api... build && \
     pnpm deploy --filter @kraak/api --prod --legacy /prod/api
 
 # --- Étape 3 : image de production minimaliste ---

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,7 +32,8 @@ COPY tsconfig.base.json ./
 COPY apps/api/ apps/api/
 COPY packages/contracts/ packages/contracts/
 COPY packages/domain/ packages/domain/
-RUN pnpm --filter @kraak/api build && \
+RUN pnpm --filter @kraak/contracts --filter @kraak/domain build && \
+    pnpm --filter @kraak/api build && \
     pnpm deploy --filter @kraak/api --prod --legacy /prod/api
 
 # --- Étape 3 : image de production minimaliste ---

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -2,12 +2,19 @@
   "name": "@kraak/contracts",
   "version": "0.0.0",
   "private": true,
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "clean": "node ../../scripts/clean.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepare": "pnpm run build",
     "clean": "node ../../scripts/clean.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/contracts/tsconfig.build.json
+++ b/packages/contracts/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "verbatimModuleSyntax": false
+  },
+  "exclude": ["**/*.spec.ts", "dist", "node_modules"]
+}

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -2,12 +2,19 @@
   "name": "@kraak/domain",
   "version": "0.0.0",
   "private": true,
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "clean": "node ../../scripts/clean.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepare": "pnpm run build",
     "clean": "node ../../scripts/clean.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/domain/tsconfig.build.json
+++ b/packages/domain/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "verbatimModuleSyntax": false
+  },
+  "exclude": ["**/*.spec.ts", "dist", "node_modules"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter @kraak/client run build",
+  "buildCommand": "pnpm -r --filter \"./packages/**\" build && pnpm --filter @kraak/client run build",
   "outputDirectory": "apps/client/dist/web/browser",
   "framework": null
 }


### PR DESCRIPTION
## Contexte

Le déploiement Render de `@kraak/api` plantait au démarrage sur Node 24 avec `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` : Node refuse le type-stripping TypeScript dans `node_modules`, et `pnpm deploy` copiait les sources `.ts` brutes des packages `@kraak/domain` et `@kraak/contracts`.

## Correctif

- Émission CJS (`dist/`) depuis `packages/domain` et `packages/contracts`.
- Repointage des champs `main`, `types`, `exports`, `files` vers `dist/`.
- Build des packages dans `apps/api/Dockerfile` avant `pnpm deploy --filter @kraak/api --prod`.
- Ajout de `tsconfig.build.json` par package forçant `module: CommonJS` / `moduleResolution: Node` / `verbatimModuleSyntax: false`, sans toucher aux `tsconfig.json` (ESNext préservé pour l'éditeur et le typecheck).
- `.gitignore` : ignore les `dist/` des packages.

## Validation

- `pnpm --filter @kraak/api test` : 21 suites / 139 tests verts.
- Pre-push hook (workspace tests + 22 E2E Playwright) : tout vert.
- Build local des packages vérifié — sortie CJS confirmée.

## Suite

Après merge : poll `/health` Render, rotation de la clé API Render exposée, configuration des variables d'env Render et Vercel, smoke test E2E sur l'environnement déployé.