### PR TITLE
Fix Vercel web output directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:api:staging": "pnpm --filter @kraak/api run start:staging",
     "build:api": "pnpm --filter @kraak/api build",
     "check:observability": "node ./scripts/check-observability.mjs",
-    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs",
+    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs",
     "test:api": "pnpm --filter @kraak/api test",
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
     "test:coverage": "pnpm --filter @kraak/api test:cov && pnpm --filter @kraak/client test:coverage && pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test:coverage",

--- a/scripts/vercel-config.test.mjs
+++ b/scripts/vercel-config.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const vercelConfig = JSON.parse(
+  readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'),
+);
+
+const expectedStaticOutputDirectory = 'apps/client/dist/web/browser';
+
+test('Given le build web prerender, When Vercel publie le site, Then le dossier browser est servi', () => {
+  assert.equal(vercelConfig.outputDirectory, expectedStaticOutputDirectory);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "pnpm -r --filter \"./packages/**\" build && pnpm --filter @kraak/client run build",
-  "outputDirectory": "apps/client/dist/web",
+  "outputDirectory": "apps/client/dist/web/browser",
   "framework": null
 }


### PR DESCRIPTION
Corrige le dossier publie par Vercel pour aligner le deploiement statique sur la sortie Angular prerender.

Fixes #281

## Changements

- Pointe `vercel.json` vers `apps/client/dist/web/browser`.
- Ajoute une garde `scripts/vercel-config.test.mjs` pour detecter toute regression du dossier de sortie.
- Integre cette garde a `pnpm test:workspace`.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm test:workspace`
- `pnpm -r --filter "./packages/**" build && pnpm --filter @kraak/client run build`
- Push hook local: typecheck web/mobile/api, format, lint, tests unitaires, 22 E2E Playwright

## Notes

Le changement HTML local existant sur la page connexion etait uniquement du formatage non conforme; Prettier l'a normalise pour lever le bloqueur CI, donc il ne reste pas dans le diff final.
