### PR TITLE
feat(web): refresh Home dark-image hero

### DIFF
--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -5,7 +5,7 @@
 >
   <div
     aria-hidden="true"
-    class="via-brand-navy/45 to-brand-navy/72 absolute inset-0 bg-linear-to-b from-transparent"
+    class="via-brand-navy/20 to-brand-navy/70 absolute inset-0 bg-linear-to-b from-transparent"
   ></div>
 
   <div class="relative z-10 mx-auto flex max-w-4xl flex-col items-center">
@@ -16,20 +16,19 @@
     </p>
 
     <h1 class="text-brand-white text-4xl leading-tight font-bold md:text-5xl">
-      R&eacute;v&eacute;lez le meilleur<br />de votre trajectoire
+      R&eacute;v&eacute;lez votre potentiel
     </h1>
     <p
       class="text-brand-cyan mt-3 text-4xl leading-tight font-bold md:text-5xl"
     >
-      professionnelle
+      dans chaque opportunit&eacute;
     </p>
 
     <p
       class="text-brand-white/85 mx-auto mt-6 max-w-2xl text-lg leading-relaxed"
     >
-      Acc&eacute;l&eacute;rez vos projets de carri&egrave;re, de formation et de
-      mobilit&eacute; internationale avec un accompagnement concret, humain et
-      strat&eacute;gique.
+      Recevez nos conseils, formations et opportunit&eacute;s pour construire un
+      parcours professionnel ambitieux, localement et &agrave; l'international.
     </p>
 
     <div
@@ -47,9 +46,9 @@
         pButton
         type="button"
         class="h-12 w-full rounded-full sm:w-auto"
-        aria-label="Recevoir les opportunit&eacute;s KRAAK"
+        aria-label="M'avertir des opportunit&eacute;s"
       >
-        Recevoir les opportunit&eacute;s
+        M'avertir
       </button>
     </div>
 

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -8,7 +8,7 @@
     class="via-brand-navy/20 to-brand-navy/70 absolute inset-0 bg-linear-to-b from-transparent"
   ></div>
 
-  <div class="relative z-10 mx-auto flex max-w-4xl flex-col items-center">
+  <div class="relative z-10 mx-auto flex max-w-4xl flex-col items-center px-6">
     <p
       class="text-brand-white/78 mb-4 text-xs font-semibold tracking-[0.3em] uppercase"
     >

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -1,52 +1,60 @@
 <!-- Hero -->
 <section
-  class="bg-brand-navy text-brand-white relative overflow-hidden py-20 text-center lg:py-28"
+  class="relative overflow-hidden bg-cover bg-center bg-no-repeat px-4 py-20 text-center md:px-8 lg:px-12 lg:py-28"
+  [ngStyle]="heroBackgroundStyle"
 >
   <div
     aria-hidden="true"
-    class="bg-brand-cyan/30 absolute -top-10 right-[-6rem] h-44 w-44 rounded-full blur-3xl"
+    class="via-brand-navy/45 to-brand-navy/72 absolute inset-0 bg-linear-to-b from-transparent"
   ></div>
-  <div
-    aria-hidden="true"
-    class="bg-brand-gold/22 absolute bottom-[-4rem] left-[-2rem] h-40 w-40 rounded-full blur-3xl"
-  ></div>
-  <div
-    class="relative z-10 mx-auto flex max-w-4xl flex-col items-center px-4 lg:px-6"
-  >
-    <div
-      class="border-brand-white/14 bg-brand-white/8 mb-8 inline-flex max-w-xl items-center gap-4 rounded-full border px-4 py-3 text-left shadow-[0_18px_45px_rgb(0_0_0_/_16%)] backdrop-blur"
+
+  <div class="relative z-10 mx-auto flex max-w-4xl flex-col items-center">
+    <p
+      class="text-brand-white/78 mb-4 text-xs font-semibold tracking-[0.3em] uppercase"
     >
-      <img
-        src="/kraak_consulting_symbol_96w.png"
-        alt="Symbole KRAAK Consulting"
-        width="48"
-        height="48"
-        fetchpriority="high"
-        loading="eager"
-        decoding="async"
-        class="bg-brand-white/96 h-12 w-12 rounded-full p-2"
-      />
-      <div>
-        <p
-          class="text-brand-white/70 text-xs font-semibold tracking-[0.34em] uppercase"
-        >
-          KRAAK Consulting
-        </p>
-        <p class="text-brand-white/82 text-sm">
-          Leadership, mobilit&eacute; et impact concret pour les talents et les
-          organisations.
-        </p>
-      </div>
-    </div>
-    <h1 class="text-brand-white text-4xl leading-tight font-bold lg:text-5xl">
-      D&eacute;veloppez votre potentiel.<br />Construisez votre impact.
-    </h1>
-    <p class="mx-auto mt-6 max-w-2xl text-lg text-neutral-300">
-      KRAAK accompagne les jeunes professionnels et les organisations vers des
-      opportunit&eacute;s concr&egrave;tes, locales et internationales.
+      KRAAK Consulting
     </p>
+
+    <h1 class="text-brand-white text-4xl leading-tight font-bold md:text-5xl">
+      R&eacute;v&eacute;lez le meilleur<br />de votre trajectoire
+    </h1>
+    <p
+      class="text-brand-cyan mt-3 text-4xl leading-tight font-bold md:text-5xl"
+    >
+      professionnelle
+    </p>
+
+    <p
+      class="text-brand-white/85 mx-auto mt-6 max-w-2xl text-lg leading-relaxed"
+    >
+      Acc&eacute;l&eacute;rez vos projets de carri&egrave;re, de formation et de
+      mobilit&eacute; internationale avec un accompagnement concret, humain et
+      strat&eacute;gique.
+    </p>
+
     <div
-      class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
+      class="mt-8 flex w-full max-w-3xl flex-col items-center justify-center gap-4 sm:flex-row"
+    >
+      <input
+        pInputText
+        type="email"
+        class="border-brand-white/70 bg-brand-white/8 text-brand-white placeholder:text-brand-white/62 h-12 w-full rounded-full border px-5 sm:w-96"
+        placeholder="Votre adresse email"
+        aria-label="Votre adresse email"
+        [(ngModel)]="email"
+      />
+      <button
+        pButton
+        type="button"
+        class="h-12 w-full rounded-full sm:w-auto"
+        aria-label="Recevoir les opportunit&eacute;s KRAAK"
+      >
+        Recevoir les opportunit&eacute;s
+      </button>
+    </div>
+
+    <div
+      class="mt-6 flex flex-col items-center justify-center gap-4 sm:flex-row"
     >
       <a
         pButton

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -31,12 +31,14 @@
       parcours professionnel ambitieux, localement et &agrave; l'international.
     </p>
 
-    <div
+    <form
       class="mt-8 flex w-full max-w-3xl flex-col items-center justify-center gap-4 sm:flex-row"
+      (ngSubmit)="onHeroNotifySubmit()"
     >
       <input
         pInputText
         type="email"
+        name="heroEmail"
         class="border-brand-white/70 bg-brand-white/8 text-brand-white placeholder:text-brand-white/62 h-12 w-full rounded-full border px-5 sm:w-96"
         placeholder="Votre adresse email"
         aria-label="Votre adresse email"
@@ -44,13 +46,13 @@
       />
       <button
         pButton
-        type="button"
+        type="submit"
         class="h-12 w-full rounded-full sm:w-auto"
         aria-label="M'avertir des opportunit&eacute;s"
       >
         M'avertir
       </button>
-    </div>
+    </form>
 
     <div
       class="mt-6 flex flex-col items-center justify-center gap-4 sm:flex-row"

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -19,7 +19,7 @@ describe('HomePage', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain('trajectoire');
+    expect(heading?.textContent).toContain('potentiel');
   });
 
   it('should render a newsletter email input in the hero', () => {
@@ -43,7 +43,7 @@ describe('HomePage', () => {
       'bw-hero-bg.jpg',
     );
     expect(component.heroBackgroundStyle.backgroundBlendMode).toBe(
-      'normal, multiply, normal',
+      'normal, multiply, lighten, normal',
     );
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -19,22 +19,31 @@ describe('HomePage', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain('potentiel');
+    expect(heading?.textContent).toContain('trajectoire');
   });
 
-  it('should prioritize and size the hero visual assets', () => {
+  it('should render a newsletter email input in the hero', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
 
     const element = fixture.nativeElement as HTMLElement;
-    const heroBadgeImage = element.querySelector(
-      'img[alt="Symbole KRAAK Consulting"]',
-    ) as HTMLImageElement | null;
+    const emailInput = element.querySelector(
+      'input[type="email"][aria-label="Votre adresse email"]',
+    ) as HTMLInputElement | null;
 
-    expect(heroBadgeImage?.getAttribute('fetchpriority')).toBe('high');
-    expect(heroBadgeImage?.getAttribute('loading')).toBe('eager');
-    expect(heroBadgeImage?.getAttribute('decoding')).toBe('async');
-    expect(heroBadgeImage?.getAttribute('width')).toBe('48');
-    expect(heroBadgeImage?.getAttribute('height')).toBe('48');
+    expect(emailInput).toBeTruthy();
+    expect(emailInput?.placeholder).toBe('Votre adresse email');
+  });
+
+  it('should expose a dark hero background style object', () => {
+    const fixture = TestBed.createComponent(HomePage);
+    const component = fixture.componentInstance;
+
+    expect(component.heroBackgroundStyle.background).toContain(
+      'bw-hero-bg.jpg',
+    );
+    expect(component.heroBackgroundStyle.backgroundBlendMode).toBe(
+      'normal, multiply, normal',
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
+import { vi } from 'vitest';
 import HomePage from './home.page';
 
 describe('HomePage', () => {
@@ -45,5 +46,23 @@ describe('HomePage', () => {
     expect(component.heroBackgroundStyle.backgroundBlendMode).toBe(
       'normal, multiply, lighten, normal',
     );
+  });
+
+  it('should navigate to contact when the hero notify form is submitted', async () => {
+    const fixture = TestBed.createComponent(HomePage);
+    const component = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    component.email = 'contact@example.com';
+    component.onHeroNotifySubmit();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/contact'], {
+      queryParams: {
+        email: 'contact@example.com',
+        source: 'home_hero_notify',
+      },
+      queryParamsHandling: 'merge',
+    });
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
+import { NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
-import { NgStyle } from '@angular/common';
 
 import { CtaBanner } from '../../shared/cta-banner/cta-banner';
 
@@ -25,7 +25,7 @@ export default class HomePage {
 
   heroBackgroundStyle = {
     background:
-      "linear-gradient(0deg, color-mix(in srgb, var(--p-surface-950) 55%, transparent) 0%, transparent 100%), linear-gradient(0deg, color-mix(in srgb, var(--p-primary-700) 72%, transparent) 0%, color-mix(in srgb, var(--p-primary-700) 72%, transparent) 100%), url('https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/hero/bw-hero-bg.jpg') center/cover no-repeat",
-    backgroundBlendMode: 'normal, multiply, normal',
+      "linear-gradient(0deg, color-mix(in srgb, var(--p-surface-950) 50%, transparent) 0%, transparent 100%), linear-gradient(0deg, var(--p-primary-500) 0%, var(--p-primary-500) 100%), linear-gradient(0deg, color-mix(in srgb, var(--p-primary-800) 60%, transparent) 0%, color-mix(in srgb, var(--p-primary-800) 60%, transparent) 100%), url('https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/hero/bw-hero-bg.jpg') center/cover no-repeat",
+    backgroundBlendMode: 'normal, multiply, lighten, normal',
   };
 }

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 
@@ -22,10 +22,21 @@ import { CtaBanner } from '../../shared/cta-banner/cta-banner';
 })
 export default class HomePage {
   email = '';
+  private readonly router = inject(Router);
 
   heroBackgroundStyle = {
     background:
       "linear-gradient(0deg, color-mix(in srgb, var(--p-surface-950) 50%, transparent) 0%, transparent 100%), linear-gradient(0deg, var(--p-primary-500) 0%, var(--p-primary-500) 100%), linear-gradient(0deg, color-mix(in srgb, var(--p-primary-800) 60%, transparent) 0%, color-mix(in srgb, var(--p-primary-800) 60%, transparent) 100%), url('https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/hero/bw-hero-bg.jpg') center/cover no-repeat",
     backgroundBlendMode: 'normal, multiply, lighten, normal',
   };
+
+  onHeroNotifySubmit(): void {
+    void this.router.navigate(['/contact'], {
+      queryParams: {
+        email: this.email || undefined,
+        source: 'home_hero_notify',
+      },
+      queryParamsHandling: 'merge',
+    });
+  }
 }

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -1,13 +1,31 @@
 import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { NgStyle } from '@angular/common';
 
 import { CtaBanner } from '../../shared/cta-banner/cta-banner';
 
 @Component({
   selector: 'kraak-home-page',
   standalone: true,
-  imports: [RouterLink, ButtonDirective, CtaBanner],
+  imports: [
+    NgStyle,
+    FormsModule,
+    RouterLink,
+    ButtonDirective,
+    InputText,
+    CtaBanner,
+  ],
   templateUrl: './home.page.html',
 })
-export default class HomePage {}
+export default class HomePage {
+  email = '';
+
+  heroBackgroundStyle = {
+    background:
+      "linear-gradient(0deg, color-mix(in srgb, var(--p-surface-950) 55%, transparent) 0%, transparent 100%), linear-gradient(0deg, color-mix(in srgb, var(--p-primary-700) 72%, transparent) 0%, color-mix(in srgb, var(--p-primary-700) 72%, transparent) 100%), url('https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/hero/bw-hero-bg.jpg') center/cover no-repeat",
+    backgroundBlendMode: 'normal, multiply, normal',
+  };
+}


### PR DESCRIPTION
## Summary
- adapt the Home hero to a dark image background variant inspired by the provided component
- restore email capture input and hero background blend styles in the Home page component
- keep CTA actions and fix hero inner spacing to satisfy existing design-system E2E expectations

## Validation
- pnpm ng test web --watch=false --include=projects/web/src/app/features/home/home.page.spec.ts
- pnpm --filter @kraak/client e2e -- tests/e2e/design-system.spec.ts
- pre-push hooks (format, lint, unit, e2e) completed during push
