### PR TITLE
fix(infra): corriger hotspots Sonar Docker chmod et ReDoS regex

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -57,7 +57,7 @@ ENV NODE_ENV=production \
 # Copies avec ownership correct dès la création
 COPY --from=build --chown=nestjs:nodejs --chmod=0555 /prod/api/node_modules ./node_modules
 COPY --from=build --chown=nestjs:nodejs --chmod=0444 /prod/api/package.json ./package.json
-COPY --from=build --chown=nestjs:nodejs /app/apps/api/dist ./dist
+COPY --from=build --chown=nestjs:nodejs --chmod=0555 /app/apps/api/dist ./dist
 
 USER nestjs
 EXPOSE 3000

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -62,9 +62,9 @@ ENV NODE_ENV=production \
     HOST=0.0.0.0
 
 # Runtime SSR (express) + sortie Angular
-COPY --from=build --chown=angular:nodejs /prod/web/node_modules ./node_modules
-COPY --from=build --chown=angular:nodejs /prod/web/package.json ./package.json
-COPY --from=build --chown=angular:nodejs /app/apps/client/dist ./dist
+COPY --from=build --chown=angular:nodejs --chmod=0555 /prod/web/node_modules ./node_modules
+COPY --from=build --chown=angular:nodejs --chmod=0444 /prod/web/package.json ./package.json
+COPY --from=build --chown=angular:nodejs --chmod=0555 /app/apps/client/dist ./dist
 
 USER angular
 EXPOSE 4000

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -37,15 +37,18 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 
 export const seoPages = siteSeoDefinitions as SeoPageDefinition[];
 
+const SLASH_CHAR_CODE = '/'.charCodeAt(0);
+
 const trimLeadingSlashes = (str: string): string => {
   let start = 0;
-  while (start < str.length && str.charCodeAt(start) === 47) start++;
+  while (start < str.length && str.charCodeAt(start) === SLASH_CHAR_CODE)
+    start++;
   return start === 0 ? str : str.slice(start);
 };
 
 const trimTrailingSlashes = (str: string): string => {
   let end = str.length;
-  while (end > 0 && str.charCodeAt(end - 1) === 47) end--;
+  while (end > 0 && str.charCodeAt(end - 1) === SLASH_CHAR_CODE) end--;
   return end === str.length ? str : str.slice(0, end);
 };
 

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -37,11 +37,23 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 
 export const seoPages = siteSeoDefinitions as SeoPageDefinition[];
 
+const trimLeadingSlashes = (str: string): string => {
+  let start = 0;
+  while (start < str.length && str.charCodeAt(start) === 47) start++;
+  return start === 0 ? str : str.slice(start);
+};
+
+const trimTrailingSlashes = (str: string): string => {
+  let end = str.length;
+  while (end > 0 && str.charCodeAt(end - 1) === 47) end--;
+  return end === str.length ? str : str.slice(0, end);
+};
+
 const normalizeRoutePath = (path: string): string =>
-  path.replaceAll(/^\/+|\/+$/g, '');
+  trimTrailingSlashes(trimLeadingSlashes(path));
 
 export const normalizeSiteUrl = (siteUrl: string): string =>
-  siteUrl.replaceAll(/\/+$/g, '') || DEFAULT_SITE_URL;
+  trimTrailingSlashes(siteUrl) || DEFAULT_SITE_URL;
 
 export const resolvePublicSiteUrl = (siteUrl?: string): string => {
   const runtimeSiteUrl = runtimeGlobals.process?.env?.['PUBLIC_SITE_URL'] ?? '';


### PR DESCRIPTION
## Résumé

Correction de 9 hotspots de sécurité SonarCloud détectés dans les Dockerfiles et le code TypeScript.

## Hotspots corrigés

### docker:S6504 – Write permissions sur les instructions COPY (×6)

**`apps/api/Dockerfile`**
- Ligne 60 : ajout de `--chmod=0555` sur le COPY `dist` (le dossier n'avait aucun chmod)

**`apps/client/Dockerfile`**
- Lignes 65-67 : ajout de `--chmod=0555` sur `node_modules` et `dist`, `--chmod=0444` sur `package.json`

### typescript:S5852 – ReDoS via regex (×2)

**`apps/client/projects/web/src/app/seo/site-seo.ts`**
- Remplacement de `/^\/+|\/+$/g` et `/\/+$/g` par des helpers linéaires `trimLeadingSlashes` / `trimTrailingSlashes` basés sur `charCodeAt` (aucune regex, aucun backtracking)

### Web:S5725 – Absence de SRI sur lien Google Fonts (×1)

- Marqué `SAFE` directement dans SonarCloud : Google Fonts sert du CSS généré dynamiquement par user-agent, un hash SRI statique est impossible à pré-calculer. Risque évalué et accepté pour le MVP.

## Validation

- 98 tests web passent ✓

Closes #255