### PR TITLE
feat(web): align sign-up actions with primary CTA style

### DIFF
--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.html
@@ -211,7 +211,9 @@
               "
               [loading]="submitting()"
               [disabled]="submitting()"
-              aria-label="Créer mon compte"
+              [attr.aria-label]="
+                submitting() ? 'Création en cours...' : 'Créer mon compte'
+              "
               class="kr-button-primary mt-1 w-full"
             ></button>
           </form>

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.html
@@ -203,20 +203,31 @@
             }
 
             <button
+              pButton
               type="submit"
-              class="btn btn-primary mt-1"
+              size="large"
+              [label]="
+                submitting() ? 'Création en cours...' : 'Créer mon compte'
+              "
+              [loading]="submitting()"
               [disabled]="submitting()"
-            >
-              {{ submitting() ? 'Création en cours...' : 'Créer mon compte' }}
-            </button>
+              aria-label="Créer mon compte"
+              class="kr-button-primary mt-1 w-full"
+            ></button>
           </form>
 
-          <div
-            class="mt-7 flex flex-col gap-2 border-t border-slate-200 pt-5 text-sm font-semibold"
-          >
-            <a routerLink="/connexion" class="text-brand-blue hover:underline">
-              D&eacute;j&agrave; un compte&nbsp;? Se connecter
-            </a>
+          <div class="mt-7 flex flex-col gap-2 border-t border-slate-200 pt-5">
+            <p class="text-sm font-semibold text-slate-600">
+              D&eacute;j&agrave; un compte&nbsp;?
+            </p>
+            <a
+              pButton
+              routerLink="/connexion"
+              size="large"
+              label="Se connecter"
+              aria-label="Se connecter"
+              class="kr-button-primary w-full"
+            ></a>
           </div>
         </div>
       </div>

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { MessageService } from 'primeng/api';
+import { ButtonDirective } from 'primeng/button';
 import { Message } from 'primeng/message';
 import {
   WebAuthService,
@@ -23,7 +24,7 @@ interface SignUpFormModel {
 @Component({
   selector: 'kraak-web-sign-up-page',
   standalone: true,
-  imports: [ReactiveFormsModule, RouterLink, Message],
+  imports: [ReactiveFormsModule, RouterLink, ButtonDirective, Message],
   templateUrl: './sign-up.page.html',
 })
 export default class SignUpPage {


### PR DESCRIPTION
## Résumé\n- aligne le bouton "Créer mon compte" sur le style primaire partagé\n- applique le même style primaire à l’action "Se connecter"\n- conserve la navigation vers /connexion\n\n## Validation\n- hooks pre-commit/pre-push exécutés avec succès (lint, tests unitaires, e2e)