### PR TITLE
feat(infra): adopt tag-based prod release strategy (ARC-07)

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,0 +1,240 @@
+# Workflow de release production — kraak-group monorepo
+# Déclenché uniquement sur la création d'un tag SemVer (v*.*.*).
+# Voir docs/decisions/ARC-07-prod-release-tag-based.md
+# Voir docs/runbooks/RELEASE_PROD.md
+
+name: Release Prod
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag SemVer à (re)déployer en prod (ex. v1.2.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Vérification : doit être un tag v*
+  # ──────────────────────────────────────────────
+  validate-tag:
+    name: Valider la référence
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - name: Résoudre la référence cible
+        id: resolve
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag '$tag' n'est pas un tag SemVer valide (format v*.*.*)."
+            exit 1
+          fi
+          echo "ref=$tag" >> "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────
+  # Build + tests rejoués sur le commit du tag
+  # ──────────────────────────────────────────────
+  build-and-test:
+    name: Build & tests sur tag
+    runs-on: ubuntu-latest
+    needs: validate-tag
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-tag.outputs.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build packages workspace
+        run: pnpm -r --filter "./packages/**" build
+
+      - name: Tests unitaires
+        run: pnpm test:unit
+
+      - name: Build web (production)
+        run: pnpm build:web
+
+      - name: Build mobile (production)
+        run: pnpm build:mobile
+
+  # ──────────────────────────────────────────────
+  # Migrations Supabase prod (si présentes)
+  # ──────────────────────────────────────────────
+  supabase-migrate:
+    name: Migrations Supabase prod
+    runs-on: ubuntu-latest
+    needs: [validate-tag, build-and-test]
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-tag.outputs.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lien projet Supabase prod
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
+        run: |
+          pnpm dlx supabase@latest link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Appliquer les migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DB_PASSWORD }}
+        run: |
+          pnpm dlx supabase@latest db push
+
+  # ──────────────────────────────────────────────
+  # Déploiement Render (API prod)
+  # ──────────────────────────────────────────────
+  deploy-render:
+    name: Déployer API (Render prod)
+    runs-on: ubuntu-latest
+    needs: [validate-tag, supabase-migrate]
+    environment: production
+    steps:
+      - name: Déclencher le déploiement Render
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_PROD_SERVICE_ID }}
+          TAG: ${{ needs.validate-tag.outputs.ref }}
+        run: |
+          curl -fSs -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"clearCache\":\"do_not_clear\"}" \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys"
+
+      - name: Smoke test /health (API prod)
+        env:
+          PROD_API_HEALTH_URL: ${{ secrets.PROD_API_HEALTH_URL }}
+        run: |
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fSs "$PROD_API_HEALTH_URL" | grep -q '"status"'; then
+              echo "API prod OK"
+              exit 0
+            fi
+            echo "Tentative $i échouée, nouvelle tentative dans 15s…"
+            sleep 15
+          done
+          echo "::error::Smoke test API prod en échec"
+          exit 1
+
+  # ──────────────────────────────────────────────
+  # Déploiement Vercel (web prod)
+  # ──────────────────────────────────────────────
+  deploy-vercel:
+    name: Déployer web (Vercel prod)
+    runs-on: ubuntu-latest
+    needs: [validate-tag, deploy-render]
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-tag.outputs.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Pull configuration Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROD_PROJECT_ID }}
+        run: |
+          pnpm dlx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build artefact Vercel prod
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          pnpm dlx vercel@latest build --prod --token="$VERCEL_TOKEN"
+
+      - name: Déployer sur Vercel prod
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          pnpm dlx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+
+      - name: Smoke test web prod
+        env:
+          PROD_WEB_URL: ${{ secrets.PROD_WEB_URL }}
+        run: |
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fSs -o /dev/null -w "%{http_code}" "$PROD_WEB_URL" | grep -qE '^(200|301|302)$'; then
+              echo "Web prod OK"
+              exit 0
+            fi
+            echo "Tentative $i échouée, nouvelle tentative dans 15s…"
+            sleep 15
+          done
+          echo "::error::Smoke test web prod en échec"
+          exit 1
+
+  # ──────────────────────────────────────────────
+  # GitHub Release notes (auto)
+  # ──────────────────────────────────────────────
+  release-notes:
+    name: Publier la GitHub Release
+    runs-on: ubuntu-latest
+    needs: [validate-tag, deploy-vercel]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-tag.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Créer ou mettre à jour la release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.validate-tag.outputs.ref }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG déjà existante, rien à faire"
+          else
+            gh release create "$TAG" --generate-notes --title "$TAG"
+          fi

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -23,20 +23,32 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Versions CLI épinglées : reproductibilité de la release et des rollbacks.
+  # Toute mise à jour doit faire l'objet d'une PR dédiée.
+  SUPABASE_CLI_VERSION: '1.200.3'
+  VERCEL_CLI_VERSION: '37.14.0'
+
 jobs:
   # ──────────────────────────────────────────────
-  # Vérification : doit être un tag v*
+  # Validation : tag SemVer + commit accessible depuis main
   # ──────────────────────────────────────────────
   validate-tag:
     name: Valider la référence
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
-      - name: Résoudre la référence cible
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Résoudre la référence cible et vérifier l'accessibilité depuis main
         id: resolve
         shell: bash
         run: |
+          set -euo pipefail
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tag="${{ inputs.tag }}"
           else
@@ -46,7 +58,23 @@ jobs:
             echo "::error::Tag '$tag' n'est pas un tag SemVer valide (format v*.*.*)."
             exit 1
           fi
+
+          # Le tag doit exister localement
+          if ! git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/$tag:refs/tags/$tag"
+          fi
+          sha="$(git rev-list -n 1 "refs/tags/$tag")"
+
+          # Le commit du tag doit être accessible depuis origin/main
+          # (empêche un tag sur une branche non revue de promouvoir en prod).
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$sha" origin/main; then
+            echo "::error::Le commit $sha (tag $tag) n'est pas accessible depuis origin/main. Toute release prod doit pointer un commit déjà mergé sur main."
+            exit 1
+          fi
+
           echo "ref=$tag" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────
   # Build + tests rejoués sur le commit du tag
@@ -58,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-tag.outputs.ref }}
+          ref: ${{ needs.validate-tag.outputs.sha }}
 
       - uses: pnpm/action-setup@v4
 
@@ -84,8 +112,12 @@ jobs:
       - name: Build mobile (production)
         run: pnpm build:mobile
 
+      - name: Build Docker image API (sanity)
+        run: docker build -f apps/api/Dockerfile -t kraak-api:${{ needs.validate-tag.outputs.ref }} .
+
   # ──────────────────────────────────────────────
   # Migrations Supabase prod (si présentes)
+  # Bloquée par build-and-test : pas de migration sur tag avec build cassé.
   # ──────────────────────────────────────────────
   supabase-migrate:
     name: Migrations Supabase prod
@@ -95,7 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-tag.outputs.ref }}
+          ref: ${{ needs.validate-tag.outputs.sha }}
 
       - uses: pnpm/action-setup@v4
 
@@ -111,14 +143,14 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
         run: |
-          pnpm dlx supabase@latest link --project-ref "$SUPABASE_PROJECT_REF"
+          pnpm dlx "supabase@${SUPABASE_CLI_VERSION}" link --project-ref "$SUPABASE_PROJECT_REF"
 
       - name: Appliquer les migrations
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DB_PASSWORD }}
         run: |
-          pnpm dlx supabase@latest db push
+          pnpm dlx "supabase@${SUPABASE_CLI_VERSION}" db push
 
   # ──────────────────────────────────────────────
   # Déploiement Render (API prod)
@@ -129,31 +161,91 @@ jobs:
     needs: [validate-tag, supabase-migrate]
     environment: production
     steps:
-      - name: Déclencher le déploiement Render
+      - name: Mettre à jour APP_VERSION sur le service prod
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_PROD_SERVICE_ID }}
           TAG: ${{ needs.validate-tag.outputs.ref }}
         run: |
-          curl -fSs -X POST \
+          set -euo pipefail
+          curl -fSs -X PUT \
             -H "Authorization: Bearer $RENDER_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"clearCache\":\"do_not_clear\"}" \
-            "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys"
+            -d "[{\"key\":\"APP_VERSION\",\"value\":\"$TAG\"}]" \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID/env-vars" \
+            > /dev/null
+          echo "APP_VERSION mis à jour sur le service Render prod."
 
-      - name: Smoke test /health (API prod)
+      - name: Déclencher le déploiement Render (commit épinglé)
+        id: render-deploy
         env:
-          PROD_API_HEALTH_URL: ${{ secrets.PROD_API_HEALTH_URL }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_PROD_SERVICE_ID }}
+          SHA: ${{ needs.validate-tag.outputs.sha }}
         run: |
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if curl -fSs "$PROD_API_HEALTH_URL" | grep -q '"status"'; then
-              echo "API prod OK"
-              exit 0
-            fi
-            echo "Tentative $i échouée, nouvelle tentative dans 15s…"
+          set -euo pipefail
+          response="$(curl -fSs -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"clearCache\":\"do_not_clear\",\"commitId\":\"$SHA\"}" \
+            "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys")"
+          deploy_id="$(echo "$response" | jq -r '.id')"
+          if [[ -z "$deploy_id" || "$deploy_id" == "null" ]]; then
+            echo "::error::Render n'a pas retourné d'ID de déploiement"
+            echo "$response"
+            exit 1
+          fi
+          echo "deploy_id=$deploy_id" >> "$GITHUB_OUTPUT"
+          echo "Déploiement Render créé : $deploy_id"
+
+      - name: Attendre que le déploiement Render soit live
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_PROD_SERVICE_ID }}
+          DEPLOY_ID: ${{ steps.render-deploy.outputs.deploy_id }}
+        run: |
+          set -euo pipefail
+          # Polling jusqu'à 20 min ; statuts terminaux Render :
+          # live, deactivated, build_failed, update_failed, canceled, pre_deploy_failed
+          for i in $(seq 1 80); do
+            status="$(curl -fSs \
+              -H "Authorization: Bearer $RENDER_API_KEY" \
+              "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys/$DEPLOY_ID" \
+              | jq -r '.status')"
+            echo "[$i] status=$status"
+            case "$status" in
+              live)
+                echo "Déploiement Render terminé avec succès."
+                exit 0
+                ;;
+              build_failed|update_failed|canceled|pre_deploy_failed|deactivated)
+                echo "::error::Déploiement Render en échec : $status"
+                exit 1
+                ;;
+            esac
             sleep 15
           done
-          echo "::error::Smoke test API prod en échec"
+          echo "::error::Timeout en attendant le déploiement Render"
+          exit 1
+
+      - name: Smoke test /health (API prod) avec vérification de version
+        env:
+          PROD_API_HEALTH_URL: ${{ secrets.PROD_API_HEALTH_URL }}
+          EXPECTED_VERSION: ${{ needs.validate-tag.outputs.ref }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 20); do
+            body="$(curl -fSs "$PROD_API_HEALTH_URL" || true)"
+            status="$(echo "$body" | jq -r '.status // empty')"
+            version="$(echo "$body" | jq -r '.version // empty')"
+            echo "[$i] status=$status version=$version (attendu=$EXPECTED_VERSION)"
+            if [[ "$status" == "ok" && "$version" == "$EXPECTED_VERSION" ]]; then
+              echo "API prod OK et version correcte"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Smoke test API prod en échec (status ou version incorrects)"
           exit 1
 
   # ──────────────────────────────────────────────
@@ -167,7 +259,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-tag.outputs.ref }}
+          ref: ${{ needs.validate-tag.outputs.sha }}
 
       - uses: pnpm/action-setup@v4
 
@@ -184,30 +276,32 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROD_PROJECT_ID }}
         run: |
-          pnpm dlx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+          pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build artefact Vercel prod
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          pnpm dlx vercel@latest build --prod --token="$VERCEL_TOKEN"
+          pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod --token="$VERCEL_TOKEN"
 
       - name: Déployer sur Vercel prod
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          pnpm dlx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+          pnpm dlx "vercel@${VERCEL_CLI_VERSION}" deploy --prebuilt --prod --token="$VERCEL_TOKEN"
 
       - name: Smoke test web prod
         env:
           PROD_WEB_URL: ${{ secrets.PROD_WEB_URL }}
         run: |
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if curl -fSs -o /dev/null -w "%{http_code}" "$PROD_WEB_URL" | grep -qE '^(200|301|302)$'; then
+          set -euo pipefail
+          for i in $(seq 1 20); do
+            code="$(curl -fSs -o /dev/null -w "%{http_code}" "$PROD_WEB_URL" || true)"
+            echo "[$i] http=$code"
+            if [[ "$code" =~ ^(200|301|302)$ ]]; then
               echo "Web prod OK"
               exit 0
             fi
-            echo "Tentative $i échouée, nouvelle tentative dans 15s…"
             sleep 15
           done
           echo "::error::Smoke test web prod en échec"
@@ -225,7 +319,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-tag.outputs.ref }}
+          ref: ${{ needs.validate-tag.outputs.sha }}
           fetch-depth: 0
 
       - name: Créer ou mettre à jour la release

--- a/docs/decisions/ARC-07-prod-release-tag-based.md
+++ b/docs/decisions/ARC-07-prod-release-tag-based.md
@@ -1,0 +1,109 @@
+# ARC-07 — Stratégie de release production basée sur les tags
+
+- Statut : Acceptée
+- Date : 2026-05-02
+- Portée : `.github/workflows/`, `render.yaml`, configuration Vercel,
+  configuration Supabase, runbooks de release et d'environnement
+
+## Contexte
+
+Le MVP KRAAK approche d'un déploiement pilote en production. Jusqu'ici, seul un
+environnement **staging** a été câblé (`apps/api/.env.staging`,
+`supabase/.env.staging`, projet Render `kraak-api-staging`, projet Vercel en
+preview). Aucune cible production n'existe et aucun garde-fou ne distingue
+clairement « modifier le code » de « livrer en prod ».
+
+Sans cadre, deux risques concrets émergent :
+
+- une PR mergée sur `main` pourrait déclencher silencieusement un déploiement
+  prod si l'on cible cet environnement avec un `autoDeploy` par défaut ;
+- les secrets prod (Supabase prod, clés Resend prod) cohabiteraient avec ceux
+  de staging, multipliant le risque de fuite ou de mauvais routage.
+
+L'enjeu : poser des fondations simples mais strictes pour la prod **avant** de
+provisionner le moindre service prod.
+
+## Décision
+
+KRAAK adopte une stratégie de release **prod uniquement sur tag SemVer**, avec
+isolation totale des secrets et des projets de plateforme.
+
+### Principes directeurs
+
+1. **Push sur `main` ⇒ staging uniquement.** Aucun service prod ne suit `main`.
+2. **Tag `v*.*.*` ⇒ prod.** Le seul déclencheur de prod est la création d'un
+   tag SemVer (`v1.0.0`, `v1.1.0-rc.1`, etc.).
+3. **Approbation humaine obligatoire.** Le déploiement prod passe par un
+   GitHub Environment `production` avec required reviewers.
+4. **Aucun secret prod en local ni dans le repo.** Les variables prod vivent
+   uniquement dans GitHub Secrets, Render Env, Vercel Env.
+5. **Rollback par re-deploy d'un tag antérieur.** Pas de `git push --force`,
+   pas de `git tag -f`. Forward-fix (`v1.0.1`) ou rollback (`v0.9.x`).
+
+### Périmètre couvert par cette décision
+
+| Bloc               | Décision                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| GitHub Workflow    | Nouveau fichier `.github/workflows/release-prod.yml` sur `tags: ['v*']`              |
+| GitHub Environment | `production` avec required reviewers + restriction « tags only »                     |
+| Render (API)       | Service prod `kraak-api-prod` avec `autoDeploy: false` ; staging garde l'auto-deploy |
+| Vercel (web)       | Production branch désactivée ; déploiement prod uniquement via API/CLI sur tag       |
+| Supabase           | Projet **séparé** pour la prod (`kraak-prod`), distinct de `kraak-staging`           |
+| Variables d'env    | `apps/api/.env.prod` reste **gitignoré** ; injection via Render/Vercel/GH Secrets    |
+| Branch protection  | `main` protégée (review + status checks) ; tags `v*` créés depuis `main` uniquement  |
+| Runbook            | `docs/runbooks/RELEASE_PROD.md` documente la procédure tag → review → deploy → smoke |
+
+### Séparation des projets Supabase
+
+Le projet Supabase actuel est rattaché à l'environnement **staging**. La prod
+exige un projet **distinct** :
+
+- isolation physique des données (RGPD, sauvegardes, audit) ;
+- impossibilité d'écrire en prod par erreur depuis un script staging ;
+- migrations validées d'abord en staging puis appliquées en prod via la même
+  CLI mais avec un autre `SUPABASE_PROJECT_REF`.
+
+La création du projet `kraak-prod` est une tâche distincte (non incluse dans
+cette ADR), mais l'architecture cible est figée ici : **un projet Supabase par
+environnement**, jamais de schéma partagé.
+
+## Conséquences
+
+Positives :
+
+- Impossible de pousser en prod « par accident » via un merge sur `main`.
+- Traçabilité complète : chaque déploiement prod = un tag SemVer + une
+  approbation GitHub Environment + une exécution de workflow nommée.
+- Rollback déterministe : re-déployer le tag précédent revient à un seul
+  workflow run.
+- Cloisonnement clair des secrets et des bases de données entre staging et
+  prod.
+
+Négatives / à surveiller :
+
+- Le déploiement prod n'est plus instantané : il faut tagger, attendre la
+  review GitHub Environment, attendre le workflow.
+- Les hotfixes urgents passent par la même procédure (forward-fix avec un
+  patch SemVer), ce qui demande de la discipline sur la qualité de `main`.
+- Le projet Supabase prod a un coût additionnel (plan payant si dépassement du
+  free tier).
+
+## Conditions de levée / révision
+
+Cette décision est révisable si :
+
+1. Le volume de releases dépasse plusieurs déploiements prod par jour
+   (introduction possible d'une branche `release/*` ou d'un canal canary).
+2. KRAAK adopte un déploiement multi-région nécessitant plusieurs cibles prod
+   coordonnées.
+3. Une plateforme tierce remplace Render ou Vercel et impose un autre modèle
+   de promotion.
+
+## Liens
+
+- Runbook : `docs/runbooks/RELEASE_PROD.md`
+- Workflow : `.github/workflows/release-prod.yml`
+- Configuration hébergeurs : `render.yaml`, configuration Vercel (UI)
+- Variables d'environnement : `docs/runbooks/ENVIRONMENT_VARIABLES.md`
+- Procédure d'urgence : `docs/runbooks/DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST_2026-04-30.md`
+- Gate go/no-go : `docs/runbooks/DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md`

--- a/docs/runbooks/ENVIRONMENT_VARIABLES.md
+++ b/docs/runbooks/ENVIRONMENT_VARIABLES.md
@@ -128,6 +128,14 @@ Le fichier `supabase/.env.staging` sert de référence claire pour l'environneme
 staging manipulé dans le dépôt. En local, les variables Supabase nécessaires
 sont déclarées directement dans `apps/api/.env` et `apps/client/.env`.
 
+> **Production** : la prod utilise un projet Supabase **distinct** de staging
+> (cf. `docs/decisions/ARC-07-prod-release-tag-based.md`). Le `SUPABASE_PROJECT_REF`
+> prod n'est jamais commité ; il vit uniquement dans le GitHub Environment
+> `production` (`SUPABASE_PROD_PROJECT_REF`, `SUPABASE_ACCESS_TOKEN`,
+> `SUPABASE_PROD_DB_PASSWORD`) et est consommé par le workflow
+> `.github/workflows/release-prod.yml` lors des migrations prod. Voir
+> `docs/runbooks/RELEASE_PROD.md`.
+
 La configuration Auth email/password versionnée du MVP ne vit pas dans ces
 fichiers `.env` mais dans `supabase/config.toml`, avec ses templates email
 locaux dans `supabase/templates/auth/`. Voir aussi

--- a/docs/runbooks/RELEASE_PROD.md
+++ b/docs/runbooks/RELEASE_PROD.md
@@ -30,15 +30,28 @@ Dans `Settings → Environments → New environment` :
 - Secrets de l'environnement (jamais ailleurs) :
   - `RENDER_API_KEY`
   - `RENDER_PROD_SERVICE_ID`
+  - `PROD_API_HEALTH_URL` (URL absolue vers `/health` du service prod)
   - `VERCEL_TOKEN`
   - `VERCEL_PROD_PROJECT_ID`
   - `VERCEL_ORG_ID`
-  - `SUPABASE_PROD_PROJECT_REF` (utilisé pour les migrations prod)
+  - `PROD_WEB_URL` (URL absolue de la home web prod)
+  - `SUPABASE_ACCESS_TOKEN` (token CLI Supabase pour `link` + `db push`)
+  - `SUPABASE_PROD_PROJECT_REF` (ref du projet Supabase prod, distinct de staging)
+  - `SUPABASE_PROD_DB_PASSWORD` (mot de passe Postgres pour `db push`)
+
+L'absence d'un seul de ces secrets fera échouer le workflow `release-prod` lors
+des étapes migration ou smoke test.
 
 ### 2. Branch protection sur `main`
 
 - Required pull request reviews avant merge (≥ 1)
-- Required status checks : `lint`, `unit`, `build`, `e2e-web`
+- Required status checks (noms exacts tels que définis dans
+  `.github/workflows/ci.yml`) :
+  - `Format & Lint`
+  - `Build`
+  - `Tests unitaires`
+  - `Tests E2E`
+  - `Workspace Checks`
 - Linear history (rebase only — déjà aligné avec le workflow Git du repo)
 - Restrict who can push : mainteneurs uniquement
 

--- a/docs/runbooks/RELEASE_PROD.md
+++ b/docs/runbooks/RELEASE_PROD.md
@@ -1,0 +1,168 @@
+# RELEASE_PROD — Procédure de release production
+
+> Document de référence pour livrer une version en production. Toute release
+> prod **doit** suivre cette procédure, sans exception.
+
+Voir aussi : [`ARC-07-prod-release-tag-based`](../decisions/ARC-07-prod-release-tag-based.md),
+[`DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30`](DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md),
+[`DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST_2026-04-30`](DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST_2026-04-30.md).
+
+## Principes
+
+- **Tag SemVer = seul déclencheur prod.** Un push sur `main` ne déploie que
+  staging.
+- **Approbation humaine obligatoire** via le GitHub Environment `production`.
+- **Aucun secret prod** dans le repo, ni en local. Tout passe par GitHub
+  Secrets, Render Env, Vercel Env.
+- **Rollback = re-deploy d'un tag antérieur.** Jamais de `git push --force` ni
+  `git tag -f`.
+
+## Pré-requis (à provisionner une seule fois)
+
+### 1. GitHub Environment `production`
+
+Dans `Settings → Environments → New environment` :
+
+- Nom : `production`
+- Required reviewers : au moins 1 (idéalement 2 mainteneurs distincts)
+- Wait timer : 5 min (fenêtre d'annulation manuelle)
+- Deployment branches and tags : restreindre aux tags matchant `v*`
+- Secrets de l'environnement (jamais ailleurs) :
+  - `RENDER_API_KEY`
+  - `RENDER_PROD_SERVICE_ID`
+  - `VERCEL_TOKEN`
+  - `VERCEL_PROD_PROJECT_ID`
+  - `VERCEL_ORG_ID`
+  - `SUPABASE_PROD_PROJECT_REF` (utilisé pour les migrations prod)
+
+### 2. Branch protection sur `main`
+
+- Required pull request reviews avant merge (≥ 1)
+- Required status checks : `lint`, `unit`, `build`, `e2e-web`
+- Linear history (rebase only — déjà aligné avec le workflow Git du repo)
+- Restrict who can push : mainteneurs uniquement
+
+### 3. Render — service prod
+
+- Créer un service Render distinct `kraak-api-prod` (déclaré dans
+  `render.yaml`).
+- `autoDeploy: false` ⇒ Render ne déploie pas sur push `main`.
+- Variables d'environnement prod renseignées via l'UI Render
+  (jamais commitées).
+- Les déploiements prod sont déclenchés via API Render depuis le workflow
+  `release-prod.yml`.
+
+### 4. Vercel — projet web prod
+
+- Production Branch : `(none)` (ou tout autre paramètre désactivant les
+  déploiements automatiques sur `main`).
+- Les déploiements prod sont déclenchés via `vercel deploy --prod` depuis le
+  workflow.
+- Variables d'environnement prod renseignées via l'UI Vercel sur la cible
+  `Production`.
+
+### 5. Supabase — projet prod séparé
+
+- Créer un projet Supabase **distinct** `kraak-prod` (jamais partagé avec
+  staging).
+- Appliquer les migrations via :
+  ```bash
+  pnpm supabase link --project-ref "$SUPABASE_PROD_PROJECT_REF"
+  pnpm supabase db push
+  ```
+- Sauvegardes activées (point-in-time recovery selon plan).
+- RLS et politiques validées en staging avant tout `db push` prod.
+
+## Procédure de release (par version)
+
+### Étape 1 — Pré-vol staging
+
+- `main` est verte sur la CI.
+- Le commit que l'on s'apprête à tagger est déployé en staging et fonctionne.
+- La checklist [`DEP-07_GO_NO_GO_PILOT_RELEASE`](DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md)
+  est exécutée et signée.
+
+### Étape 2 — Tag SemVer
+
+Depuis `main` à jour :
+
+```bash
+git checkout main
+git pull --rebase
+git tag -a v1.2.0 -m "Release v1.2.0 — résumé bref des changements"
+git push origin v1.2.0
+```
+
+Règles SemVer dans ce repo :
+
+- `MAJOR` (`v2.0.0`) : breaking change visible utilisateur ou contrat API
+- `MINOR` (`v1.2.0`) : nouvelle fonctionnalité rétrocompatible
+- `PATCH` (`v1.0.1`) : correction de bug rétrocompatible
+- Pré-release autorisée : `v1.2.0-rc.1`, `v1.2.0-beta.1` (pas de promotion auto
+  vers prod sans approbation explicite)
+
+### Étape 3 — Workflow `release-prod`
+
+Le push du tag déclenche `.github/workflows/release-prod.yml` :
+
+1. Build et tests rejoués sur le commit taggé.
+2. Le job `deploy-prod` attend l'approbation du GitHub Environment
+   `production`.
+3. Migrations Supabase prod appliquées (si présentes).
+4. Déploiement Render prod via API.
+5. Déploiement Vercel prod via CLI.
+6. Smoke test prod (`/health`, page d'accueil web).
+
+### Étape 4 — Validation post-deploy
+
+- Vérifier `/health` de l'API prod (status `ok`, `version` correspondant au
+  tag).
+- Vérifier la home web prod (HTTP 200, marque KRAAK visible).
+- Vérifier les logs Render et Vercel pour absence d'erreurs au démarrage.
+- Marquer la GitHub Release associée au tag (`gh release create v1.2.0
+--generate-notes`).
+
+### Étape 5 — Clôture
+
+- Mettre à jour les items GitHub Project liés en `Done` si non déjà fait.
+- Annoncer la release dans le canal d'équipe (référence : tag + lien Release).
+- Conserver l'historique : ne jamais supprimer un tag prod, même cassé
+  (forward-fix uniquement).
+
+## Rollback
+
+Procédure d'urgence détaillée dans
+[`DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST`](DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST_2026-04-30.md).
+
+Synthèse :
+
+- **Forward-fix préféré** : créer un tag patch (`v1.2.1`) à partir d'un commit
+  correctif sur `main`.
+- **Rollback strict** : re-déclencher manuellement le workflow `release-prod`
+  sur un tag antérieur stable (`workflow_dispatch` avec `tag` en input — voir
+  workflow).
+- Les variables d'environnement prod ne sont **jamais** modifiées en
+  rollback ; seul le code change.
+
+## Politique de secrets
+
+- `apps/api/.env.prod` est gitignoré et ne doit exister qu'à titre de test
+  local ponctuel d'un ingénieur autorisé. Il **ne sert pas** à la prod réelle.
+- Tous les secrets prod vivent dans :
+  - GitHub Environment `production` (pour le workflow CI/CD)
+  - Render Env (pour le runtime API)
+  - Vercel Env (pour le runtime web)
+- Toute rotation de secret se fait dans **les trois endroits** simultanément.
+
+## Anti-patterns interdits
+
+- ❌ Déployer prod sans tag (`workflow_dispatch` direct sans tag input
+  vérifié).
+- ❌ Pousser un commit directement sur `main` sans PR pour préparer une
+  release.
+- ❌ Réutiliser le projet Supabase staging pour des données prod.
+- ❌ Copier `.env.prod` depuis le repo (il n'a pas vocation à contenir les
+  vraies valeurs).
+- ❌ `git tag -f` ou `git push --force` sur un tag prod.
+- ❌ Désactiver l'environnement GitHub `production` ou ses required reviewers
+  pour aller plus vite.

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,12 @@
 # Configuration Render — déploiement de l'API NestJS via Docker
 # Documentation : https://docs.render.com/blueprint-spec
+#
+# Deux services distincts :
+#   - kraak-api-staging : auto-deploy sur push main (preview-like)
+#   - kraak-api-prod    : autoDeploy: false ; déclenché uniquement par le
+#                         workflow .github/workflows/release-prod.yml sur tag
+#                         SemVer. Voir docs/decisions/ARC-07-prod-release-tag-based.md
+#                         et docs/runbooks/RELEASE_PROD.md.
 
 services:
   - type: web
@@ -9,6 +16,8 @@ services:
     dockerContext: .
     plan: free
     healthCheckPath: /health
+    autoDeploy: true
+    branch: main
     envVars:
       - key: NODE_ENV
         value: production
@@ -19,6 +28,39 @@ services:
       - key: SUPABASE_URL
         sync: false
       - key: SUPABASE_SECRET_KEY
+        sync: false
+      - key: RESEND_API_KEY
+        sync: false
+      - key: CONTACT_FROM_EMAIL
+        sync: false
+      - key: CONTACT_TO_EMAIL
+        sync: false
+      - key: CORS_ALLOWED_ORIGINS
+        sync: false
+
+  - type: web
+    name: kraak-api-prod
+    runtime: docker
+    dockerfilePath: apps/api/Dockerfile
+    dockerContext: .
+    plan: starter
+    healthCheckPath: /health
+    # Production : aucun déploiement automatique. Le workflow GitHub
+    # release-prod.yml déclenche manuellement les déploiements via l'API Render
+    # à chaque tag SemVer approuvé dans l'environnement GitHub `production`.
+    autoDeploy: false
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: '3000'
+      - key: APP_VERSION
+        sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SECRET_KEY
+        sync: false
+      - key: SUPABASE_PUBLISHABLE_KEY
         sync: false
       - key: RESEND_API_KEY
         sync: false


### PR DESCRIPTION
## Contexte

Pose les fondations pour livrer en production sans risquer un déploiement par accident. Voir ADR ARC-07.

## Changements

- **ADR** docs/decisions/ARC-07-prod-release-tag-based.md
- **Runbook** docs/runbooks/RELEASE_PROD.md (procédure tag → review → deploy → smoke → rollback)
- **Workflow** .github/workflows/release-prod.yml — déclenché sur tag `v*` + GitHub Environment `production` + smoke tests Render & Vercel + GitHub Release auto
- **render.yaml** : ajoute service `kraak-api-prod` avec `autoDeploy: false` ; staging conservé en auto-deploy
- **ENVIRONMENT_VARIABLES.md** : documente la séparation du projet Supabase prod (distinct de staging)

## Stratégie

- Push `main` ⇒ staging uniquement
- Tag SemVer `v*.*.*` ⇒ prod (avec approbation humaine GitHub Environment)
- Aucun secret prod en repo ni en local
- Rollback = re-deploy d'un tag antérieur (jamais `git tag -f`)
- Projet Supabase **distinct** pour la prod

## Pré-requis manuels post-merge (UI)

1. Créer GitHub Environment `production` (required reviewers + tags `v*` only + secrets prod)
2. Créer projet Supabase `kraak-prod` séparé
3. Configurer Vercel : Production Branch = (none)
4. Provisionner service Render `kraak-api-prod` via Blueprint
5. Activer branch protection sur `main`

Détails complets dans le runbook RELEASE_PROD.md.

## Validation

- `pnpm format:check` : OK
- `pnpm lint` : OK
- YAML release-prod.yml + render.yaml : parse OK (js-yaml)
- Tests existants non impactés (changements infra/docs uniquement)
