### PR TITLE
test(scripts): preserve escaped newlines in runtime config spec

### DIFF
--- a/scripts/generate-client-runtime-config.spec.mjs
+++ b/scripts/generate-client-runtime-config.spec.mjs
@@ -149,7 +149,7 @@ runTest(
         [
           'export CLIENT_API_BASE_URL="https://quoted.example"',
           "export SUPABASE_URL='https://quoted.supabase.co'",
-          'SUPABASE_PUBLISHABLE_KEY="line-1\\nline-2"',
+          String.raw`SUPABASE_PUBLISHABLE_KEY="line-1\nline-2"`,
           '',
         ].join('\n'),
       );


### PR DESCRIPTION
## Résumé
- restaure le stash "wip: runtime config spec change (unrelated)" sur une branche dédiée
- remplace la fixture SUPABASE_PUBLISHABLE_KEY par String.raw dans le test
- conserve un \\n littéral dans la valeur attendue, au lieu d'un vrai saut de ligne

## Validation
- node --test scripts/generate-client-runtime-config.spec.mjs
- hooks locaux passés (format, lint:fix, e2e pre-push)
