### PR TITLE
feat(web): remplacer le bouton navbar "Nous contacter" par "Espace participant"

### DIFF
--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 const localWebPort = Number(process.env['KRAAK_WEB_PORT'] ?? '4200');
 const localWebBaseUrl = `http://localhost:${localWebPort}`;
+const reuseExistingServer = process.env['KRAAK_E2E_REUSE_SERVER'] === 'true';
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -32,7 +33,7 @@ export default defineConfig({
   webServer: {
     command: `npx ng serve web --port ${localWebPort}`,
     url: localWebBaseUrl,
-    reuseExistingServer: !process.env['CI'],
+    reuseExistingServer,
     timeout: 120_000,
   },
 });

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.html
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.html
@@ -40,11 +40,11 @@
 
     <div class="hidden lg:block">
       <a
-        routerLink="/contact"
-        aria-label="Nous contacter"
+        routerLink="/participant"
+        aria-label="Espace participant"
         class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74_/_16%)] transition-all hover:-translate-y-px"
       >
-        Nous contacter
+        Espace participant
       </a>
     </div>
 
@@ -83,12 +83,12 @@
           }
         </ul>
         <a
-          routerLink="/contact"
-          aria-label="Nous contacter"
+          routerLink="/participant"
+          aria-label="Espace participant"
           class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex w-full items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-3 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74_/_16%)] transition-all hover:-translate-y-px"
           (click)="closeMobileMenu()"
         >
-          Nous contacter
+          Espace participant
         </a>
       </div>
     </div>

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.spec.ts
@@ -20,7 +20,7 @@ describe('Navbar', () => {
       'img[alt="Logo KRAAK Consulting"]',
     ) as HTMLImageElement | null;
     const primaryCta = element.querySelector(
-      'a[aria-label="Nous contacter"]',
+      'a[aria-label="Espace participant"]',
     ) as HTMLAnchorElement | null;
     const menuToggle = element.querySelector(
       'button[aria-label="Menu de navigation"]',
@@ -28,7 +28,7 @@ describe('Navbar', () => {
 
     expect(element.querySelectorAll('.p-button').length).toBe(0);
     expect(menuToggle).toBeTruthy();
-    expect(element.textContent).toContain('Nous contacter');
+    expect(element.textContent).toContain('Espace participant');
     expect(brandImage?.getAttribute('src')).toContain(
       'kraak_consulting_logo_192w.png',
     );

--- a/apps/client/tests/e2e/analytics.spec.ts
+++ b/apps/client/tests/e2e/analytics.spec.ts
@@ -9,7 +9,7 @@ test.describe('Analytics — gating GA4', () => {
   }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(
-      page.getByRole('link', { name: 'Nous contacter' }).first(),
+      page.getByRole('link', { name: 'Espace participant' }).first(),
     ).toBeVisible();
 
     await expect(
@@ -32,7 +32,10 @@ test.describe('Analytics — gating GA4', () => {
     });
 
     await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.getByRole('link', { name: 'Nous contacter' }).first().waitFor();
+    await page
+      .getByRole('link', { name: 'Espace participant' })
+      .first()
+      .waitFor();
 
     expect(gtagRequests).toEqual([]);
   });

--- a/apps/client/tests/e2e/design-system.spec.ts
+++ b/apps/client/tests/e2e/design-system.spec.ts
@@ -23,7 +23,7 @@ test.describe(`Design system web — smoke styling`, () => {
     page,
   }) => {
     const primaryCta = page
-      .getByRole('link', { name: 'Nous contacter' })
+      .getByRole('link', { name: 'Espace participant' })
       .first();
 
     await expect(primaryCta).toBeVisible();

--- a/apps/client/tests/e2e/smoke.spec.ts
+++ b/apps/client/tests/e2e/smoke.spec.ts
@@ -23,11 +23,11 @@ test.describe(`Page d'accueil — smoke tests`, () => {
     ).toBeVisible();
   });
 
-  test(`Given la page d'accueil, When elle se charge, Then l'appel à l'action "Nous contacter" est visible`, async ({
+  test(`Given la page d'accueil, When elle se charge, Then l'appel à l'action "Espace participant" est visible`, async ({
     page,
   }) => {
     await expect(
-      page.getByRole('link', { name: 'Nous contacter' }).first(),
+      page.getByRole('link', { name: 'Espace participant' }).first(),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Résumé\n- remplace le CTA navbar web "Nous contacter" par "Espace participant"\n- redirige vers /participant en desktop et mobile\n- met à jour les tests unitaires/E2E affectés\n- corrige la config Playwright pour éviter la réutilisation d’un serveur non-KRAAK en pre-push\n\n## Validation\n- pnpm --filter @kraak/client test:web\n- pnpm test\n\n## Notes\n- le workflow pre-push complet (typecheck/format/lint/tests) passe localement