### PR TITLE
refactor(web): convertir caractères français en entités HTML nommées

### DIFF
--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-detail.page.html
@@ -46,7 +46,7 @@
           <span
             class="rounded-full bg-neutral-100 px-2 py-1 text-xs font-semibold text-neutral-700"
           >
-            Publié le {{ detail.publishedAt | date: 'fullDate' }}
+            Publi&eacute; le {{ detail.publishedAt | date: 'fullDate' }}
           </span>
         }
       </div>

--- a/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.html
+++ b/apps/client/projects/mobile/src/app/features/announcements/announcement-list.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="Flux participant"
   title="Annonces"
-  description="Gardez un oeil sur les informations à relayer rapidement."
+  description="Gardez un oeil sur les informations &agrave; relayer rapidement."
 >
   @if (errorMessage()) {
     <section
@@ -62,7 +62,8 @@
             <span
               class="rounded-full bg-neutral-100 px-2 py-1 text-xs font-semibold text-neutral-700"
             >
-              Publié le {{ announcement.publishedAt | date: 'mediumDate' }}
+              Publi&eacute; le
+              {{ announcement.publishedAt | date: 'mediumDate' }}
             </span>
           }
         </div>
@@ -81,7 +82,7 @@
           expand="block"
           class="kraak-primary-button"
         >
-          Lire le détail
+          Lire le d&eacute;tail
         </ion-button>
       </section>
     }

--- a/apps/client/projects/mobile/src/app/features/auth/password-reset.page.html
+++ b/apps/client/projects/mobile/src/app/features/auth/password-reset.page.html
@@ -57,7 +57,7 @@
         class="kraak-primary-button"
         [disabled]="submitting()"
       >
-        {{ submitting() ? 'Envoi en cours...' : 'R&eacute;initialiser' }}
+        {{ submitting() ? 'Envoi en cours...' : 'Réinitialiser' }}
       </ion-button>
     </form>
 

--- a/apps/client/projects/mobile/src/app/features/auth/password-reset.page.html
+++ b/apps/client/projects/mobile/src/app/features/auth/password-reset.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
-  eyebrow="Sécurité"
-  title="Réinitialiser votre mot de passe"
-  description="Entrez votre adresse email pour recevoir un lien sécurisé de récupération."
+  eyebrow="S&eacute;curit&eacute;"
+  title="R&eacute;initialiser votre mot de passe"
+  description="Entrez votre adresse email pour recevoir un lien s&eacute;curis&eacute; de r&eacute;cup&eacute;ration."
   backHref="/sign-in"
 >
   <section
@@ -57,13 +57,13 @@
         class="kraak-primary-button"
         [disabled]="submitting()"
       >
-        {{ submitting() ? 'Envoi en cours...' : 'Réinitialiser' }}
+        {{ submitting() ? 'Envoi en cours...' : 'R&eacute;initialiser' }}
       </ion-button>
     </form>
 
     <div class="border-brand-blue/12 border-t pt-4">
       <a routerLink="/sign-in" class="text-brand-blue text-sm font-semibold">
-        Retour à la connexion
+        Retour &agrave; la connexion
       </a>
     </div>
   </section>

--- a/apps/client/projects/mobile/src/app/features/auth/sign-in.page.html
+++ b/apps/client/projects/mobile/src/app/features/auth/sign-in.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
-  eyebrow="Accès"
+  eyebrow="Acc&egrave;s"
   title="Se connecter"
-  description="Retrouvez vos programmes, vos annonces et votre canal de support en un seul accès."
+  description="Retrouvez vos programmes, vos annonces et votre canal de support en un seul acc&egrave;s."
   backHref="/welcome"
 >
   <section
@@ -47,12 +47,12 @@
           type="password"
           formControlName="password"
           autocomplete="current-password"
-          placeholder="Minimum 8 caractères"
+          placeholder="Minimum 8 caract&egrave;res"
           class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
         />
         @if (form.controls.password.touched && form.controls.password.invalid) {
           <p class="text-sm leading-6 text-rose-700">
-            Votre mot de passe doit contenir au moins 8 caractères.
+            Votre mot de passe doit contenir au moins 8 caract&egrave;res.
           </p>
         }
       </div>
@@ -77,13 +77,13 @@
 
     <div class="border-brand-blue/12 flex flex-col gap-3 border-t pt-4">
       <a routerLink="/sign-up" class="text-brand-blue text-sm font-semibold">
-        Créer un compte
+        Cr&eacute;er un compte
       </a>
       <a
         routerLink="/password-reset"
         class="text-brand-blue text-sm font-semibold"
       >
-        Mot de passe oublié
+        Mot de passe oubli&eacute;
       </a>
     </div>
   </section>

--- a/apps/client/projects/mobile/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/mobile/src/app/features/auth/sign-up.page.html
@@ -130,11 +130,7 @@
         class="kraak-primary-button"
         [disabled]="submitting()"
       >
-        {{
-          submitting()
-            ? 'Cr&eacute;ation en cours...'
-            : 'Cr&eacute;er un compte'
-        }}
+        {{ submitting() ? 'Création en cours...' : 'Créer un compte' }}
       </ion-button>
     </form>
 

--- a/apps/client/projects/mobile/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/mobile/src/app/features/auth/sign-up.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="Compte"
-  title="Créer un compte"
-  description="Préparez votre accès participant avec vos informations de base, puis confirmez votre email."
+  title="Cr&eacute;er un compte"
+  description="Pr&eacute;parez votre acc&egrave;s participant avec vos informations de base, puis confirmez votre email."
   backHref="/sign-in"
 >
   <section
@@ -19,7 +19,7 @@
             for="sign-up-first-name"
             class="text-sm font-semibold text-neutral-900"
           >
-            Prénom
+            Pr&eacute;nom
           </label>
           <input
             id="sign-up-first-name"
@@ -76,7 +76,7 @@
           type="password"
           formControlName="password"
           autocomplete="new-password"
-          placeholder="Minimum 8 caractères"
+          placeholder="Minimum 8 caract&egrave;res"
           class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
         />
       </div>
@@ -86,7 +86,7 @@
           for="sign-up-phone"
           class="text-sm font-semibold text-neutral-900"
         >
-          Téléphone
+          T&eacute;l&eacute;phone
         </label>
         <input
           id="sign-up-phone"
@@ -97,14 +97,14 @@
           class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
         />
         <p class="text-sm leading-6 text-neutral-700">
-          Optionnel. Ajoutez-le si vous souhaitez être recontacté plus
-          facilement.
+          Optionnel. Ajoutez-le si vous souhaitez &ecirc;tre recontact&eacute;
+          plus facilement.
         </p>
       </div>
 
       @if (form.invalid && form.touched) {
         <p class="text-sm leading-6 text-rose-700">
-          Vérifiez vos informations avant de continuer.
+          V&eacute;rifiez vos informations avant de continuer.
         </p>
       }
 
@@ -130,7 +130,11 @@
         class="kraak-primary-button"
         [disabled]="submitting()"
       >
-        {{ submitting() ? 'Création en cours...' : 'Créer un compte' }}
+        {{
+          submitting()
+            ? 'Cr&eacute;ation en cours...'
+            : 'Cr&eacute;er un compte'
+        }}
       </ion-button>
     </form>
 

--- a/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
+++ b/apps/client/projects/mobile/src/app/features/dashboard/home.page.html
@@ -39,7 +39,7 @@
               KRAAK mobile
             </p>
             <p class="text-brand-white/84 text-sm">
-              Un point d'entrée simple vers vos programmes, annonces et
+              Un point d'entr&eacute;e simple vers vos programmes, annonces et
               ressources.
             </p>
           </div>
@@ -50,8 +50,9 @@
             Bienvenue sur KRAAK.
           </h1>
           <p class="text-brand-white/80 max-w-md text-sm leading-7">
-            Retrouvez rapidement les informations utiles, les opportunités à
-            suivre et les canaux pour rester en lien avec notre équipe.
+            Retrouvez rapidement les informations utiles, les
+            opportunit&eacute;s &agrave; suivre et les canaux pour rester en
+            lien avec notre &eacute;quipe.
           </p>
         </div>
 
@@ -114,7 +115,7 @@
               (keydown)="$event.stopPropagation()"
               onKeyDown="void(0)"
             >
-              Réessayer
+              R&eacute;essayer
             </ion-button>
           </div>
         } @else if (loading()) {
@@ -153,7 +154,7 @@
               <p class="kraak-overline">Prochaines sessions</p>
               @if (upcomingSessions.length === 0) {
                 <p class="text-sm leading-6 text-neutral-700">
-                  Aucune session planifiée pour le moment.
+                  Aucune session planifi&eacute;e pour le moment.
                 </p>
               } @else {
                 <ul class="space-y-2">
@@ -173,7 +174,7 @@
 
             <div class="space-y-2">
               <div class="flex items-center justify-between gap-3">
-                <p class="kraak-overline">Annonces récentes</p>
+                <p class="kraak-overline">Annonces r&eacute;centes</p>
                 <a
                   routerLink="/tabs/annonces"
                   class="kraak-inline-link text-xs"
@@ -183,7 +184,7 @@
               </div>
               @if (recentAnnouncements.length === 0) {
                 <p class="text-sm leading-6 text-neutral-700">
-                  Aucune annonce récente pour l'instant.
+                  Aucune annonce r&eacute;cente pour l'instant.
                 </p>
               } @else {
                 <ul class="space-y-2">

--- a/apps/client/projects/mobile/src/app/features/onboarding/welcome.page.html
+++ b/apps/client/projects/mobile/src/app/features/onboarding/welcome.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="KRAAK Mobile"
   title="Bienvenue dans votre espace participant"
-  description="Accédez rapidement à vos programmes, ressources et points de contact en un seul endroit."
+  description="Acc&eacute;dez rapidement &agrave; vos programmes, ressources et points de contact en un seul endroit."
 >
   <section
     class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-3 border p-5"
@@ -12,7 +12,7 @@
         expand="block"
         class="kraak-primary-button"
       >
-        Démarrer
+        D&eacute;marrer
       </ion-button>
       <ion-button
         routerLink="/sign-in"
@@ -29,14 +29,14 @@
     <kraak-feature-card
       tag="Programmes"
       title="Suivez votre progression"
-      description="Retrouvez vos étapes clés et les prochaines actions recommandées."
+      description="Retrouvez vos &eacute;tapes cl&eacute;s et les prochaines actions recommand&eacute;es."
     />
 
     <kraak-feature-card
       tag="Support"
       tone="accent"
       title="Gardez un canal direct"
-      description="Contactez facilement l'équipe KRAAK pour obtenir une orientation personnalisée."
+      description="Contactez facilement l'&eacute;quipe KRAAK pour obtenir une orientation personnalis&eacute;e."
     />
   </section>
 </kraak-page-shell>

--- a/apps/client/projects/mobile/src/app/features/programs/program-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/programs/program-detail.page.html
@@ -1,6 +1,6 @@
 <kraak-page-shell
   [title]="pageTitle()"
-  eyebrow="Détail du programme"
+  eyebrow="D&eacute;tail du programme"
   backHref="/tabs/programmes"
 >
   @if (errorMessage()) {
@@ -17,7 +17,7 @@
         (click)="reloadProgram()"
         (keydown.enter)="reloadProgram()"
       >
-        Réessayer
+        R&eacute;essayer
       </ion-button>
     </section>
   } @else if (loading()) {
@@ -26,7 +26,7 @@
     >
       <ion-spinner name="crescent" aria-label="Chargement"></ion-spinner>
       <p class="text-sm leading-6 text-neutral-700">
-        Chargement du détail du programme...
+        Chargement du d&eacute;tail du programme...
       </p>
     </section>
   } @else if (programDetail(); as detail) {
@@ -52,7 +52,7 @@
           class="border-t border-neutral-200/50 pt-3 text-xs leading-5 text-neutral-700"
         >
           <p>
-            <span class="font-semibold">Créé le:</span>
+            <span class="font-semibold">Cr&eacute;&eacute; le:</span>
             {{ detail.program.createdAt | date: 'mediumDate' }}
           </p>
           <p class="mt-1">
@@ -84,7 +84,7 @@
               </p>
             }
             <p>
-              <span class="font-semibold">Début:</span>
+              <span class="font-semibold">D&eacute;but:</span>
               {{ detail.cohort.startDate | date: 'mediumDate' }}
             </p>
             @if (detail.cohort.endDate) {
@@ -95,7 +95,7 @@
             }
             @if (detail.cohort.capacity) {
               <p>
-                <span class="font-semibold">Capacité:</span>
+                <span class="font-semibold">Capacit&eacute;:</span>
                 {{ detail.cohort.capacity }} participants
               </p>
             }
@@ -138,7 +138,7 @@
                   expand="block"
                   class="kraak-primary-button mt-2"
                 >
-                  Voir les détails
+                  Voir les d&eacute;tails
                 </ion-button>
               </li>
             }
@@ -146,7 +146,7 @@
         </article>
       } @else {
         <p class="px-1 text-sm leading-6 text-neutral-700">
-          Aucune session programmée pour le moment.
+          Aucune session programm&eacute;e pour le moment.
         </p>
       }
 
@@ -183,7 +183,7 @@
                     expand="block"
                     class="kraak-primary-button mt-2"
                   >
-                    Accéder
+                    Acc&eacute;der
                   </ion-button>
                 }
               </li>
@@ -212,7 +212,8 @@
                   {{ announcement.title }}
                 </p>
                 <p class="text-xs leading-5 text-neutral-700">
-                  Publié: {{ announcement.publishedAt | date: 'mediumDate' }}
+                  Publi&eacute;:
+                  {{ announcement.publishedAt | date: 'mediumDate' }}
                 </p>
               </li>
             }
@@ -226,7 +227,7 @@
         fill="outline"
         class="kraak-secondary-button mb-4"
       >
-        Retour à la liste
+        Retour &agrave; la liste
       </ion-button>
     </section>
   }

--- a/apps/client/projects/mobile/src/app/features/programs/program-list.page.html
+++ b/apps/client/projects/mobile/src/app/features/programs/program-list.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="Programmes"
   title="Vos parcours"
-  description="Explorez les programmes auxquels vous êtes inscrits."
+  description="Explorez les programmes auxquels vous &ecirc;tes inscrits."
 >
   @if (errorMessage()) {
     <section
@@ -17,7 +17,7 @@
         (click)="reloadPrograms()"
         (keydown.enter)="reloadPrograms()"
       >
-        Réessayer
+        R&eacute;essayer
       </ion-button>
     </section>
   } @else if (loading()) {
@@ -41,7 +41,7 @@
         expand="block"
         class="kraak-primary-button"
       >
-        Retour à l'accueil
+        Retour &agrave; l'accueil
       </ion-button>
     </section>
   } @else {
@@ -78,7 +78,8 @@
               <p class="font-semibold">Cohorte: {{ program.cohort.name }}</p>
               @if (program.cohort.startDate) {
                 <p class="mt-1">
-                  Début: {{ program.cohort.startDate | date: 'shortDate' }}
+                  D&eacute;but:
+                  {{ program.cohort.startDate | date: 'shortDate' }}
                 </p>
               }
             </div>
@@ -89,7 +90,7 @@
             expand="block"
             class="kraak-primary-button"
           >
-            Voir le détail
+            Voir le d&eacute;tail
           </ion-button>
         </article>
       }

--- a/apps/client/projects/mobile/src/app/features/programs/session-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/programs/session-detail.page.html
@@ -1,6 +1,6 @@
 <kraak-page-shell
   [title]="session()?.title ?? 'Session'"
-  eyebrow="Détail de la session"
+  eyebrow="D&eacute;tail de la session"
   [backHref]="'/tabs/programmes/' + programId()"
 >
   @if (errorMessage()) {
@@ -17,7 +17,7 @@
         (click)="reloadSession()"
         (keydown.enter)="onReloadKeydown($event)"
       >
-        Réessayer
+        R&eacute;essayer
       </ion-button>
     </section>
   } @else if (loading()) {
@@ -57,7 +57,7 @@
         <p class="text-primary text-lg font-semibold">Informations</p>
         <div class="space-y-3 text-sm leading-6 text-neutral-700">
           <div class="rounded-lg bg-neutral-100/50 p-3">
-            <p class="font-semibold">Début</p>
+            <p class="font-semibold">D&eacute;but</p>
             <p class="mt-1">{{ sess.startsAt | date: 'medium' }}</p>
           </div>
 
@@ -85,7 +85,7 @@
 
           @if (sess.meetingLink) {
             <div class="rounded-lg bg-neutral-100/50 p-3">
-              <p class="font-semibold">Lien de réunion</p>
+              <p class="font-semibold">Lien de r&eacute;union</p>
               <ion-button
                 [href]="sess.meetingLink"
                 target="_blank"
@@ -107,9 +107,9 @@
         <p class="text-primary text-lg font-semibold">Progression</p>
         <p class="text-sm leading-6 text-neutral-700">
           @if (isSessionCompleted()) {
-            Session marquée comme terminée.
+            Session marqu&eacute;e comme termin&eacute;e.
           } @else {
-            Session non terminée.
+            Session non termin&eacute;e.
           }
         </p>
 
@@ -128,7 +128,7 @@
             (click)="markSessionCompletion(false)"
             (keydown.enter)="onMarkKeydown($event, false)"
           >
-            Marquer comme non terminée
+            Marquer comme non termin&eacute;e
           </ion-button>
         } @else {
           <ion-button
@@ -138,7 +138,7 @@
             (click)="markSessionCompletion(true)"
             (keydown.enter)="onMarkKeydown($event, true)"
           >
-            Marquer comme terminée
+            Marquer comme termin&eacute;e
           </ion-button>
         }
       </article>
@@ -167,7 +167,7 @@
       class="rounded-card border-brand-blue/12 bg-brand-white shadow-card m-4 flex flex-col gap-4 border p-5"
     >
       <p class="text-sm leading-6 text-neutral-700">
-        La session n'a pas pu être trouvée.
+        La session n'a pas pu &ecirc;tre trouv&eacute;e.
       </p>
       <ion-button
         [routerLink]="['/tabs/programmes', programId()]"

--- a/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.html
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-detail.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="Ressource"
-  title="Détail de la ressource"
-  description="Consultez le contenu et accédez rapidement au lien ou au fichier associé."
+  title="D&eacute;tail de la ressource"
+  description="Consultez le contenu et acc&eacute;dez rapidement au lien ou au fichier associ&eacute;."
   backHref="/tabs/programmes/ressources"
 >
   <section class="flex flex-col gap-4 px-4 py-5">
@@ -18,7 +18,7 @@
           (click)="reloadResource()"
           (keydown.enter)="reloadResource()"
         >
-          Réessayer
+          R&eacute;essayer
         </ion-button>
       </article>
     } @else if (loading()) {

--- a/apps/client/projects/mobile/src/app/features/resources/resource-list.page.html
+++ b/apps/client/projects/mobile/src/app/features/resources/resource-list.page.html
@@ -1,5 +1,5 @@
 <kraak-page-shell
-  eyebrow="Références"
+  eyebrow="R&eacute;f&eacute;rences"
   title="Ressources"
   description="Recherchez et filtrez les contenus utiles selon votre besoin."
   backHref="/tabs/programmes"
@@ -28,14 +28,14 @@
           <span
             class="text-xs font-semibold tracking-wide text-neutral-700 uppercase"
           >
-            Thème
+            Th&egrave;me
           </span>
           <select
             [value]="selectedTheme()"
             (change)="onThemeChange($event)"
             class="focus:border-brand-blue rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 outline-none"
           >
-            <option value="">Tous les thèmes</option>
+            <option value="">Tous les th&egrave;mes</option>
             @for (option of resourceThemeOptions; track option.value) {
               <option [value]="option.value">{{ option.label }}</option>
             }
@@ -75,7 +75,7 @@
           (click)="reloadResources()"
           (keydown.enter)="reloadResources()"
         >
-          Réessayer
+          R&eacute;essayer
         </ion-button>
       </article>
     } @else if (loading()) {
@@ -92,7 +92,7 @@
         class="rounded-card border-brand-blue/12 bg-brand-white shadow-card flex flex-col gap-4 border p-5"
       >
         <p class="text-sm leading-6 text-neutral-700">
-          Aucune ressource ne correspond à vos critères.
+          Aucune ressource ne correspond &agrave; vos crit&egrave;res.
         </p>
       </article>
     } @else {
@@ -135,7 +135,7 @@
             expand="block"
             class="kraak-primary-button"
           >
-            Voir le détail
+            Voir le d&eacute;tail
           </ion-button>
         </article>
       }

--- a/apps/client/projects/mobile/src/app/features/support/support-request.page.html
+++ b/apps/client/projects/mobile/src/app/features/support/support-request.page.html
@@ -1,7 +1,7 @@
 <kraak-page-shell
   eyebrow="Support"
   title="Nouvelle demande"
-  description="Décrivez votre besoin et notre équipe vous répondra dans les plus brefs délais."
+  description="D&eacute;crivez votre besoin et notre &eacute;quipe vous r&eacute;pondra dans les plus brefs d&eacute;lais."
   backHref="/tabs/support"
 >
   <section
@@ -31,7 +31,7 @@
         />
         @if (form.controls.name.touched && form.controls.name.invalid) {
           <p class="text-sm leading-6 text-rose-700">
-            Le nom est requis (2 à 80 caractères).
+            Le nom est requis (2 &agrave; 80 caract&egrave;res).
           </p>
         }
       </div>
@@ -59,13 +59,13 @@
         }
       </div>
 
-      <!-- Catégorie -->
+      <!-- Cat&eacute;gorie -->
       <div class="flex flex-col gap-2">
         <label
           for="support-category"
           class="text-sm font-semibold text-neutral-900"
         >
-          Catégorie
+          Cat&eacute;gorie
         </label>
         <select
           id="support-category"
@@ -90,12 +90,12 @@
           id="support-subject"
           type="text"
           formControlName="subject"
-          placeholder="Résumez votre demande en quelques mots"
+          placeholder="R&eacute;sumez votre demande en quelques mots"
           class="rounded-card border-brand-blue/12 focus:border-brand-blue min-h-12 border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
         />
         @if (form.controls.subject.touched && form.controls.subject.invalid) {
           <p class="text-sm leading-6 text-rose-700">
-            L'objet est requis (3 à 120 caractères).
+            L'objet est requis (3 &agrave; 120 caract&egrave;res).
           </p>
         }
       </div>
@@ -112,12 +112,12 @@
           id="support-message"
           formControlName="message"
           rows="5"
-          placeholder="Décrivez votre demande en détail…"
+          placeholder="D&eacute;crivez votre demande en d&eacute;tail&hellip;"
           class="rounded-card border-brand-blue/12 focus:border-brand-blue resize-none border bg-white px-4 py-3 text-sm text-neutral-900 outline-none"
         ></textarea>
         @if (form.controls.message.touched && form.controls.message.invalid) {
           <p class="text-sm leading-6 text-rose-700">
-            Le message est requis (10 à 2 000 caractères).
+            Le message est requis (10 &agrave; 2 000 caract&egrave;res).
           </p>
         }
       </div>

--- a/apps/client/projects/mobile/src/app/features/support/support.page.html
+++ b/apps/client/projects/mobile/src/app/features/support/support.page.html
@@ -7,7 +7,7 @@
     class="rounded-card border-brand-blue/12 bg-brand-white shadow-card border p-5"
   >
     <p class="text-sm leading-6 text-neutral-700">
-      Besoin d'aide ? Contactez notre équipe.
+      Besoin d'aide ? Contactez notre &eacute;quipe.
     </p>
 
     <ion-button
@@ -15,7 +15,7 @@
       expand="block"
       class="kraak-primary-button mt-4"
     >
-      Démarrer une demande
+      D&eacute;marrer une demande
     </ion-button>
   </section>
 
@@ -36,7 +36,7 @@
       </p>
     } @else if (requests().length === 0) {
       <p class="text-sm leading-6 text-neutral-700">
-        Aucune demande de support enregistrée pour le moment.
+        Aucune demande de support enregistr&eacute;e pour le moment.
       </p>
     } @else {
       <ul class="flex flex-col gap-3">
@@ -49,7 +49,8 @@
               Statut: {{ getStatusLabel(request.status) }}
             </p>
             <p class="text-xs text-neutral-500">
-              Mis à jour le {{ request.updatedAt | date: 'dd/MM/yyyy HH:mm' }}
+              Mis &agrave; jour le
+              {{ request.updatedAt | date: 'dd/MM/yyyy HH:mm' }}
             </p>
           </li>
         }

--- a/apps/client/projects/web/src/app/features/about/about.page.html
+++ b/apps/client/projects/web/src/app/features/about/about.page.html
@@ -2,11 +2,12 @@
 <section class="bg-brand-navy text-brand-white py-20 text-center">
   <div class="mx-auto max-w-4xl px-4 lg:px-6">
     <h1 class="text-brand-white text-4xl leading-tight font-bold lg:text-5xl">
-      Former une génération prête à agir
+      Former une g&eacute;n&eacute;ration pr&ecirc;te &agrave; agir
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
-      KRAAK est née de la conviction que chaque jeune professionnel peut devenir
-      un acteur de changement, à condition d'être bien accompagné.
+      KRAAK est n&eacute;e de la conviction que chaque jeune professionnel peut
+      devenir un acteur de changement, &agrave; condition d'&ecirc;tre bien
+      accompagn&eacute;.
     </p>
   </div>
 </section>
@@ -16,9 +17,9 @@
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-3xl font-bold lg:text-4xl">Notre mission</h2>
     <p class="mt-4 max-w-3xl text-lg text-neutral-700">
-      Accompagner les jeunes dans le développement de compétences solides et
-      d'un positionnement professionnel clair, afin qu'ils puissent saisir des
-      opportunités locales et internationales.
+      Accompagner les jeunes dans le d&eacute;veloppement de comp&eacute;tences
+      solides et d'un positionnement professionnel clair, afin qu'ils puissent
+      saisir des opportunit&eacute;s locales et internationales.
     </p>
   </div>
 </section>
@@ -28,8 +29,9 @@
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-3xl font-bold lg:text-4xl">Notre vision</h2>
     <p class="mt-4 max-w-3xl text-lg text-neutral-700">
-      Construire une génération de leaders africains capables de créer un impact
-      durable dans leurs communautés et au-delà.
+      Construire une g&eacute;n&eacute;ration de leaders africains capables de
+      cr&eacute;er un impact durable dans leurs communaut&eacute;s et
+      au-del&agrave;.
     </p>
   </div>
 </section>
@@ -43,16 +45,16 @@
         <p class="text-primary text-lg font-bold">Humanisme</p>
       </div>
       <div class="rounded-card bg-neutral-50 p-5 text-center">
-        <p class="text-primary text-lg font-bold">Responsabilité</p>
+        <p class="text-primary text-lg font-bold">Responsabilit&eacute;</p>
       </div>
       <div class="rounded-card bg-neutral-50 p-5 text-center">
         <p class="text-primary text-lg font-bold">Leadership</p>
       </div>
       <div class="rounded-card bg-neutral-50 p-5 text-center">
-        <p class="text-primary text-lg font-bold">Solidarité</p>
+        <p class="text-primary text-lg font-bold">Solidarit&eacute;</p>
       </div>
       <div class="rounded-card bg-neutral-50 p-5 text-center">
-        <p class="text-primary text-lg font-bold">Résilience</p>
+        <p class="text-primary text-lg font-bold">R&eacute;silience</p>
       </div>
       <div class="rounded-card bg-neutral-50 p-5 text-center">
         <p class="text-primary text-lg font-bold">Ouverture</p>
@@ -67,20 +69,22 @@
 <!-- Leadership (placeholder) -->
 <section class="bg-neutral-50 py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <h2 class="text-3xl font-bold lg:text-4xl">Notre équipe</h2>
+    <h2 class="text-3xl font-bold lg:text-4xl">Notre &eacute;quipe</h2>
     <p class="mt-4 max-w-3xl text-neutral-700">
-      KRAAK est portée par une équipe engagée, animée par une vision commune du
-      développement professionnel en Afrique et à l'international.
+      KRAAK est port&eacute;e par une &eacute;quipe engag&eacute;e,
+      anim&eacute;e par une vision commune du d&eacute;veloppement professionnel
+      en Afrique et &agrave; l'international.
     </p>
   </div>
 </section>
 
-<!-- Preuves / réalisations (placeholder) -->
+<!-- Preuves / r&eacute;alisations (placeholder) -->
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-6xl px-4 text-center lg:px-6">
-    <h2 class="text-3xl font-bold lg:text-4xl">Nos réalisations</h2>
+    <h2 class="text-3xl font-bold lg:text-4xl">Nos r&eacute;alisations</h2>
     <p class="mx-auto mt-4 max-w-2xl text-neutral-700">
-      Nos réalisations détaillées seront bientôt disponibles ici.
+      Nos r&eacute;alisations d&eacute;taill&eacute;es seront bient&ocirc;t
+      disponibles ici.
     </p>
   </div>
 </section>
@@ -88,7 +92,7 @@
 <!-- CTA -->
 <kraak-cta-banner
   heading="Envie d'en savoir plus ?"
-  body="Contactez-nous pour découvrir comment KRAAK peut vous accompagner."
+  body="Contactez-nous pour d&eacute;couvrir comment KRAAK peut vous accompagner."
   ctaLabel="Nous contacter"
   ctaLink="/contact"
   ctaContext="about_main_cta"

--- a/apps/client/projects/web/src/app/features/contact/contact.page.html
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.html
@@ -1,12 +1,12 @@
-<!-- En-tête de la page contact -->
+<!-- En-t&ecirc;te de la page contact -->
 <section class="bg-brand-navy text-brand-white py-20 text-center">
   <div class="mx-auto max-w-4xl px-4 lg:px-6">
     <h1 class="text-brand-white text-4xl leading-tight font-bold lg:text-5xl">
       Contactez-nous
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
-      Une question, un projet, une demande d'accompagnement ? Écrivez-nous et
-      nous vous répondrons rapidement.
+      Une question, un projet, une demande d'accompagnement ?
+      &Eacute;crivez-nous et nous vous r&eacute;pondrons rapidement.
     </p>
   </div>
 </section>
@@ -17,7 +17,7 @@
     @if (success()) {
       <p-message
         severity="success"
-        text="Votre message a bien été envoyé. Nous vous répondrons dans les plus brefs délais."
+        text="Votre message a bien &eacute;t&eacute; envoy&eacute;. Nous vous r&eacute;pondrons dans les plus brefs d&eacute;lais."
         [closable]="false"
         styleClass="w-full mb-6"
       />
@@ -63,7 +63,7 @@
               @if (name.errors?.['required']) {
                 Le nom est requis.
               } @else if (name.errors?.['minlength']) {
-                Le nom doit contenir au moins 2 caractères.
+                Le nom doit contenir au moins 2 caract&egrave;res.
               }
             </p>
           }
@@ -137,7 +137,7 @@
             pTextarea
             id="message"
             rows="6"
-            placeholder="Décrivez votre besoin ou votre question..."
+            placeholder="D&eacute;crivez votre besoin ou votre question..."
             formControlName="message"
             class="w-full"
             [ngClass]="{ 'ng-invalid ng-dirty': isInvalid(message) }"
@@ -156,7 +156,7 @@
               @if (message.errors?.['required']) {
                 Le message est requis.
               } @else if (message.errors?.['minlength']) {
-                Le message doit contenir au moins 10 caractères.
+                Le message doit contenir au moins 10 caract&egrave;res.
               }
             </p>
           }
@@ -179,10 +179,12 @@
   </div>
 </section>
 
-<!-- Coordonnées -->
+<!-- Coordonn&eacute;es -->
 <section class="bg-neutral-50 py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <h2 class="text-center text-3xl font-bold lg:text-4xl">Nos coordonnées</h2>
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      Nos coordonn&eacute;es
+    </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-3">
       <div class="text-center">
         <i class="pi pi-envelope text-3xl" aria-hidden="true"></i>
@@ -198,14 +200,14 @@
         <i class="pi pi-map-marker text-3xl" aria-hidden="true"></i>
         <h3 class="mt-2 text-lg font-bold">Zone d'intervention</h3>
         <p class="mt-1 text-neutral-700">
-          Afrique &amp; international — accompagnement à distance et en
-          présentiel.
+          Afrique &amp; international &mdash; accompagnement &agrave; distance
+          et en pr&eacute;sentiel.
         </p>
       </div>
       <div class="text-center">
         <i class="pi pi-link text-3xl" aria-hidden="true"></i>
-        <h3 class="mt-2 text-lg font-bold">Réseaux sociaux</h3>
-        <p class="mt-1 text-neutral-700">Liens à venir</p>
+        <h3 class="mt-2 text-lg font-bold">R&eacute;seaux sociaux</h3>
+        <p class="mt-1 text-neutral-700">Liens &agrave; venir</p>
       </div>
     </div>
   </div>
@@ -213,6 +215,6 @@
 
 <!-- CTA -->
 <kraak-cta-banner
-  heading="Besoin d'un accompagnement personnalisé ?"
-  body="Notre équipe est à votre écoute pour répondre à toutes vos questions et vous guider dans votre projet."
+  heading="Besoin d'un accompagnement personnalis&eacute; ?"
+  body="Notre &eacute;quipe est &agrave; votre &eacute;coute pour r&eacute;pondre &agrave; toutes vos questions et vous guider dans votre projet."
 />

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -33,17 +33,17 @@
           KRAAK Consulting
         </p>
         <p class="text-brand-white/82 text-sm">
-          Leadership, mobilité et impact concret pour les talents et les
+          Leadership, mobilit&eacute; et impact concret pour les talents et les
           organisations.
         </p>
       </div>
     </div>
     <h1 class="text-brand-white text-4xl leading-tight font-bold lg:text-5xl">
-      Développez votre potentiel.<br />Construisez votre impact.
+      D&eacute;veloppez votre potentiel.<br />Construisez votre impact.
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
       KRAAK accompagne les jeunes professionnels et les organisations vers des
-      opportunités concrètes, locales et internationales.
+      opportunit&eacute;s concr&egrave;tes, locales et internationales.
     </p>
     <div
       class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
@@ -73,8 +73,8 @@
     <h2 class="text-center text-3xl font-bold lg:text-4xl">Notre mission</h2>
     <p class="mx-auto mt-6 max-w-3xl text-center text-lg text-neutral-700">
       Nous identifions, formons et accompagnons des talents pour leur permettre
-      de s'intégrer stratégiquement dans des environnements professionnels
-      exigeants.
+      de s'int&eacute;grer strat&eacute;giquement dans des environnements
+      professionnels exigeants.
     </p>
   </div>
 </section>
@@ -95,12 +95,12 @@
         </div>
         <h3 class="text-xl font-bold">Formation</h3>
         <p class="text-secondary mt-2 text-sm font-medium">
-          Développement de compétences techniques et linguistiques
+          D&eacute;veloppement de comp&eacute;tences techniques et linguistiques
         </p>
         <p class="mt-3 text-neutral-700">
-          Programmes de formation en développement personnel, communication
-          professionnelle et langues (anglais/français), adaptés aux exigences
-          du marché.
+          Programmes de formation en d&eacute;veloppement personnel,
+          communication professionnelle et langues (anglais/fran&ccedil;ais),
+          adapt&eacute;s aux exigences du march&eacute;.
         </p>
       </div>
 
@@ -113,11 +113,11 @@
         </div>
         <h3 class="text-xl font-bold">Gestion de projet</h3>
         <p class="text-secondary mt-2 text-sm font-medium">
-          Accompagnement stratégique des organisations
+          Accompagnement strat&eacute;gique des organisations
         </p>
         <p class="mt-3 text-neutral-700">
           Support en structuration de projets, identification de talents,
-          recrutement et développement de partenariats.
+          recrutement et d&eacute;veloppement de partenariats.
         </p>
       </div>
 
@@ -130,10 +130,11 @@
         </div>
         <h3 class="text-xl font-bold">Conseil en immigration</h3>
         <p class="text-secondary mt-2 text-sm font-medium">
-          Orientation vers des opportunités internationales
+          Orientation vers des opportunit&eacute;s internationales
         </p>
         <p class="mt-3 text-neutral-700">
-          Conseil stratégique pour études, travail et mobilité internationale.
+          Conseil strat&eacute;gique pour &eacute;tudes, travail et
+          mobilit&eacute; internationale.
         </p>
       </div>
     </div>
@@ -150,28 +151,32 @@
       <div class="flex gap-4">
         <i class="pi pi-check text-accent mt-1 text-2xl" aria-hidden="true"></i>
         <div>
-          <h3 class="text-lg font-bold">Approche centrée sur l'impact</h3>
+          <h3 class="text-lg font-bold">
+            Approche centr&eacute;e sur l'impact
+          </h3>
           <p class="mt-1 text-neutral-700">
-            Chaque programme cible des résultats concrets et mesurables.
+            Chaque programme cible des r&eacute;sultats concrets et mesurables.
           </p>
         </div>
       </div>
       <div class="flex gap-4">
         <i class="pi pi-check text-accent mt-1 text-2xl" aria-hidden="true"></i>
         <div>
-          <h3 class="text-lg font-bold">Accompagnement personnalisé</h3>
+          <h3 class="text-lg font-bold">Accompagnement personnalis&eacute;</h3>
           <p class="mt-1 text-neutral-700">
-            Un suivi adapté aux besoins et au profil de chaque participant.
+            Un suivi adapt&eacute; aux besoins et au profil de chaque
+            participant.
           </p>
         </div>
       </div>
       <div class="flex gap-4">
         <i class="pi pi-check text-accent mt-1 text-2xl" aria-hidden="true"></i>
         <div>
-          <h3 class="text-lg font-bold">Réseau international</h3>
+          <h3 class="text-lg font-bold">R&eacute;seau international</h3>
           <p class="mt-1 text-neutral-700">
-            Accès à des opportunités locales et internationales grâce à un
-            réseau étendu de partenaires.
+            Acc&egrave;s &agrave; des opportunit&eacute;s locales et
+            internationales gr&acirc;ce &agrave; un r&eacute;seau &eacute;tendu
+            de partenaires.
           </p>
         </div>
       </div>
@@ -180,8 +185,9 @@
         <div>
           <h3 class="text-lg font-bold">Expertise reconnue</h3>
           <p class="mt-1 text-neutral-700">
-            Une équipe engagée avec une vision claire du développement
-            professionnel en Afrique et à l'international.
+            Une &eacute;quipe engag&eacute;e avec une vision claire du
+            d&eacute;veloppement professionnel en Afrique et &agrave;
+            l'international.
           </p>
         </div>
       </div>
@@ -189,45 +195,46 @@
   </div>
 </section>
 
-<!-- Résultats & impact -->
+<!-- R&eacute;sultats & impact -->
 <section class="bg-neutral-50 py-16">
   <div class="mx-auto max-w-6xl px-4 text-center lg:px-6">
-    <h2 class="text-3xl font-bold lg:text-4xl">Nos résultats</h2>
+    <h2 class="text-3xl font-bold lg:text-4xl">Nos r&eacute;sultats</h2>
     <p class="mx-auto mt-4 max-w-2xl text-neutral-700">
-      KRAAK s'engage à produire un impact réel et mesurable auprès de ses
-      participants et partenaires.
+      KRAAK s'engage &agrave; produire un impact r&eacute;el et mesurable
+      aupr&egrave;s de ses participants et partenaires.
     </p>
     <div class="mt-10 grid gap-8 sm:grid-cols-3">
       <div>
-        <p class="text-secondary text-4xl font-bold">—</p>
-        <p class="mt-2 text-neutral-700">Participants accompagnés</p>
+        <p class="text-secondary text-4xl font-bold">&mdash;</p>
+        <p class="mt-2 text-neutral-700">Participants accompagn&eacute;s</p>
       </div>
       <div>
-        <p class="text-secondary text-4xl font-bold">—</p>
+        <p class="text-secondary text-4xl font-bold">&mdash;</p>
         <p class="mt-2 text-neutral-700">Partenaires actifs</p>
       </div>
       <div>
-        <p class="text-secondary text-4xl font-bold">—</p>
+        <p class="text-secondary text-4xl font-bold">&mdash;</p>
         <p class="mt-2 text-neutral-700">Pays couverts</p>
       </div>
     </div>
   </div>
 </section>
 
-<!-- Témoignages (placeholder) -->
+<!-- T&eacute;moignages (placeholder) -->
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-6xl px-4 text-center lg:px-6">
     <h2 class="text-3xl font-bold lg:text-4xl">Ce qu'ils en disent</h2>
     <p class="mx-auto mt-4 max-w-2xl text-neutral-700">
-      Les témoignages de nos participants seront bientôt disponibles.
+      Les t&eacute;moignages de nos participants seront bient&ocirc;t
+      disponibles.
     </p>
   </div>
 </section>
 
 <!-- CTA principal -->
 <kraak-cta-banner
-  heading="Prêt à passer à l'action ?"
-  body="Prenez contact avec notre équipe pour explorer vos opportunités."
+  heading="Pr&ecirc;t &agrave; passer &agrave; l'action ?"
+  body="Prenez contact avec notre &eacute;quipe pour explorer vos opportunit&eacute;s."
   ctaLabel="Demander une consultation"
   ctaLink="/contact"
   ctaContext="home_main_cta"
@@ -241,7 +248,7 @@
     <div>
       <h3 class="text-xl font-bold">Une question ?</h3>
       <p class="mt-1 text-neutral-700">
-        Écrivez-nous à
+        &Eacute;crivez-nous &agrave;
         <a href="mailto:contact@kraak-consulting.com" class="kr-link">
           contact&#64;kraak-consulting.com
         </a>

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
@@ -17,9 +17,10 @@
             voici votre vue d'ensemble.
           </h1>
           <p class="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-            Ce dashboard MVP synthétise les contenus prioritaires issus de votre
-            parcours: programmes suivis, prochaines sessions et dernières
-            annonces, alimentés par le service dashboard de KRAAK.
+            Ce dashboard MVP synth&eacute;tise les contenus prioritaires issus
+            de votre parcours: programmes suivis, prochaines sessions et
+            derni&egrave;res annonces, aliment&eacute;s par le service dashboard
+            de KRAAK.
           </p>
         </div>
       </div>
@@ -34,11 +35,11 @@
           Point d'attention
         </p>
         <h2 id="dashboard-attention-title" class="mt-3 text-2xl font-semibold">
-          Rester aligné sur la prochaine étape
+          Rester align&eacute; sur la prochaine &eacute;tape
         </h2>
         <p class="mt-3 text-sm leading-6 text-slate-200">
-          L'accueil sert de repère rapide: programmes actifs, prochaines
-          sessions et annonces récentes sont consolidés ici.
+          L'accueil sert de rep&egrave;re rapide: programmes actifs, prochaines
+          sessions et annonces r&eacute;centes sont consolid&eacute;s ici.
         </p>
       </aside>
     </section>
@@ -60,7 +61,7 @@
             id="dashboard-synthesis-title"
             class="mt-2 text-2xl font-semibold text-slate-950"
           >
-            Synthèse utile
+            Synth&egrave;se utile
           </h2>
         </div>
         @if (!loading() && !errorMessage()) {
@@ -72,11 +73,13 @@
 
       @if (loading()) {
         <p class="mt-4 text-sm leading-6 text-slate-600">
-          La synthèse se met à jour avec vos dernières informations.
+          La synth&egrave;se se met &agrave; jour avec vos derni&egrave;res
+          informations.
         </p>
       } @else if (errorMessage()) {
         <p class="mt-4 text-sm leading-6 text-red-700">
-          La synthèse n'a pas pu être chargée pour le moment.
+          La synth&egrave;se n'a pas pu &ecirc;tre charg&eacute;e pour le
+          moment.
         </p>
       } @else {
         <div class="mt-5 grid gap-4 lg:grid-cols-[1.65fr_minmax(16rem,1fr)]">
@@ -107,7 +110,7 @@
             <p
               class="text-xs font-semibold tracking-[0.2em] text-cyan-200 uppercase"
             >
-              Prochaine étape
+              Prochaine &eacute;tape
             </p>
             <h3
               id="dashboard-next-step-title"
@@ -140,7 +143,7 @@
             id="dashboard-overview-title"
             class="mt-2 text-2xl font-semibold text-slate-950"
           >
-            Votre vue d'ensemble personnalisée
+            Votre vue d'ensemble personnalis&eacute;e
           </h2>
         </div>
         @if (loading()) {
@@ -148,7 +151,7 @@
             class="text-sm font-medium tracking-[0.18em] text-slate-500 uppercase"
             aria-live="polite"
           >
-            Chargement…
+            Chargement&hellip;
           </output>
         }
       </div>
@@ -166,12 +169,12 @@
             class="btn btn-primary"
             (click)="reloadDashboard()"
           >
-            Réessayer
+            R&eacute;essayer
           </button>
         </div>
       } @else if (loading()) {
         <p class="mt-6 text-sm leading-6 text-slate-600">
-          Chargement de votre dashboard…
+          Chargement de votre dashboard&hellip;
         </p>
       } @else if (!hasDashboardContent()) {
         <p class="mt-6 text-sm leading-6 text-slate-600">
@@ -236,11 +239,11 @@
               id="dashboard-sessions-title"
               class="mt-2 text-lg font-semibold text-slate-950"
             >
-              Les rappels à ne pas manquer
+              Les rappels &agrave; ne pas manquer
             </h3>
             @if (upcomingSessions().length === 0) {
               <p class="mt-3 text-sm leading-6 text-slate-600">
-                Aucune session planifiée pour le moment.
+                Aucune session planifi&eacute;e pour le moment.
               </p>
             } @else {
               <ul class="mt-4 space-y-3">
@@ -270,7 +273,7 @@
             <p
               class="text-brand-blue text-xs font-semibold tracking-[0.24em] uppercase"
             >
-              Annonces récentes
+              Annonces r&eacute;centes
             </p>
             <h3
               id="dashboard-announcements-title"
@@ -280,7 +283,7 @@
             </h3>
             @if (recentAnnouncements().length === 0) {
               <p class="mt-3 text-sm leading-6 text-slate-600">
-                Aucune annonce récente pour l'instant.
+                Aucune annonce r&eacute;cente pour l'instant.
               </p>
             } @else {
               <ul class="mt-4 space-y-3">
@@ -311,7 +314,7 @@
       <p
         class="text-sm font-semibold tracking-[0.22em] text-cyan-200 uppercase"
       >
-        Accès rapides
+        Acc&egrave;s rapides
       </p>
       <h2 id="dashboard-quicklinks-title" class="mt-2 text-2xl font-semibold">
         Des sorties utiles depuis votre espace

--- a/apps/client/projects/web/src/app/features/programs/programs.page.html
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.html
@@ -5,8 +5,9 @@
       Nos programmes
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
-      Des parcours structurés pour développer vos compétences et accélérer votre
-      insertion professionnelle.
+      Des parcours structur&eacute;s pour d&eacute;velopper vos
+      comp&eacute;tences et acc&eacute;l&eacute;rer votre insertion
+      professionnelle.
     </p>
   </div>
 </section>
@@ -15,40 +16,45 @@
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Découvrez nos parcours
+      D&eacute;couvrez nos parcours
     </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
       <div class="rounded-card shadow-card bg-neutral-50 p-6">
         <i class="pi pi-bolt text-3xl" aria-hidden="true"></i>
         <h3 class="mt-3 text-xl font-bold">Leadership & Management</h3>
         <p class="mt-2 text-neutral-700">
-          Développer votre posture de leader, structurer votre prise de décision
-          et inspirer votre entourage professionnel.
+          D&eacute;velopper votre posture de leader, structurer votre prise de
+          d&eacute;cision et inspirer votre entourage professionnel.
         </p>
         <p class="text-secondary mt-4 text-sm font-medium">
-          Durée : 8 semaines
+          Dur&eacute;e : 8 semaines
         </p>
       </div>
       <div class="rounded-card shadow-card bg-neutral-50 p-6">
         <i class="pi pi-briefcase text-3xl" aria-hidden="true"></i>
-        <h3 class="mt-3 text-xl font-bold">Gestion de projet appliquée</h3>
+        <h3 class="mt-3 text-xl font-bold">
+          Gestion de projet appliqu&eacute;e
+        </h3>
         <p class="mt-2 text-neutral-700">
-          Maîtriser les outils et méthodes de gestion de projet pour livrer des
-          résultats concrets dans les délais.
+          Ma&icirc;triser les outils et m&eacute;thodes de gestion de projet
+          pour livrer des r&eacute;sultats concrets dans les d&eacute;lais.
         </p>
         <p class="text-secondary mt-4 text-sm font-medium">
-          Durée : 6 semaines
+          Dur&eacute;e : 6 semaines
         </p>
       </div>
       <div class="rounded-card shadow-card bg-neutral-50 p-6">
         <i class="pi pi-globe text-3xl" aria-hidden="true"></i>
-        <h3 class="mt-3 text-xl font-bold">Préparation à l'international</h3>
+        <h3 class="mt-3 text-xl font-bold">
+          Pr&eacute;paration &agrave; l'international
+        </h3>
         <p class="mt-2 text-neutral-700">
-          Préparer votre projet d'immigration avec méthode : évaluation,
-          dossier, intégration et projet professionnel.
+          Pr&eacute;parer votre projet d'immigration avec m&eacute;thode :
+          &eacute;valuation, dossier, int&eacute;gration et projet
+          professionnel.
         </p>
         <p class="text-secondary mt-4 text-sm font-medium">
-          Durée : 10 semaines
+          Dur&eacute;e : 10 semaines
         </p>
       </div>
     </div>
@@ -66,73 +72,79 @@
         <p class="text-accent text-3xl font-bold">1</p>
         <h3 class="mt-2 text-lg font-bold">Candidature</h3>
         <p class="mt-1 text-neutral-700">
-          Remplissez le formulaire de contact en précisant le programme visé.
+          Remplissez le formulaire de contact en pr&eacute;cisant le programme
+          vis&eacute;.
         </p>
       </div>
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">2</p>
         <h3 class="mt-2 text-lg font-bold">Entretien</h3>
         <p class="mt-1 text-neutral-700">
-          Un échange pour comprendre vos objectifs et valider l'adéquation.
+          Un &eacute;change pour comprendre vos objectifs et valider
+          l'ad&eacute;quation.
         </p>
       </div>
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">3</p>
         <h3 class="mt-2 text-lg font-bold">Inscription</h3>
         <p class="mt-1 text-neutral-700">
-          Validation de votre place et accès aux ressources du programme.
+          Validation de votre place et acc&egrave;s aux ressources du programme.
         </p>
       </div>
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">4</p>
-        <h3 class="mt-2 text-lg font-bold">Démarrage</h3>
+        <h3 class="mt-2 text-lg font-bold">D&eacute;marrage</h3>
         <p class="mt-1 text-neutral-700">
-          Début de votre parcours avec un suivi personnalisé.
+          D&eacute;but de votre parcours avec un suivi personnalis&eacute;.
         </p>
       </div>
     </div>
   </div>
 </section>
 
-<!-- Résultats attendus -->
+<!-- R&eacute;sultats attendus -->
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Résultats attendus
+      R&eacute;sultats attendus
     </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-3">
       <div class="rounded-card bg-neutral-50 p-6 text-center">
         <p class="text-brand-navy text-4xl font-bold">95 %</p>
-        <p class="mt-2 text-neutral-700">Taux de complétion des programmes</p>
+        <p class="mt-2 text-neutral-700">
+          Taux de compl&eacute;tion des programmes
+        </p>
       </div>
       <div class="rounded-card bg-neutral-50 p-6 text-center">
         <p class="text-brand-navy text-4xl font-bold">80 %</p>
         <p class="mt-2 text-neutral-700">
-          Participants en emploi ou activité dans les 6 mois
+          Participants en emploi ou activit&eacute; dans les 6 mois
         </p>
       </div>
       <div class="rounded-card bg-neutral-50 p-6 text-center">
         <p class="text-brand-navy text-4xl font-bold">200+</p>
-        <p class="mt-2 text-neutral-700">Participants accompagnés</p>
+        <p class="mt-2 text-neutral-700">Participants accompagn&eacute;s</p>
       </div>
     </div>
   </div>
 </section>
 
-<!-- Témoignages (placeholder) -->
+<!-- T&eacute;moignages (placeholder) -->
 <section class="bg-neutral-50 py-16">
   <div class="mx-auto max-w-4xl px-4 text-center lg:px-6">
     <h2 class="text-3xl font-bold lg:text-4xl">
       Ce qu'en disent nos participants
     </h2>
-    <p class="mt-4 text-neutral-600">Témoignages à venir — restez connectés.</p>
+    <p class="mt-4 text-neutral-600">
+      T&eacute;moignages &agrave; venir &mdash; restez connect&eacute;s.
+    </p>
   </div>
 </section>
 
 <!-- CTA -->
 <kraak-cta-banner
   heading="Rejoignez notre prochaine cohorte"
-  body="Les places sont limitées. Postulez dès maintenant et lancez votre parcours avec KRAAK."
+  body="Les places sont limit&eacute;es. Postulez d&egrave;s maintenant et lancez votre parcours avec KRAAK."
   ctaLabel="S'inscrire maintenant"
   ctaLink="/contact"
   ctaContext="programs_main_cta"

--- a/apps/client/projects/web/src/app/features/resources/resources.page.html
+++ b/apps/client/projects/web/src/app/features/resources/resources.page.html
@@ -1,11 +1,12 @@
 <section class="bg-brand-navy text-brand-white py-20 text-center">
   <div class="mx-auto max-w-4xl px-4 lg:px-6">
     <h1 class="text-brand-white text-4xl leading-tight font-bold lg:text-5xl">
-      Ressources utiles pour avancer avec méthode
+      Ressources utiles pour avancer avec m&eacute;thode
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
-      Guides, modèles et repères pratiques pour préparer votre parcours,
-      structurer vos projets et clarifier vos prochaines étapes.
+      Guides, mod&egrave;les et rep&egrave;res pratiques pour pr&eacute;parer
+      votre parcours, structurer vos projets et clarifier vos prochaines
+      &eacute;tapes.
     </p>
   </div>
 </section>
@@ -17,14 +18,14 @@
         <i class="pi pi-graduation-cap text-3xl" aria-hidden="true"></i>
         <h2 class="mt-4 text-2xl font-bold">Formation</h2>
         <p class="mt-3 text-neutral-700">
-          Sélections de contenus pour renforcer vos fondamentaux, préparer vos
-          sessions et garder des repères utiles entre deux temps forts du
-          programme.
+          S&eacute;lections de contenus pour renforcer vos fondamentaux,
+          pr&eacute;parer vos sessions et garder des rep&egrave;res utiles entre
+          deux temps forts du programme.
         </p>
         <ul class="mt-4 space-y-2 text-sm text-neutral-700">
-          <li>Guides de démarrage et feuilles de route</li>
-          <li>Capsules vidéo et documents de synthèse</li>
-          <li>Ressources pour réviser à votre rythme</li>
+          <li>Guides de d&eacute;marrage et feuilles de route</li>
+          <li>Capsules vid&eacute;o et documents de synth&egrave;se</li>
+          <li>Ressources pour r&eacute;viser &agrave; votre rythme</li>
         </ul>
       </article>
 
@@ -33,12 +34,12 @@
         <h2 class="mt-4 text-2xl font-bold">Gestion de projet</h2>
         <p class="mt-3 text-neutral-700">
           Des supports concrets pour cadrer un projet, suivre l'avancement et
-          mieux piloter les priorités dans un contexte réel.
+          mieux piloter les priorit&eacute;s dans un contexte r&eacute;el.
         </p>
         <ul class="mt-4 space-y-2 text-sm text-neutral-700">
-          <li>Modèles de plan d'action et trames de suivi</li>
+          <li>Mod&egrave;les de plan d'action et trames de suivi</li>
           <li>Outils de priorisation et d'organisation</li>
-          <li>Repères pour documenter les livrables essentiels</li>
+          <li>Rep&egrave;res pour documenter les livrables essentiels</li>
         </ul>
       </article>
 
@@ -46,12 +47,13 @@
         <i class="pi pi-globe text-3xl" aria-hidden="true"></i>
         <h2 class="mt-4 text-2xl font-bold">International</h2>
         <p class="mt-3 text-neutral-700">
-          Une base documentaire claire pour préparer un projet d'évolution,
-          comprendre les étapes clés et réduire les zones d'incertitude.
+          Une base documentaire claire pour pr&eacute;parer un projet
+          d'&eacute;volution, comprendre les &eacute;tapes cl&eacute;s et
+          r&eacute;duire les zones d'incertitude.
         </p>
         <ul class="mt-4 space-y-2 text-sm text-neutral-700">
-          <li>Checklists de préparation de dossier</li>
-          <li>Guides d'orientation et d'intégration</li>
+          <li>Checklists de pr&eacute;paration de dossier</li>
+          <li>Guides d'orientation et d'int&eacute;gration</li>
           <li>Ressources pour comparer les options possibles</li>
         </ul>
       </article>
@@ -62,21 +64,22 @@
 <section class="bg-neutral-50 py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Un accès simple, orienté action
+      Un acc&egrave;s simple, orient&eacute; action
     </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-3">
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">1</p>
-        <h3 class="mt-2 text-lg font-bold">Repérer</h3>
+        <h3 class="mt-2 text-lg font-bold">Rep&eacute;rer</h3>
         <p class="mt-1 text-neutral-700">
-          Identifiez rapidement la ressource adaptée à votre besoin immédiat.
+          Identifiez rapidement la ressource adapt&eacute;e &agrave; votre
+          besoin imm&eacute;diat.
         </p>
       </div>
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">2</p>
         <h3 class="mt-2 text-lg font-bold">Appliquer</h3>
         <p class="mt-1 text-neutral-700">
-          Utilisez des supports concrets pour passer de l'information à
+          Utilisez des supports concrets pour passer de l'information &agrave;
           l'action.
         </p>
       </div>
@@ -94,14 +97,16 @@
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-4xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Questions fréquentes
+      Questions fr&eacute;quentes
     </h2>
     <div class="mt-10 space-y-6">
       <article>
-        <h3 class="text-lg font-bold">À qui s'adressent ces ressources ?</h3>
+        <h3 class="text-lg font-bold">
+          &Agrave; qui s'adressent ces ressources ?
+        </h3>
         <p class="mt-2 text-neutral-700">
-          Elles servent aux participants, aux personnes en réflexion sur un
-          programme et aux organisations qui veulent comprendre l'approche
+          Elles servent aux participants, aux personnes en r&eacute;flexion sur
+          un programme et aux organisations qui veulent comprendre l'approche
           KRAAK.
         </p>
       </article>
@@ -110,14 +115,14 @@
           Les ressources sont-elles accessibles avant l'inscription ?
         </h3>
         <p class="mt-2 text-neutral-700">
-          Une partie sert à découvrir l'approche et à préparer votre décision.
-          Les bibliothèques plus ciblées sont ensuite ouvertes dans les
-          parcours.
+          Une partie sert &agrave; d&eacute;couvrir l'approche et &agrave;
+          pr&eacute;parer votre d&eacute;cision. Les biblioth&egrave;ques plus
+          cibl&eacute;es sont ensuite ouvertes dans les parcours.
         </p>
       </article>
       <article>
         <h3 class="text-lg font-bold">
-          Comment obtenir des ressources adaptées à mon contexte ?
+          Comment obtenir des ressources adapt&eacute;es &agrave; mon contexte ?
         </h3>
         <p class="mt-2 text-neutral-700">
           Le plus efficace est de nous contacter pour orienter la demande selon
@@ -129,9 +134,9 @@
 </section>
 
 <kraak-cta-banner
-  heading="Besoin d'une ressource adaptée à votre situation ?"
-  body="Expliquez votre besoin et nous vous orienterons vers le bon programme, le bon support ou le bon point d'entrée."
-  ctaLabel="Parler à l'équipe KRAAK"
+  heading="Besoin d'une ressource adapt&eacute;e &agrave; votre situation ?"
+  body="Expliquez votre besoin et nous vous orienterons vers le bon programme, le bon support ou le bon point d'entr&eacute;e."
+  ctaLabel="Parler &agrave; l'&eacute;quipe KRAAK"
   ctaLink="/contact"
   ctaContext="resources_main_cta"
 />

--- a/apps/client/projects/web/src/app/features/services/services.page.html
+++ b/apps/client/projects/web/src/app/features/services/services.page.html
@@ -5,8 +5,9 @@
       Nos services
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
-      Des solutions concrètes pour développer vos compétences, structurer vos
-      projets et sécuriser votre parcours international.
+      Des solutions concr&egrave;tes pour d&eacute;velopper vos
+      comp&eacute;tences, structurer vos projets et s&eacute;curiser votre
+      parcours international.
     </p>
   </div>
 </section>
@@ -18,14 +19,16 @@
       <i class="pi pi-graduation-cap text-4xl" aria-hidden="true"></i>
       <h2 class="mt-4 text-3xl font-bold lg:text-4xl">Formation</h2>
       <p class="text-secondary mt-2 text-lg font-medium">
-        Développer des compétences concrètes et immédiatement mobilisables.
+        D&eacute;velopper des comp&eacute;tences concr&egrave;tes et
+        imm&eacute;diatement mobilisables.
       </p>
       <p class="mt-4 text-neutral-700">
-        Nos programmes de formation sont conçus pour répondre aux besoins réels
-        du marché. Du leadership à la gestion de projet en passant par les
-        compétences techniques, nous proposons des parcours structurés, animés
-        par des praticiens expérimentés, pour que chaque participant reparte
-        avec des outils immédiatement applicables.
+        Nos programmes de formation sont con&ccedil;us pour r&eacute;pondre aux
+        besoins r&eacute;els du march&eacute;. Du leadership &agrave; la gestion
+        de projet en passant par les comp&eacute;tences techniques, nous
+        proposons des parcours structur&eacute;s, anim&eacute;s par des
+        praticiens exp&eacute;riment&eacute;s, pour que chaque participant
+        reparte avec des outils imm&eacute;diatement applicables.
       </p>
     </div>
   </div>
@@ -38,13 +41,14 @@
       <i class="pi pi-chart-bar text-4xl" aria-hidden="true"></i>
       <h2 class="mt-4 text-3xl font-bold lg:text-4xl">Gestion de projet</h2>
       <p class="text-secondary mt-2 text-lg font-medium">
-        Structurer, exécuter et livrer avec méthode.
+        Structurer, ex&eacute;cuter et livrer avec m&eacute;thode.
       </p>
       <p class="mt-4 text-neutral-700">
         Que vous lanciez une initiative interne, un programme communautaire ou
-        un projet institutionnel, KRAAK vous aide à cadrer, planifier et piloter
-        chaque étape. Notre approche combine rigueur méthodologique et
-        adaptabilité pour maximiser l'impact de chaque projet.
+        un projet institutionnel, KRAAK vous aide &agrave; cadrer, planifier et
+        piloter chaque &eacute;tape. Notre approche combine rigueur
+        m&eacute;thodologique et adaptabilit&eacute; pour maximiser l'impact de
+        chaque projet.
       </p>
     </div>
   </div>
@@ -59,14 +63,16 @@
         Conseil en immigration
       </h2>
       <p class="text-secondary mt-2 text-lg font-medium">
-        Sécuriser votre parcours vers de nouvelles opportunités internationales.
+        S&eacute;curiser votre parcours vers de nouvelles opportunit&eacute;s
+        internationales.
       </p>
       <p class="mt-4 text-neutral-700">
-        Nous accompagnons les candidats à l'immigration dans toutes les étapes
-        de leur projet : évaluation de profil, identification des programmes
-        adaptés, préparation des dossiers et suivi personnalisé. Notre objectif
-        est de maximiser vos chances tout en vous donnant les clés pour réussir
-        votre intégration.
+        Nous accompagnons les candidats &agrave; l'immigration dans toutes les
+        &eacute;tapes de leur projet : &eacute;valuation de profil,
+        identification des programmes adapt&eacute;s, pr&eacute;paration des
+        dossiers et suivi personnalis&eacute;. Notre objectif est de maximiser
+        vos chances tout en vous donnant les cl&eacute;s pour r&eacute;ussir
+        votre int&eacute;gration.
       </p>
     </div>
   </div>
@@ -81,23 +87,23 @@
         <p class="text-accent text-3xl font-bold">1</p>
         <h3 class="mt-2 text-lg font-bold">Diagnostic</h3>
         <p class="mt-1 text-neutral-700">
-          Nous analysons votre situation et vos objectifs pour définir un plan
-          d'action adapté.
+          Nous analysons votre situation et vos objectifs pour d&eacute;finir un
+          plan d'action adapt&eacute;.
         </p>
       </div>
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">2</p>
         <h3 class="mt-2 text-lg font-bold">Accompagnement</h3>
         <p class="mt-1 text-neutral-700">
-          Nous mettons en œuvre les actions identifiées avec un suivi régulier
-          et personnalisé.
+          Nous mettons en &oelig;uvre les actions identifi&eacute;es avec un
+          suivi r&eacute;gulier et personnalis&eacute;.
         </p>
       </div>
       <div class="text-center">
         <p class="text-accent text-3xl font-bold">3</p>
-        <h3 class="mt-2 text-lg font-bold">Résultats</h3>
+        <h3 class="mt-2 text-lg font-bold">R&eacute;sultats</h3>
         <p class="mt-1 text-neutral-700">
-          Nous mesurons l'impact et ajustons pour garantir des résultats
+          Nous mesurons l'impact et ajustons pour garantir des r&eacute;sultats
           concrets et durables.
         </p>
       </div>
@@ -109,18 +115,18 @@
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-4xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Questions fréquentes
+      Questions fr&eacute;quentes
     </h2>
     <div class="mt-10 space-y-6">
       <div>
         <h3 class="text-lg font-bold">
-          À qui s'adressent les services de KRAAK ?
+          &Agrave; qui s'adressent les services de KRAAK ?
         </h3>
         <p class="mt-2 text-neutral-700">
-          Nos services s'adressent aux jeunes professionnels, aux étudiants en
-          fin de cycle, et à toute personne souhaitant renforcer ses
-          compétences, structurer un projet ou préparer un parcours
-          international.
+          Nos services s'adressent aux jeunes professionnels, aux
+          &eacute;tudiants en fin de cycle, et &agrave; toute personne
+          souhaitant renforcer ses comp&eacute;tences, structurer un projet ou
+          pr&eacute;parer un parcours international.
         </p>
       </div>
       <div>
@@ -128,19 +134,20 @@
           Les formations sont-elles certifiantes ?
         </h3>
         <p class="mt-2 text-neutral-700">
-          Certaines de nos formations débouchent sur des attestations de
-          compétence. Les détails sont précisés dans chaque fiche programme.
+          Certaines de nos formations d&eacute;bouchent sur des attestations de
+          comp&eacute;tence. Les d&eacute;tails sont pr&eacute;cis&eacute;s dans
+          chaque fiche programme.
         </p>
       </div>
       <div>
         <h3 class="text-lg font-bold">
-          Comment se déroule un accompagnement en immigration ?
+          Comment se d&eacute;roule un accompagnement en immigration ?
         </h3>
         <p class="mt-2 text-neutral-700">
-          Nous commençons par une évaluation de votre profil, puis nous
-          identifions les programmes adaptés et vous accompagnons dans la
-          constitution de votre dossier, jusqu'à l'aboutissement de votre
-          projet.
+          Nous commen&ccedil;ons par une &eacute;valuation de votre profil, puis
+          nous identifions les programmes adapt&eacute;s et vous accompagnons
+          dans la constitution de votre dossier, jusqu'&agrave; l'aboutissement
+          de votre projet.
         </p>
       </div>
     </div>
@@ -149,8 +156,8 @@
 
 <!-- CTA -->
 <kraak-cta-banner
-  heading="Prêt à passer à l'action ?"
-  body="Prenez rendez-vous pour une consultation gratuite et découvrez comment KRAAK peut vous accompagner."
+  heading="Pr&ecirc;t &agrave; passer &agrave; l'action ?"
+  body="Prenez rendez-vous pour une consultation gratuite et d&eacute;couvrez comment KRAAK peut vous accompagner."
   ctaLabel="Demander une consultation"
   ctaLink="/contact"
   ctaContext="services_main_cta"

--- a/apps/client/projects/web/src/app/layouts/footer/footer.html
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.html
@@ -23,7 +23,7 @@
             >KRAAK</span
           >
           <p class="text-secondary text-sm font-medium">
-            Accompagnement, formation et mobilité.
+            Accompagnement, formation et mobilit&eacute;.
           </p>
         </div>
       </div>
@@ -55,7 +55,7 @@
   <div class="border-brand-blue/10 bg-brand-navy border-t">
     <div class="mx-auto w-full max-w-6xl px-4 py-4 lg:px-6">
       <p class="text-brand-white/72 text-xs">
-        &copy; {{ currentYear }} KRAAK. Tous droits réservés.
+        &copy; {{ currentYear }} KRAAK. Tous droits r&eacute;serv&eacute;s.
       </p>
     </div>
   </div>

--- a/apps/client/projects/web/src/app/shared/testimonials/testimonials.html
+++ b/apps/client/projects/web/src/app/shared/testimonials/testimonials.html
@@ -24,8 +24,8 @@
       class="rounded-(--kr-radius-card) border border-dashed border-neutral-300 bg-neutral-50 p-6 text-center"
     >
       <p class="text-sm leading-7 text-neutral-600">
-        Témoignages à venir - nos participants partagent bientôt leurs
-        expériences.
+        T&eacute;moignages &agrave; venir - nos participants partagent
+        bient&ocirc;t leurs exp&eacute;riences.
       </p>
     </div>
   }

--- a/apps/client/projects/web/src/index.html
+++ b/apps/client/projects/web/src/index.html
@@ -2,12 +2,12 @@
 <html lang="fr">
   <head>
     <meta charset="utf-8" />
-    <title>KRAAK | Développez votre potentiel</title>
+    <title>KRAAK | D&eacute;veloppez votre potentiel</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Formation, accompagnement et opportunités internationales pour jeunes professionnels et organisations."
+      content="Formation, accompagnement et opportunit&eacute;s internationales pour jeunes professionnels et organisations."
     />
     <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#122b4a" />

--- a/supabase/templates/auth/confirmation.html
+++ b/supabase/templates/auth/confirmation.html
@@ -3,8 +3,8 @@
 <p>Bonjour,</p>
 
 <p>
-  Votre espace participant est presque prêt. Confirmez votre adresse email pour
-  activer votre accès sécurisé.
+  Votre espace participant est presque pr&ecirc;t. Confirmez votre adresse email
+  pour activer votre acc&egrave;s s&eacute;curis&eacute;.
 </p>
 
 <p>

--- a/supabase/templates/auth/recovery.html
+++ b/supabase/templates/auth/recovery.html
@@ -1,14 +1,15 @@
-<h2>Réinitialisez votre mot de passe KRAAK</h2>
+<h2>R&eacute;initialisez votre mot de passe KRAAK</h2>
 
 <p>Bonjour,</p>
 
 <p>
-  Une demande de réinitialisation de mot de passe a été reçue pour votre espace
-  KRAAK. Utilisez le lien ci-dessous pour choisir un nouveau mot de passe.
+  Une demande de r&eacute;initialisation de mot de passe a &eacute;t&eacute;
+  re&ccedil;ue pour votre espace KRAAK. Utilisez le lien ci-dessous pour choisir
+  un nouveau mot de passe.
 </p>
 
 <p>
-  <a href="{{ .ConfirmationURL }}">Réinitialiser mon mot de passe</a>
+  <a href="{{ .ConfirmationURL }}">R&eacute;initialiser mon mot de passe</a>
 </p>
 
 <p>


### PR DESCRIPTION
## Contexte

Le contenu du site est majoritairement en français et utilise donc fréquemment des caractères non-ASCII (`é`, `à`, `ç`, `’`, `…`, etc.). Pour garantir un rendu portable indépendamment de l’encodage de transport, des éditeurs et des outils intermédiaires (templates Supabase, exports, copy/paste), tous les caractères non-ASCII des fichiers HTML sont désormais encodés en entités HTML nommées (avec repli numérique pour les caractères sans nom standard).

## Portée

- `apps/client/projects/web/**/*.html` (templates Angular du site)
- `apps/client/projects/mobile/**/*.html` (templates Ionic)
- `supabase/templates/auth/*.html` (emails transactionnels)

26 fichiers convertis. Aucune modification fonctionnelle, uniquement de la représentation textuelle.

## Choix techniques

- Entités nommées préférées (`&eacute;`, `&agrave;`, `&rsquo;`, `&hellip;`, `&laquo;`, `&raquo;`, `&mdash;`, etc.).
- Caractères ASCII (y compris l’apostrophe droite `'`) laissés intacts pour ne pas casser les bindings Angular (ex. `[(ngModel)]`, expressions `{{ ... }}`).
- Les fichiers TypeScript, JSON, Markdown restent en UTF-8 (les caractères y sont valides et lisibles, et toute conversion automatique risquerait de casser du code).

## Validation

- Hooks Husky pre-commit (Prettier) et pre-push (lint, build, tests unitaires, E2E Playwright) verts en local : 22 scénarios E2E passés.
- Le rendu navigateur est identique : les entités sont décodées par le moteur HTML.

## Ticket

Aucun item Project préexistant — tâche initiée à la demande directe de la maintenance ; un item de suivi sera créé/aligné dans la foulée.
