### PR TITLE
fix(web): align contact page email display

### DIFF
--- a/apps/client/projects/web/src/app/features/contact/contact.page.html
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.html
@@ -303,7 +303,7 @@
               <a
                 href="mailto:kraakconsulting@gmail.com"
                 class="text-brand-white hover:underline"
-                >contact&#64;kraak-consulting.com</a
+                >kraakconsulting&#64;gmail.com</a
               >
             </li>
             <li class="flex items-center gap-3">
@@ -329,12 +329,12 @@
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
       Nos coordonn&eacute;es
     </h2>
-    <div class="mt-10 grid gap-8 md:grid-cols-3">
+    <div class="mt-10 grid gap-8 md:grid-cols-2">
       <div class="text-center">
         <i class="pi pi-envelope text-3xl" aria-hidden="true"></i>
         <h3 class="mt-2 text-lg font-bold">E-mail</h3>
         <a href="mailto:kraakconsulting@gmail.com" class="kr-link mt-1 block">
-          contact&#64;kraak-consulting.com
+          kraakconsulting&#64;gmail.com
         </a>
       </div>
       <div class="text-center">


### PR DESCRIPTION
## Résumé
- aligne l'email affiché sur la page Contact avec l'adresse réellement utilisée
- garde le lien mailto cohérent avec le texte affiché
- ajuste la grille des coordonnées (md:grid-cols-2) pour correspondre aux blocs présents

## Validation
- pnpm --filter @kraak/client test:web (102 tests passants)
- pré-push complet vert (lint, tests workspace, e2e)

Closes #290