### PR TITLE
style(web): refresh inscription form with two-column layout

### DIFF
--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.html
@@ -23,7 +23,10 @@
             <span
               class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 ring-1 ring-white/30"
             >
-              <i class="pi pi-compass text-base text-white"></i>
+              <i
+                class="pi pi-compass text-base text-white"
+                aria-hidden="true"
+              ></i>
             </span>
             <div>
               <p
@@ -38,17 +41,15 @@
           </div>
 
           <div class="relative z-10 mt-12 flex flex-col gap-8">
-            <h2
-              class="max-w-sm text-3xl leading-tight font-semibold text-white"
-            >
+            <p class="max-w-sm text-3xl leading-tight font-semibold text-white">
               Rejoignez KRAAK et lancez votre parcours d&apos;accompagnement.
-            </h2>
+            </p>
             <div class="space-y-5 text-sm leading-6 text-slate-100/90">
               <div class="flex items-start gap-3">
                 <span
                   class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/30"
                 >
-                  <i class="pi pi-star text-xs"></i>
+                  <i class="pi pi-star text-xs" aria-hidden="true"></i>
                 </span>
                 <p>
                   Acc&eacute;dez &agrave; vos programmes de formation, de
@@ -59,7 +60,7 @@
                 <span
                   class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/30"
                 >
-                  <i class="pi pi-users text-xs"></i>
+                  <i class="pi pi-users text-xs" aria-hidden="true"></i>
                 </span>
                 <p>
                   B&eacute;n&eacute;ficiez d&apos;un suivi personnalis&eacute;
@@ -71,7 +72,7 @@
                 <span
                   class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/30"
                 >
-                  <i class="pi pi-shield text-xs"></i>
+                  <i class="pi pi-shield text-xs" aria-hidden="true"></i>
                 </span>
                 <p>
                   Vos donn&eacute;es personnelles sont prot&eacute;g&eacute;es
@@ -89,7 +90,7 @@
             Espace participant
           </p>
           <h1 class="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
-            Cr&eacute;er un compte
+            Créer un compte
           </h1>
           <p class="mt-3 max-w-lg text-sm leading-6 text-slate-600">
             Ouvrez votre espace KRAAK pour suivre vos programmes et vos
@@ -206,11 +207,7 @@
               class="btn btn-primary mt-1"
               [disabled]="submitting()"
             >
-              {{
-                submitting()
-                  ? 'Cr&eacute;ation en cours...'
-                  : 'Cr&eacute;er mon compte'
-              }}
+              {{ submitting() ? 'Création en cours...' : 'Créer mon compte' }}
             </button>
           </form>
 

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.html
@@ -1,135 +1,227 @@
-<main class="min-h-screen bg-slate-50 py-12 sm:py-16">
-  <div class="mx-auto w-full max-w-xl px-4 sm:px-6">
+<main
+  class="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(15,23,42,0.08),transparent_45%),linear-gradient(165deg,#f8fafc_0%,#eef6ff_45%,#fff8ee_100%)] px-4 py-10 sm:px-6 sm:py-12 lg:px-8 lg:py-16"
+>
+  <div class="mx-auto w-full max-w-6xl">
     <section
-      class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+      class="overflow-hidden rounded-3xl border border-slate-200/70 bg-white/90 shadow-2xl shadow-slate-900/10 backdrop-blur-sm"
     >
-      <p
-        class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
-      >
-        Espace participant
-      </p>
-      <h1 class="mt-3 text-3xl font-semibold text-slate-950">
-        Creer un compte
-      </h1>
-      <p class="mt-3 text-sm leading-6 text-slate-600">
-        Ouvrez votre espace KRAAK pour suivre vos programmes et vos prochaines
-        sessions.
-      </p>
+      <div class="grid lg:grid-cols-2">
+        <aside
+          class="relative hidden overflow-hidden bg-slate-900 px-10 py-14 text-slate-50 lg:flex lg:flex-col lg:justify-between"
+        >
+          <div
+            class="absolute inset-0 bg-[linear-gradient(160deg,rgba(14,116,144,0.85)_0%,rgba(15,23,42,0.92)_55%,rgba(12,74,110,0.88)_100%)]"
+          ></div>
+          <div
+            class="absolute -top-20 -left-24 h-72 w-72 rounded-full bg-cyan-300/25 blur-3xl"
+          ></div>
+          <div
+            class="absolute right-0 -bottom-28 h-72 w-72 rounded-full bg-amber-300/20 blur-3xl"
+          ></div>
 
-      <form
-        [formGroup]="form"
-        (ngSubmit)="submit()"
-        class="mt-6 flex flex-col gap-4"
-        novalidate
-      >
-        <div class="grid gap-4 sm:grid-cols-2">
-          <div class="flex flex-col gap-2">
-            <label
-              for="web-sign-up-first-name"
-              class="text-sm font-semibold text-slate-900"
+          <div class="relative z-10 flex items-center gap-3">
+            <span
+              class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 ring-1 ring-white/30"
             >
-              Prenom
-            </label>
-            <input
-              id="web-sign-up-first-name"
-              type="text"
-              formControlName="firstName"
-              autocomplete="given-name"
-              class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
-            />
+              <i class="pi pi-compass text-base text-white"></i>
+            </span>
+            <div>
+              <p
+                class="text-xs font-semibold tracking-[0.22em] text-white/75 uppercase"
+              >
+                Espace participant
+              </p>
+              <p class="text-lg leading-tight font-semibold text-white">
+                KRAAK
+              </p>
+            </div>
           </div>
 
-          <div class="flex flex-col gap-2">
-            <label
-              for="web-sign-up-last-name"
-              class="text-sm font-semibold text-slate-900"
+          <div class="relative z-10 mt-12 flex flex-col gap-8">
+            <h2
+              class="max-w-sm text-3xl leading-tight font-semibold text-white"
             >
-              Nom
-            </label>
-            <input
-              id="web-sign-up-last-name"
-              type="text"
-              formControlName="lastName"
-              autocomplete="family-name"
-              class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
-            />
+              Rejoignez KRAAK et lancez votre parcours d&apos;accompagnement.
+            </h2>
+            <div class="space-y-5 text-sm leading-6 text-slate-100/90">
+              <div class="flex items-start gap-3">
+                <span
+                  class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/30"
+                >
+                  <i class="pi pi-star text-xs"></i>
+                </span>
+                <p>
+                  Acc&eacute;dez &agrave; vos programmes de formation, de
+                  conseil et d&apos;accompagnement en un seul espace.
+                </p>
+              </div>
+              <div class="flex items-start gap-3">
+                <span
+                  class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/30"
+                >
+                  <i class="pi pi-users text-xs"></i>
+                </span>
+                <p>
+                  B&eacute;n&eacute;ficiez d&apos;un suivi personnalis&eacute;
+                  et d&apos;une communaut&eacute; engag&eacute;e autour de vos
+                  objectifs.
+                </p>
+              </div>
+              <div class="flex items-start gap-3">
+                <span
+                  class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/30"
+                >
+                  <i class="pi pi-shield text-xs"></i>
+                </span>
+                <p>
+                  Vos donn&eacute;es personnelles sont prot&eacute;g&eacute;es
+                  avec nos standards de s&eacute;curit&eacute;.
+                </p>
+              </div>
+            </div>
           </div>
-        </div>
+        </aside>
 
-        @if (
-          (form.controls.firstName.touched &&
-            form.controls.firstName.invalid) ||
-          (form.controls.lastName.touched && form.controls.lastName.invalid)
-        ) {
-          <p class="text-sm leading-6 text-rose-700">
-            Renseignez votre prenom et votre nom.
+        <div class="px-5 py-8 sm:px-8 sm:py-10 lg:px-12 lg:py-12">
+          <p
+            class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase lg:hidden"
+          >
+            Espace participant
           </p>
-        }
+          <h1 class="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+            Cr&eacute;er un compte
+          </h1>
+          <p class="mt-3 max-w-lg text-sm leading-6 text-slate-600">
+            Ouvrez votre espace KRAAK pour suivre vos programmes et vos
+            prochaines sessions.
+          </p>
 
-        <div class="flex flex-col gap-2">
-          <label
-            for="web-sign-up-email"
-            class="text-sm font-semibold text-slate-900"
+          <form
+            [formGroup]="form"
+            (ngSubmit)="submit()"
+            class="mt-8 flex flex-col gap-5"
+            novalidate
           >
-            Adresse email
-          </label>
-          <input
-            id="web-sign-up-email"
-            type="email"
-            formControlName="email"
-            autocomplete="email"
-            placeholder="vous@kraak.org"
-            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
-          />
-          @if (form.controls.email.touched && form.controls.email.invalid) {
-            <p class="text-sm leading-6 text-rose-700">
-              Saisissez une adresse email valide.
-            </p>
-          }
-        </div>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="flex flex-col gap-2">
+                <label
+                  for="web-sign-up-first-name"
+                  class="text-sm font-semibold text-slate-900"
+                >
+                  Pr&eacute;nom
+                </label>
+                <input
+                  id="web-sign-up-first-name"
+                  type="text"
+                  formControlName="firstName"
+                  autocomplete="given-name"
+                  class="focus:border-brand-blue focus:ring-brand-blue/20 min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 transition-shadow outline-none focus:ring-4"
+                />
+              </div>
 
-        <div class="flex flex-col gap-2">
-          <label
-            for="web-sign-up-password"
-            class="text-sm font-semibold text-slate-900"
+              <div class="flex flex-col gap-2">
+                <label
+                  for="web-sign-up-last-name"
+                  class="text-sm font-semibold text-slate-900"
+                >
+                  Nom
+                </label>
+                <input
+                  id="web-sign-up-last-name"
+                  type="text"
+                  formControlName="lastName"
+                  autocomplete="family-name"
+                  class="focus:border-brand-blue focus:ring-brand-blue/20 min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 transition-shadow outline-none focus:ring-4"
+                />
+              </div>
+            </div>
+
+            @if (
+              (form.controls.firstName.touched &&
+                form.controls.firstName.invalid) ||
+              (form.controls.lastName.touched && form.controls.lastName.invalid)
+            ) {
+              <p class="text-sm leading-6 text-rose-700">
+                Renseignez votre pr&eacute;nom et votre nom.
+              </p>
+            }
+
+            <div class="flex flex-col gap-2">
+              <label
+                for="web-sign-up-email"
+                class="text-sm font-semibold text-slate-900"
+              >
+                Adresse email
+              </label>
+              <input
+                id="web-sign-up-email"
+                type="email"
+                formControlName="email"
+                autocomplete="email"
+                placeholder="vous@kraak.org"
+                class="focus:border-brand-blue focus:ring-brand-blue/20 min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 transition-shadow outline-none focus:ring-4"
+              />
+              @if (form.controls.email.touched && form.controls.email.invalid) {
+                <p class="text-sm leading-6 text-rose-700">
+                  Saisissez une adresse email valide.
+                </p>
+              }
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <label
+                for="web-sign-up-password"
+                class="text-sm font-semibold text-slate-900"
+              >
+                Mot de passe
+              </label>
+              <input
+                id="web-sign-up-password"
+                type="password"
+                formControlName="password"
+                autocomplete="new-password"
+                placeholder="Minimum 8 caract&egrave;res"
+                class="focus:border-brand-blue focus:ring-brand-blue/20 min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 transition-shadow outline-none focus:ring-4"
+              />
+              @if (
+                form.controls.password.touched && form.controls.password.invalid
+              ) {
+                <p class="text-sm leading-6 text-rose-700">
+                  Le mot de passe doit contenir au moins 8 caract&egrave;res.
+                </p>
+              }
+            </div>
+
+            @if (errorMessage()) {
+              <p-message
+                severity="error"
+                [text]="errorMessage()!"
+                [closable]="false"
+                styleClass="w-full"
+              />
+            }
+
+            <button
+              type="submit"
+              class="btn btn-primary mt-1"
+              [disabled]="submitting()"
+            >
+              {{
+                submitting()
+                  ? 'Cr&eacute;ation en cours...'
+                  : 'Cr&eacute;er mon compte'
+              }}
+            </button>
+          </form>
+
+          <div
+            class="mt-7 flex flex-col gap-2 border-t border-slate-200 pt-5 text-sm font-semibold"
           >
-            Mot de passe
-          </label>
-          <input
-            id="web-sign-up-password"
-            type="password"
-            formControlName="password"
-            autocomplete="new-password"
-            placeholder="Minimum 8 caracteres"
-            class="focus:border-brand-blue min-h-12 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none"
-          />
-          @if (
-            form.controls.password.touched && form.controls.password.invalid
-          ) {
-            <p class="text-sm leading-6 text-rose-700">
-              Le mot de passe doit contenir au moins 8 caracteres.
-            </p>
-          }
+            <a routerLink="/connexion" class="text-brand-blue hover:underline">
+              D&eacute;j&agrave; un compte&nbsp;? Se connecter
+            </a>
+          </div>
         </div>
-
-        @if (errorMessage()) {
-          <p-message
-            severity="error"
-            [text]="errorMessage()!"
-            [closable]="false"
-            styleClass="w-full"
-          />
-        }
-
-        <button type="submit" class="btn btn-primary" [disabled]="submitting()">
-          {{ submitting() ? 'Creation en cours...' : 'Creer mon compte' }}
-        </button>
-      </form>
-
-      <div class="mt-5 border-t border-slate-200 pt-4 text-sm font-semibold">
-        <a routerLink="/connexion" class="text-brand-blue hover:underline">
-          Deja un compte ? Se connecter
-        </a>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Résumé

Aligne la page d'inscription (/inscription) sur le style de la page de connexion (/connexion).

## Changements

- Fond avec dégradé radial identique à la page de connexion
- Carte deux colonnes avec panneau décoratif sombre sur desktop (lg:grid-cols-2)
- Aside avec overlay teal-to-navy, cercles d'ambiance flous et 3 bullets bénéfices
- Formulaire avec les mêmes styles d'inputs (focus:ring-brand-blue/20, transition-shadow)
- Bouton soumettre avec btn btn-primary mt-1
- Lien de retour connexion avec séparateur identique

## Validation

- Rendu visuel aligné sur sign-in.page.html
- Aucune logique métier modifiée