### PR TITLE
fix(web): update footer Facebook link

### DIFF
--- a/apps/client/projects/web/src/app/layouts/footer/footer.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.spec.ts
@@ -41,6 +41,6 @@ describe('Footer', () => {
     );
     expect(footerLinks.length).toBeGreaterThan(0);
     expect(socialButtons.every(Boolean)).toBe(true);
-    expect(facebookLink?.href).toBe(expectedFacebookUrl);
+    expect(facebookLink?.getAttribute('href')).toBe(expectedFacebookUrl);
   });
 });

--- a/apps/client/projects/web/src/app/layouts/footer/footer.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.spec.ts
@@ -3,6 +3,8 @@ import { provideRouter } from '@angular/router';
 
 import { Footer } from './footer';
 
+const expectedFacebookUrl = 'https://www.facebook.com/kraakconsulting/';
+
 describe('Footer', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -30,11 +32,15 @@ describe('Footer', () => {
     const socialButtons = ['Facebook', 'Instagram', 'WhatsApp', 'TikTok'].map(
       (name) => element.querySelector(`a[aria-label="${name}"]`),
     );
+    const facebookLink = element.querySelector(
+      'a[aria-label="Facebook"]',
+    ) as HTMLAnchorElement | null;
 
     expect(brandImage?.getAttribute('src')).toContain(
       'kraak_consulting_symbol_96w.png',
     );
     expect(footerLinks.length).toBeGreaterThan(0);
-    expect(socialButtons.every((button) => button)).toBe(true);
+    expect(socialButtons.every(Boolean)).toBe(true);
+    expect(facebookLink?.href).toBe(expectedFacebookUrl);
   });
 });

--- a/apps/client/projects/web/src/app/layouts/footer/footer.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.ts
@@ -32,7 +32,7 @@ export class Footer {
   protected readonly socialLinks: FooterSocialLink[] = [
     {
       label: 'Facebook',
-      href: 'https://www.facebook.com/profile.php?id=61588664064530',
+      href: 'https://www.facebook.com/kraakconsulting/',
       icon: 'pi-facebook',
     },
     {


### PR DESCRIPTION
Closes #285

## Summary
- Updates the footer Facebook social link to the canonical KRAAK Consulting page.
- Adds a footer component assertion for the expected Facebook href.

## Validation
- pnpm --filter @kraak/client exec ng test web --watch=false --include projects/web/src/app/layouts/footer/footer.spec.ts
- pnpm --filter @kraak/client lint
- pre-push pnpm test, including Playwright E2E