### PR TITLE
fix(mobile): empêcher le crash au démarrage de l'APK Android

### DIFF
--- a/apps/client/capacitor.config.ts
+++ b/apps/client/capacitor.config.ts
@@ -1,11 +1,27 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
+// Filtrage volontairement vide des plugins natifs Android.
+//
+// Le plugin @capacitor/push-notifications integre des composants Firebase
+// Cloud Messaging (FirebaseMessagingService) qui sont initialises par
+// Android au demarrage de l'application. Sans google-services.json valide
+// et sans application du plugin Gradle com.google.gms.google-services,
+// l'initialisation de Firebase echoue ("Default FirebaseApp is not
+// initialized") et fait planter l'APK avant le rendu de la WebView.
+//
+// Tant que Firebase n'est pas provisionne pour l'app KRAAK Android, on
+// retire le plugin du build natif via includePlugins. Cote JS, le service
+// MobilePushNotificationsService bascule alors automatiquement sur son
+// stub de fallback. La liste sera reactivee une fois Firebase configure.
 const config: CapacitorConfig = {
   appId: 'com.kraak.mobile',
   appName: 'KRAAK',
   webDir: 'dist/mobile/browser',
   server: {
     androidScheme: 'https',
+  },
+  android: {
+    includePlugins: [],
   },
 };
 

--- a/apps/client/capacitor.config.ts
+++ b/apps/client/capacitor.config.ts
@@ -2,17 +2,17 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 // Filtrage volontairement vide des plugins natifs Android.
 //
-// Le plugin @capacitor/push-notifications integre des composants Firebase
-// Cloud Messaging (FirebaseMessagingService) qui sont initialises par
-// Android au demarrage de l'application. Sans google-services.json valide
+// Le plugin @capacitor/push-notifications intègre des composants Firebase
+// Cloud Messaging (FirebaseMessagingService) qui sont initialisés par
+// Android au démarrage de l'application. Sans google-services.json valide
 // et sans application du plugin Gradle com.google.gms.google-services,
-// l'initialisation de Firebase echoue ("Default FirebaseApp is not
+// l'initialisation de Firebase échoue ("Default FirebaseApp is not
 // initialized") et fait planter l'APK avant le rendu de la WebView.
 //
-// Tant que Firebase n'est pas provisionne pour l'app KRAAK Android, on
-// retire le plugin du build natif via includePlugins. Cote JS, le service
+// Tant que Firebase n'est pas provisionné pour l'app KRAAK Android, on
+// retire le plugin du build natif via includePlugins. Côté JS, le service
 // MobilePushNotificationsService bascule alors automatiquement sur son
-// stub de fallback. La liste sera reactivee une fois Firebase configure.
+// stub de fallback. La liste sera réactivée une fois Firebase configuré.
 const config: CapacitorConfig = {
   appId: 'com.kraak.mobile',
   appName: 'KRAAK',

--- a/docs/decisions/ARC-06-gating-firebase-mobile-push.md
+++ b/docs/decisions/ARC-06-gating-firebase-mobile-push.md
@@ -1,0 +1,64 @@
+# ARC-06 — Gating natif des notifications push mobile sur Firebase
+
+- Statut : Accepte
+- Date : 2026-04-10
+- Portee : `apps/client/projects/mobile`, `apps/client/capacitor.config.ts`, build Android Capacitor
+
+## Contexte
+
+Le service `MobilePushNotificationsService` integre `@capacitor/push-notifications` pour preparer l'experience d'annonces prioritaires (`MOB-05`, `ANN-04`). Le plugin natif Android contribue, via la fusion de manifeste (`merged AndroidManifest.xml`), un service `FirebaseMessagingService` instancie au demarrage de l'application.
+
+Or, le projet Firebase Cloud Messaging de KRAAK n'est pas encore provisionne :
+
+- aucun fichier `apps/client/android/app/google-services.json` n'est present ;
+- le plugin Gradle `com.google.gms.google-services` n'est applique que sous condition (`if (project.file('google-services.json').exists())`), donc actuellement non applique ;
+- aucune metadonnee Firebase n'est presente dans le manifeste applicatif.
+
+Resultat observe : a l'ouverture de l'APK staging sur appareil Android reel, Android tente d'instancier `FirebaseMessagingService` avant le rendu de la WebView, l'initialisation echoue (`Default FirebaseApp is not initialized in this process`) et le systeme affiche le dialogue « KRAAK closed because this app has a bug ». Le `try/catch` JavaScript du service ne peut pas intercepter cette exception native.
+
+## Decision
+
+Tant que Firebase n'est pas pleinement provisionne pour KRAAK Android, le build Capacitor exclut explicitement tous les plugins natifs Android via :
+
+```ts
+// apps/client/capacitor.config.ts
+android: {
+  includePlugins: [],
+}
+```
+
+Ce whitelist vide empeche `cap sync` d'inclure `@capacitor/push-notifications` (et tout autre plugin natif futur) dans `capacitor.settings.gradle` / `capacitor.build.gradle`. Le manifest fusionne ne reference plus de `FirebaseMessagingService` et l'APK demarre normalement.
+
+Cote JavaScript, aucun changement n'est necessaire : `MobilePushNotificationsService` bascule deja automatiquement sur son token stub lorsque le bridge natif n'expose pas le plugin (chemins `non-native`, `registration-error`, `initialization-error`).
+
+## Consequences
+
+Positives :
+
+- Suppression immediate du crash au demarrage de l'APK staging.
+- L'experience web et le service JS restent fonctionnels avec leur fallback stub.
+- L'ajout futur de Firebase devient explicite et controlable via une seule liste.
+
+Negatives / a surveiller :
+
+- Toute fonctionnalite mobile dependant d'un plugin natif Android (par ex. `@capacitor/app`, `@capacitor/haptics`, futurs plugins) doit etre ajoutee explicitement a `includePlugins` quand elle sera utilisee. La regle est testee par `scripts/verify-capacitor-android-plugins.test.mjs`.
+- Les notifications push natives Android sont desactivees jusqu'a la mise en place de Firebase.
+
+## Conditions de levee
+
+Le whitelist sera ouvert (ou supprime) lorsque les conditions suivantes seront reunies :
+
+1. Un projet Firebase est cree pour KRAAK et `google-services.json` est present sous `apps/client/android/app/`.
+2. Le plugin Gradle `com.google.gms.google-services` est applique inconditionnellement dans `apps/client/android/app/build.gradle`.
+3. Les permissions Android `POST_NOTIFICATIONS` et la metadata FCM par defaut sont declarees dans le manifeste applicatif.
+4. Une validation manuelle confirme que l'APK demarre et qu'un token FCM est obtenu.
+
+Le test de garde `scripts/verify-capacitor-android-plugins.test.mjs` se desactive automatiquement des qu'il detecte la presence de `google-services.json`, ce qui permet de retirer le whitelist sans casser la suite de tests.
+
+## Liens
+
+- Service concerne : `apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts`
+- Configuration Capacitor : `apps/client/capacitor.config.ts`
+- Test de garde : `scripts/verify-capacitor-android-plugins.test.mjs`
+- Runbook : `docs/runbooks/MOBILE_BUILD.md`
+- Reference Capacitor : option `includePlugins` (`@capacitor/cli` v7.x)

--- a/docs/decisions/ARC-06-gating-firebase-mobile-push.md
+++ b/docs/decisions/ARC-06-gating-firebase-mobile-push.md
@@ -1,24 +1,24 @@
 # ARC-06 — Gating natif des notifications push mobile sur Firebase
 
-- Statut : Accepte
+- Statut : Acceptée
 - Date : 2026-04-10
-- Portee : `apps/client/projects/mobile`, `apps/client/capacitor.config.ts`, build Android Capacitor
+- Portée : `apps/client/projects/mobile`, `apps/client/capacitor.config.ts`, build Android Capacitor
 
 ## Contexte
 
-Le service `MobilePushNotificationsService` integre `@capacitor/push-notifications` pour preparer l'experience d'annonces prioritaires (`MOB-05`, `ANN-04`). Le plugin natif Android contribue, via la fusion de manifeste (`merged AndroidManifest.xml`), un service `FirebaseMessagingService` instancie au demarrage de l'application.
+Le service `MobilePushNotificationsService` intègre `@capacitor/push-notifications` pour préparer l'expérience d'annonces prioritaires (`MOB-05`, `ANN-04`). Le plugin natif Android contribue, via la fusion de manifeste (`merged AndroidManifest.xml`), un service `FirebaseMessagingService` instancié au démarrage de l'application.
 
-Or, le projet Firebase Cloud Messaging de KRAAK n'est pas encore provisionne :
+Or, le projet Firebase Cloud Messaging de KRAAK n'est pas encore provisionné :
 
-- aucun fichier `apps/client/android/app/google-services.json` n'est present ;
-- le plugin Gradle `com.google.gms.google-services` n'est applique que sous condition (`if (project.file('google-services.json').exists())`), donc actuellement non applique ;
-- aucune metadonnee Firebase n'est presente dans le manifeste applicatif.
+- aucun fichier `apps/client/android/app/google-services.json` n'est présent ;
+- le plugin Gradle `com.google.gms.google-services` n'est appliqué que sous condition (`if (project.file('google-services.json').exists())`), donc actuellement non appliqué ;
+- aucune métadonnée Firebase n'est présente dans le manifeste applicatif.
 
-Resultat observe : a l'ouverture de l'APK staging sur appareil Android reel, Android tente d'instancier `FirebaseMessagingService` avant le rendu de la WebView, l'initialisation echoue (`Default FirebaseApp is not initialized in this process`) et le systeme affiche le dialogue « KRAAK closed because this app has a bug ». Le `try/catch` JavaScript du service ne peut pas intercepter cette exception native.
+Résultat observé : à l'ouverture de l'APK staging sur appareil Android réel, Android tente d'instancier `FirebaseMessagingService` avant le rendu de la WebView, l'initialisation échoue (`Default FirebaseApp is not initialized in this process`) et le système affiche le dialogue « KRAAK closed because this app has a bug ». Le `try/catch` JavaScript du service ne peut pas intercepter cette exception native.
 
-## Decision
+## Décision
 
-Tant que Firebase n'est pas pleinement provisionne pour KRAAK Android, le build Capacitor exclut explicitement tous les plugins natifs Android via :
+Tant que Firebase n'est pas pleinement provisionné pour KRAAK Android, le build Capacitor exclut explicitement tous les plugins natifs Android via :
 
 ```ts
 // apps/client/capacitor.config.ts
@@ -27,38 +27,38 @@ android: {
 }
 ```
 
-Ce whitelist vide empeche `cap sync` d'inclure `@capacitor/push-notifications` (et tout autre plugin natif futur) dans `capacitor.settings.gradle` / `capacitor.build.gradle`. Le manifest fusionne ne reference plus de `FirebaseMessagingService` et l'APK demarre normalement.
+Ce whitelist vide empêche `cap sync` d'inclure `@capacitor/push-notifications` (et tout autre plugin natif futur) dans `capacitor.settings.gradle` / `capacitor.build.gradle`. Le manifest fusionné ne référence plus de `FirebaseMessagingService` et l'APK démarre normalement.
 
-Cote JavaScript, aucun changement n'est necessaire : `MobilePushNotificationsService` bascule deja automatiquement sur son token stub lorsque le bridge natif n'expose pas le plugin (chemins `non-native`, `registration-error`, `initialization-error`).
+Côté JavaScript, aucun changement n'est nécessaire : `MobilePushNotificationsService` bascule déjà automatiquement sur son token stub lorsque le bridge natif n'expose pas le plugin (chemins `non-native`, `registration-error`, `initialization-error`).
 
-## Consequences
+## Conséquences
 
 Positives :
 
-- Suppression immediate du crash au demarrage de l'APK staging.
-- L'experience web et le service JS restent fonctionnels avec leur fallback stub.
-- L'ajout futur de Firebase devient explicite et controlable via une seule liste.
+- Suppression immédiate du crash au démarrage de l'APK staging.
+- L'expérience web et le service JS restent fonctionnels avec leur fallback stub.
+- L'ajout futur de Firebase devient explicite et contrôlable via une seule liste.
 
-Negatives / a surveiller :
+Négatives / à surveiller :
 
-- Toute fonctionnalite mobile dependant d'un plugin natif Android (par ex. `@capacitor/app`, `@capacitor/haptics`, futurs plugins) doit etre ajoutee explicitement a `includePlugins` quand elle sera utilisee. La regle est testee par `scripts/verify-capacitor-android-plugins.test.mjs`.
-- Les notifications push natives Android sont desactivees jusqu'a la mise en place de Firebase.
+- Toute fonctionnalité mobile dépendant d'un plugin natif Android (par ex. `@capacitor/app`, `@capacitor/haptics`, futurs plugins) doit être ajoutée explicitement à `includePlugins` quand elle sera utilisée. La règle est testée par `scripts/verify-capacitor-android-plugins.test.mjs`.
+- Les notifications push natives Android sont désactivées jusqu'à la mise en place de Firebase.
 
-## Conditions de levee
+## Conditions de levée
 
-Le whitelist sera ouvert (ou supprime) lorsque les conditions suivantes seront reunies :
+Le whitelist sera ouvert (ou supprimé) lorsque les conditions suivantes seront réunies :
 
-1. Un projet Firebase est cree pour KRAAK et `google-services.json` est present sous `apps/client/android/app/`.
-2. Le plugin Gradle `com.google.gms.google-services` est applique inconditionnellement dans `apps/client/android/app/build.gradle`.
-3. Les permissions Android `POST_NOTIFICATIONS` et la metadata FCM par defaut sont declarees dans le manifeste applicatif.
-4. Une validation manuelle confirme que l'APK demarre et qu'un token FCM est obtenu.
+1. Un projet Firebase est créé pour KRAAK et `google-services.json` est présent sous `apps/client/android/app/`.
+2. Le plugin Gradle `com.google.gms.google-services` est appliqué inconditionnellement dans `apps/client/android/app/build.gradle`.
+3. Les permissions Android `POST_NOTIFICATIONS` et la métadonnée FCM par défaut sont déclarées dans le manifeste applicatif.
+4. Une validation manuelle confirme que l'APK démarre et qu'un token FCM est obtenu.
 
-Le test de garde `scripts/verify-capacitor-android-plugins.test.mjs` se desactive automatiquement des qu'il detecte la presence de `google-services.json`, ce qui permet de retirer le whitelist sans casser la suite de tests.
+Le test de garde `scripts/verify-capacitor-android-plugins.test.mjs` se désactive automatiquement dès qu'il détecte la présence de `google-services.json`, ce qui permet de retirer le whitelist sans casser la suite de tests.
 
 ## Liens
 
-- Service concerne : `apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts`
+- Service concerné : `apps/client/projects/mobile/src/app/core/mobile-push-notifications.service.ts`
 - Configuration Capacitor : `apps/client/capacitor.config.ts`
 - Test de garde : `scripts/verify-capacitor-android-plugins.test.mjs`
 - Runbook : `docs/runbooks/MOBILE_BUILD.md`
-- Reference Capacitor : option `includePlugins` (`@capacitor/cli` v7.x)
+- Référence Capacitor : option `includePlugins` (`@capacitor/cli` v7.x)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,10 +10,11 @@ Ce répertoire centralise les décisions d'architecture formelles du projet KRAA
 
 ## Index
 
-| ID       | Titre                                    | Statut   | Date       |
-| -------- | ---------------------------------------- | -------- | ---------- |
-| `ARC-01` | Architecture cible MVP                   | Acceptée | 2025-07-18 |
-| `ARC-02` | Conventions dépôt et workflow Git        | Acceptée | 2025-07-18 |
-| `ARC-03` | Stratégie SEO et prerendering            | Acceptée | 2025-07-18 |
-| `ARC-04` | Modèles de données MVP                   | Acceptée | 2025-07-18 |
-| `ARC-05` | Critères anti-scope-creep et cadrage ADR | Acceptée | 2025-07-18 |
+| ID       | Titre                                               | Statut   | Date       |
+| -------- | --------------------------------------------------- | -------- | ---------- |
+| `ARC-01` | Architecture cible MVP                              | Acceptée | 2025-07-18 |
+| `ARC-02` | Conventions dépôt et workflow Git                   | Acceptée | 2025-07-18 |
+| `ARC-03` | Stratégie SEO et prerendering                       | Acceptée | 2025-07-18 |
+| `ARC-04` | Modèles de données MVP                              | Acceptée | 2025-07-18 |
+| `ARC-05` | Critères anti-scope-creep et cadrage ADR            | Acceptée | 2025-07-18 |
+| `ARC-06` | Gating natif notifications push mobile sur Firebase | Acceptée | 2026-04-10 |

--- a/docs/runbooks/MOBILE_BUILD.md
+++ b/docs/runbooks/MOBILE_BUILD.md
@@ -125,6 +125,14 @@ pnpm --filter @kraak/client cap:copy
 
 Le mobile inclut un service de base `MobilePushNotificationsService` pour le wiring FCM initial.
 
+> **Important : plugin natif desactive temporairement.**
+>
+> Tant que le projet Firebase Cloud Messaging de KRAAK n'est pas provisionne (pas de `apps/client/android/app/google-services.json`, pas de plugin Gradle `com.google.gms.google-services` applique), le plugin `@capacitor/push-notifications` est explicitement exclu du build natif Android via `android.includePlugins: []` dans `apps/client/capacitor.config.ts`.
+>
+> Sans cette exclusion, Android tente d'instancier `FirebaseMessagingService` au demarrage, echoue avec `Default FirebaseApp is not initialized`, et fait planter l'APK avant le rendu de la WebView (dialogue systeme « KRAAK closed because this app has a bug »).
+>
+> Quand Firebase sera configure, retirer `includePlugins: []` (ou y reintroduire `@capacitor/push-notifications`), commiter `google-services.json`, ajouter le plugin Gradle, puis re-executer `pnpm cap:sync`. Le test de garde `scripts/verify-capacitor-android-plugins.test.mjs` se desactive automatiquement des qu'il detecte la presence de `google-services.json`.
+
 Objectif du stub MVP :
 
 - initialiser la chaine Capacitor Push Notifications au demarrage de l'application

--- a/docs/runbooks/MOBILE_BUILD.md
+++ b/docs/runbooks/MOBILE_BUILD.md
@@ -125,13 +125,13 @@ pnpm --filter @kraak/client cap:copy
 
 Le mobile inclut un service de base `MobilePushNotificationsService` pour le wiring FCM initial.
 
-> **Important : plugin natif desactive temporairement.**
+> **Important : plugin natif désactivé temporairement.**
 >
-> Tant que le projet Firebase Cloud Messaging de KRAAK n'est pas provisionne (pas de `apps/client/android/app/google-services.json`, pas de plugin Gradle `com.google.gms.google-services` applique), le plugin `@capacitor/push-notifications` est explicitement exclu du build natif Android via `android.includePlugins: []` dans `apps/client/capacitor.config.ts`.
+> Tant que le projet Firebase Cloud Messaging de KRAAK n'est pas provisionné (pas de `apps/client/android/app/google-services.json`, pas de plugin Gradle `com.google.gms.google-services` appliqué), le plugin `@capacitor/push-notifications` est explicitement exclu du build natif Android via `android.includePlugins: []` dans `apps/client/capacitor.config.ts`.
 >
-> Sans cette exclusion, Android tente d'instancier `FirebaseMessagingService` au demarrage, echoue avec `Default FirebaseApp is not initialized`, et fait planter l'APK avant le rendu de la WebView (dialogue systeme « KRAAK closed because this app has a bug »).
+> Sans cette exclusion, Android tente d'instancier `FirebaseMessagingService` au démarrage, échoue avec `Default FirebaseApp is not initialized`, et fait planter l'APK avant le rendu de la WebView (dialogue système « KRAAK closed because this app has a bug »).
 >
-> Quand Firebase sera configure, retirer `includePlugins: []` (ou y reintroduire `@capacitor/push-notifications`), commiter `google-services.json`, ajouter le plugin Gradle, puis re-executer `pnpm cap:sync`. Le test de garde `scripts/verify-capacitor-android-plugins.test.mjs` se desactive automatiquement des qu'il detecte la presence de `google-services.json`.
+> Quand Firebase sera configuré, retirer `includePlugins: []` (ou y réintroduire `@capacitor/push-notifications`), commiter `google-services.json`, ajouter le plugin Gradle, puis ré-exécuter `pnpm cap:sync`. Le test de garde `scripts/verify-capacitor-android-plugins.test.mjs` se désactive automatiquement dès qu'il détecte la présence de `google-services.json`.
 
 Objectif du stub MVP :
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:api:staging": "pnpm --filter @kraak/api run start:staging",
     "build:api": "pnpm --filter @kraak/api build",
     "check:observability": "node ./scripts/check-observability.mjs",
-    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/check-observability.test.mjs",
+    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs",
     "test:api": "pnpm --filter @kraak/api test",
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
     "test:coverage": "pnpm --filter @kraak/api test:cov && pnpm --filter @kraak/client test:coverage && pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test:coverage",

--- a/scripts/verify-capacitor-android-plugins.test.mjs
+++ b/scripts/verify-capacitor-android-plugins.test.mjs
@@ -21,11 +21,11 @@ function readCapacitorConfigSource() {
 }
 
 test(
-  "tant que google-services.json est absent, capacitor.config.ts restreint les plugins natifs Android via includePlugins pour eviter le crash FCM au demarrage",
+  "tant que google-services.json est absent, capacitor.config.ts restreint les plugins natifs Android via includePlugins pour éviter le crash FCM au démarrage",
   () => {
     if (existsSync(googleServicesJsonPath)) {
-      // Une fois Firebase provisionne, le plugin push-notifications peut etre
-      // reactive : on n'impose plus le whitelist vide.
+      // Une fois Firebase provisionné, le plugin push-notifications peut être
+      // réactivé : on n'impose plus le whitelist vide.
       return;
     }
 
@@ -34,7 +34,7 @@ test(
     assert.match(
       capacitorConfigSource,
       /android\s*:\s*\{[^}]*includePlugins\s*:\s*\[\s*\]/u,
-      "capacitor.config.ts doit definir android.includePlugins: [] tant que Firebase (google-services.json) n'est pas configure, sinon @capacitor/push-notifications fait planter l'APK au demarrage.",
+      "capacitor.config.ts doit définir android.includePlugins: [] tant que Firebase (google-services.json) n'est pas configuré, sinon @capacitor/push-notifications fait planter l'APK au démarrage.",
     );
   },
 );

--- a/scripts/verify-capacitor-android-plugins.test.mjs
+++ b/scripts/verify-capacitor-android-plugins.test.mjs
@@ -1,0 +1,40 @@
+// scripts\verify-capacitor-android-plugins.test.mjs
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const clientDirectory = path.join(scriptDirectory, '..', 'apps', 'client');
+const capacitorConfigPath = path.join(clientDirectory, 'capacitor.config.ts');
+const googleServicesJsonPath = path.join(
+  clientDirectory,
+  'android',
+  'app',
+  'google-services.json',
+);
+
+function readCapacitorConfigSource() {
+  return readFileSync(capacitorConfigPath, 'utf8');
+}
+
+test(
+  "tant que google-services.json est absent, capacitor.config.ts restreint les plugins natifs Android via includePlugins pour eviter le crash FCM au demarrage",
+  () => {
+    if (existsSync(googleServicesJsonPath)) {
+      // Une fois Firebase provisionne, le plugin push-notifications peut etre
+      // reactive : on n'impose plus le whitelist vide.
+      return;
+    }
+
+    const capacitorConfigSource = readCapacitorConfigSource();
+
+    assert.match(
+      capacitorConfigSource,
+      /android\s*:\s*\{[^}]*includePlugins\s*:\s*\[\s*\]/u,
+      "capacitor.config.ts doit definir android.includePlugins: [] tant que Firebase (google-services.json) n'est pas configure, sinon @capacitor/push-notifications fait planter l'APK au demarrage.",
+    );
+  },
+);


### PR DESCRIPTION
Closes #262

## Contexte

L'APK staging affichait `KRAAK closed because this app has a bug` au lancement, avant tout rendu de la WebView.

## Cause racine

Le plugin `@capacitor/push-notifications` enregistre `FirebaseMessagingService` dans le manifeste fusionné (`AndroidManifest.xml`). Sans `google-services.json` valide ni application du plugin Gradle `com.google.gms.google-services`, l'initialisation Firebase échoue au démarrage du process Android (`Default FirebaseApp is not initialized`) et fait planter l'APK avant que la WebView ne se monte. Le `try/catch` JavaScript ne peut pas intercepter cette exception native.

## Correctif

- Ajout de `android: { includePlugins: [] }` dans `apps/client/capacitor.config.ts` : le whitelist explicite de Capacitor 7 retire tous les plugins natifs Android tant que Firebase n'est pas provisionné.
- Côté JS, `MobilePushNotificationsService` bascule automatiquement sur son fallback stub quand le bridge n'expose plus le plugin (comportement déjà couvert).
- Test de garde workspace `scripts/verify-capacitor-android-plugins.test.mjs` : verrouille la règle tant que `apps/client/android/app/google-services.json` est absent ; le test s'auto-désactive dès que Firebase sera provisionné.
- ADR `docs/decisions/ARC-06-gating-firebase-mobile-push.md` documente la décision et les conditions de levée.
- Runbook `docs/runbooks/MOBILE_BUILD.md` mis à jour avec les étapes de réactivation.

## Validation

- `pnpm test:workspace` (16/16) — incluant le nouveau test de garde
- `pnpm typecheck:mobile` — clean
- `pnpm --filter @kraak/client test:mobile` (116/116, 27 fichiers)
- `pnpm --filter @kraak/client cap:sync android` — confirme que `:capacitor-push-notifications` ne figure plus dans `capacitor.settings.gradle`
- Pre-push : suite Playwright E2E web (22/22)

## Conditions de réactivation du plugin push natif

Voir ARC-06 — provisionner `google-services.json`, appliquer le plugin Gradle, déclarer la permission `POST_NOTIFICATIONS` et valider sur APK avant de retirer `includePlugins: []`.

Refs: ARC-06
