### PR TITLE
feat(web): center navbar menu and remove navbar Accueil link

### DIFF
--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.html
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.html
@@ -46,12 +46,12 @@
       </ul>
 
       <div
-        class="border-brand-blue/10 mt-3 flex border-t pt-3 lg:mt-0 lg:border-0 lg:pt-0"
+        class="border-brand-blue/10 mt-3 border-t pt-3 lg:mt-0 lg:border-0 lg:pt-0"
       >
         <a
           routerLink="/participant"
           aria-label="Espace participant"
-          class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex w-full items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px lg:w-auto"
+          class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
           (click)="closeMobileMenu()"
         >
           Espace participant

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.html
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.html
@@ -1,9 +1,9 @@
 <header
-  class="bg-brand-white/92 border-brand-blue/10 sticky top-0 z-50 border-b shadow-[0_12px_28px_rgb(18_43_74_/_6%)] backdrop-blur-sm"
+  class="bg-brand-white/92 border-brand-blue/10 sticky top-0 z-50 border-b shadow-[0_12px_28px_rgb(18_43_74/6%)] backdrop-blur-sm"
 >
   <nav
     aria-label="Navigation principale"
-    class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-4 lg:px-6"
+    class="relative mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-4 lg:px-6"
   >
     <a
       routerLink="/"
@@ -18,79 +18,60 @@
         fetchpriority="high"
         loading="eager"
         decoding="async"
-        class="h-11 w-auto drop-shadow-[0_10px_24px_rgb(18_43_74_/_12%)]"
+        class="h-11 w-auto drop-shadow-[0_10px_24px_rgb(18_43_74/12%)]"
       />
       <span class="sr-only">KRAAK</span>
     </a>
 
-    <ul class="hidden items-center gap-6 lg:flex">
-      @for (link of links; track link.path) {
-        <li>
-          <a
-            [routerLink]="link.path"
-            routerLinkActive="text-primary after:scale-x-100"
-            [routerLinkActiveOptions]="{ exact: link.path === '/' }"
-            class="kr-nav-link"
-          >
-            {{ link.label }}
-          </a>
-        </li>
-      }
-    </ul>
-
-    <div class="hidden lg:block">
-      <a
-        routerLink="/participant"
-        aria-label="Espace participant"
-        class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74_/_16%)] transition-all hover:-translate-y-px"
-      >
-        Espace participant
-      </a>
-    </div>
-
-    <button
-      type="button"
-      class="border-brand-blue/25 bg-brand-white text-brand-navy hover:border-brand-blue/45 hover:bg-brand-cyan/8 inline-flex items-center justify-center rounded-(--kr-radius-btn) border px-3 py-3 shadow-[0_18px_35px_rgb(18_43_74_/_16%)] transition-all hover:-translate-y-px lg:hidden"
-      (click)="toggleMobileMenu()"
-      [attr.aria-expanded]="mobileMenuOpen()"
-      aria-label="Menu de navigation"
-    >
-      <i
-        [class]="mobileMenuOpen() ? 'pi pi-times' : 'pi pi-bars'"
-        aria-hidden="true"
-      ></i>
-    </button>
-  </nav>
-
-  @if (mobileMenuOpen()) {
     <div
-      class="bg-brand-white border-brand-blue/10 border-t px-4 py-4 shadow-sm lg:hidden"
+      class="border-brand-blue/10 bg-brand-white absolute top-full left-0 z-50 w-full items-center justify-between border-t px-4 py-4 shadow-sm lg:static lg:flex lg:w-auto lg:grow lg:border-0 lg:bg-transparent lg:p-0 lg:shadow-none"
+      [class.hidden]="!mobileMenuOpen()"
+      [class.flex]="mobileMenuOpen()"
     >
-      <div class="mx-auto flex w-full max-w-6xl flex-col gap-4">
-        <ul class="flex flex-col gap-2">
-          @for (link of links; track link.path) {
-            <li>
-              <a
-                [routerLink]="link.path"
-                routerLinkActive="border-primary bg-neutral-50 text-primary"
-                [routerLinkActiveOptions]="{ exact: link.path === '/' }"
-                class="hover:border-brand-blue/15 hover:bg-brand-blue/5 hover:text-primary block rounded-(--kr-radius-btn) border border-transparent px-4 py-3 text-sm font-semibold text-neutral-700 transition-colors"
-                (click)="closeMobileMenu()"
-              >
-                {{ link.label }}
-              </a>
-            </li>
-          }
-        </ul>
+      <ul
+        class="flex grow flex-col gap-2 lg:flex-row lg:items-center lg:justify-center lg:gap-6"
+      >
+        @for (link of links; track link.path) {
+          <li>
+            <a
+              [routerLink]="link.path"
+              routerLinkActive="text-primary after:scale-x-100"
+              class="kr-nav-link"
+              (click)="closeMobileMenu()"
+            >
+              {{ link.label }}
+            </a>
+          </li>
+        }
+      </ul>
+
+      <div
+        class="border-brand-blue/10 mt-3 flex border-t pt-3 lg:mt-0 lg:border-0 lg:pt-0"
+      >
         <a
           routerLink="/participant"
           aria-label="Espace participant"
-          class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex w-full items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-3 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74_/_16%)] transition-all hover:-translate-y-px"
+          class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex w-full items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px lg:w-auto"
           (click)="closeMobileMenu()"
         >
           Espace participant
         </a>
       </div>
     </div>
-  }
+
+    <div class="lg:hidden">
+      <button
+        type="button"
+        class="border-brand-blue/25 bg-brand-white text-brand-navy hover:border-brand-blue/45 hover:bg-brand-cyan/8 inline-flex items-center justify-center rounded-(--kr-radius-btn) border px-3 py-3 shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
+        (click)="toggleMobileMenu()"
+        [attr.aria-expanded]="mobileMenuOpen()"
+        aria-label="Menu de navigation"
+      >
+        <i
+          [class]="mobileMenuOpen() ? 'pi pi-times' : 'pi pi-bars'"
+          aria-hidden="true"
+        ></i>
+      </button>
+    </div>
+  </nav>
 </header>

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.spec.ts
@@ -33,6 +33,8 @@ describe('Navbar', () => {
       'kraak_consulting_logo_192w.png',
     );
     expect(primaryCta).toBeTruthy();
+    expect(element.textContent).not.toContain('Accueil');
+    expect(element.textContent).toContain('À propos');
   });
 
   it('should provide a named navigation landmark', () => {

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.ts
@@ -14,7 +14,6 @@ interface NavLink {
 })
 export class Navbar {
   protected readonly links: NavLink[] = [
-    { label: 'Accueil', path: '/' },
     { label: 'À propos', path: '/a-propos' },
     { label: 'Services', path: '/services' },
     { label: 'Programmes', path: '/programmes' },


### PR DESCRIPTION
## Résumé\n- supprime le lien "Accueil" de la navbar (le logo conserve le lien vers la home)\n- refactorise la navbar vers une structure menu centré (logo à gauche, navigation centrée, CTA à droite)\n- conserve le comportement responsive mobile avec menu toggle\n- met à jour les tests unitaires de navbar\n\n## Validation\n- build web locale OK\n- hooks pre-push OK (unit/integration/e2e)\n