### PR TITLE
test(scripts): strengthen runtime config and brand icon tests

### DIFF
--- a/scripts/brand-icons.test.mjs
+++ b/scripts/brand-icons.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 const repoRoot = path.resolve(import.meta.dirname, '..');
@@ -49,7 +49,10 @@ const appConfigs = [
 
 const requiredLinks = [
   'href="favicon.ico"',
+  'href="favicon-32x32.png"',
+  'href="favicon-16x16.png"',
   'rel="apple-touch-icon"',
+  'sizes="180x180"',
   'href="apple-touch-icon.png"',
   'rel="manifest"',
   'href="site.webmanifest"',
@@ -57,11 +60,15 @@ const requiredLinks = [
 
 const requiredAssets = [
   'favicon.ico',
+  'favicon-32x32.png',
+  'favicon-16x16.png',
   'apple-touch-icon.png',
   'icon-192x192.png',
   'icon-512x512.png',
   'site.webmanifest',
 ];
+
+const requiredManifestIconSizes = ['192x192', '512x512'];
 
 function assertMatch(content, fragment) {
   assert.match(
@@ -83,6 +90,39 @@ for (const appConfig of appConfigs) {
       existsSync(assetPath),
       true,
       `Expected ${appConfig.label} asset to exist: ${assetName}`,
+    );
+
+    assert.ok(
+      statSync(assetPath).size > 0,
+      `Expected ${appConfig.label} asset to be non-empty: ${assetName}`,
+    );
+  }
+
+  const manifestPath = path.join(appConfig.publicDir, 'site.webmanifest');
+  const manifestContent = readFileSync(manifestPath, 'utf8');
+  const manifest = JSON.parse(manifestContent);
+
+  assert.equal(manifest.name, 'KRAAK', `Expected ${appConfig.label} manifest name to be KRAAK`);
+  assert.equal(manifest.short_name, 'KRAAK', `Expected ${appConfig.label} manifest short_name to be KRAAK`);
+  assert.equal(manifest.lang, 'fr', `Expected ${appConfig.label} manifest lang to be fr`);
+  assert.equal(
+    manifest.theme_color,
+    '#122b4a',
+    `Expected ${appConfig.label} manifest theme_color to match brand color`,
+  );
+  assert.equal(
+    manifest.background_color,
+    '#122b4a',
+    `Expected ${appConfig.label} manifest background_color to match brand color`,
+  );
+
+  const manifestIconSizes = new Set((manifest.icons ?? []).map((icon) => icon.sizes));
+
+  for (const expectedSize of requiredManifestIconSizes) {
+    assert.equal(
+      manifestIconSizes.has(expectedSize),
+      true,
+      `Expected ${appConfig.label} manifest to include icon size: ${expectedSize}`,
     );
   }
 }

--- a/scripts/generate-client-runtime-config.spec.mjs
+++ b/scripts/generate-client-runtime-config.spec.mjs
@@ -7,7 +7,10 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { loadClientRuntimeConfig } from './generate-client-runtime-config.mjs';
+import {
+  loadClientRuntimeConfig,
+  serializeRuntimeConfig,
+} from './generate-client-runtime-config.mjs';
 
 function runTest(name, fn) {
   try {
@@ -94,5 +97,100 @@ runTest(
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }
+  },
+);
+
+runTest(
+  'le runtime client priorise les variables du fichier .env sur celles de process.env',
+  () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'kraak-client-runtime-config-'));
+
+    try {
+      const envFilePath = path.join(tempRoot, '.env.staging');
+      writeFileSync(
+        envFilePath,
+        [
+          'CLIENT_API_BASE_URL=https://from-file.example',
+          'SUPABASE_URL=https://from-file.supabase.co',
+          'SUPABASE_PUBLISHABLE_KEY=from-file-key',
+          '',
+        ].join('\n'),
+      );
+
+      const runtimeConfig = loadClientRuntimeConfig('staging', {
+        clientRootPath: tempRoot,
+        processEnv: {
+          CLIENT_API_BASE_URL: 'https://from-process.example',
+          SUPABASE_URL: 'https://from-process.supabase.co',
+          SUPABASE_PUBLISHABLE_KEY: 'from-process-key',
+        },
+      });
+
+      assert.deepEqual(runtimeConfig, {
+        apiBaseUrl: 'https://from-file.example',
+        supabaseUrl: 'https://from-file.supabase.co',
+        supabasePublishableKey: 'from-file-key',
+      });
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+runTest(
+  'le runtime client supporte la syntaxe export, les guillemets et les sauts de ligne echappes depuis le fichier env',
+  () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'kraak-client-runtime-config-'));
+
+    try {
+      const envFilePath = path.join(tempRoot, '.env.local');
+      writeFileSync(
+        envFilePath,
+        [
+          'export CLIENT_API_BASE_URL="https://quoted.example"',
+          "export SUPABASE_URL='https://quoted.supabase.co'",
+          'SUPABASE_PUBLISHABLE_KEY="line-1\\nline-2"',
+          '',
+        ].join('\n'),
+      );
+
+      const runtimeConfig = loadClientRuntimeConfig('local', {
+        clientRootPath: tempRoot,
+        processEnv: {},
+      });
+
+      assert.deepEqual(runtimeConfig, {
+        apiBaseUrl: 'https://quoted.example',
+        supabaseUrl: 'https://quoted.supabase.co',
+        supabasePublishableKey: 'line-1\nline-2',
+      });
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+runTest(
+  'la serialisation du runtime produit un script executable qui fige la configuration',
+  () => {
+    const serialized = serializeRuntimeConfig({
+      apiBaseUrl: 'https://api.example',
+      supabaseUrl: 'https://supabase.example',
+      supabasePublishableKey: 'public-key',
+    });
+
+    assert.equal(
+      serialized,
+      [
+        'globalThis.__KRAAK_RUNTIME_CONFIG__ = Object.freeze(',
+        '{',
+        '  "apiBaseUrl": "https://api.example",',
+        '  "supabaseUrl": "https://supabase.example",',
+        '  "supabasePublishableKey": "public-key"',
+        '}',
+        ');',
+        '',
+      ].join('\n'),
+    );
   },
 );


### PR DESCRIPTION
## Résumé
Renforce les tests de scripts autour de la config runtime client et des assets/icônes de marque pour web + mobile.

## Changements
- scripts/generate-client-runtime-config.spec.mjs
  - Ajout de cas de test sur la priorité .env vs process.env
  - Ajout de cas sur parsing export, guillemets et sauts de ligne échappés
  - Ajout d’un test de sérialisation serializeRuntimeConfig
- scripts/brand-icons.test.mjs
  - Vérification des liens favicon 16/32, apple-touch-icon (180x180) et manifest
  - Vérification de présence + non-vacuité des assets d’icônes
  - Vérification des champs clés du manifest (name, short_name, lang, couleurs) et tailles d’icônes attendues

## Validation
- node ./scripts/generate-client-runtime-config.spec.mjs
- node ./scripts/brand-icons.test.mjs

## Scope
Tâche limitée à l’extension de couverture de tests scripts, sans changement de logique applicative de production.
