### PR TITLE
fix(web): resolve navbar RouterLink import compatibility

### DIFF
--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.ts
@@ -1,5 +1,5 @@
 import { Component, signal } from '@angular/core';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import { RouterModule } from '@angular/router';
 
 interface NavLink {
   label: string;
@@ -9,7 +9,7 @@ interface NavLink {
 @Component({
   selector: 'kraak-navbar',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive],
+  imports: [RouterModule],
   templateUrl: './navbar.html',
 })
 export class Navbar {


### PR DESCRIPTION
## Résumé\n- remplace l'import standalone / par  dans la navbar\n- évite l'erreur d'export de symbole selon la résolution Angular/TS language service\n\n## Validation\n- erreurs IDE navbar supprimées\n- build web local OK\n- hooks pre-push OK (unit/integration/e2e)\n