### PR TITLE
fix(infra): désactiver required_pull_request_reviews côté API

### DIFF
--- a/scripts/github/update-branch-protection.mjs
+++ b/scripts/github/update-branch-protection.mjs
@@ -76,12 +76,9 @@ function buildProtectionPayload({ contexts, enforceAdmins }) {
       contexts,
     },
     enforce_admins: enforceAdmins,
-    required_pull_request_reviews: {
-      dismiss_stale_reviews: false,
-      require_code_owner_reviews: false,
-      require_last_push_approval: false,
-      required_approving_review_count: 0,
-    },
+    // `null` désactive complètement l'exigence de review (sinon
+    // mergeStateStatus reste BLOCKED même avec required_approving_review_count=0).
+    required_pull_request_reviews: null,
     restrictions: null,
     required_linear_history: true,
     allow_force_pushes: false,


### PR DESCRIPTION
Corrige le payload du script `update-branch-protection.mjs` : passer `required_pull_request_reviews` à `null` au lieu de `{ required_approving_review_count: 0 }`. Sinon GitHub considère que les reviews sont activées et bloque le merge (mergeStateStatus=BLOCKED) même quand 0 approbation est exigée. Mise à jour appliquée à `main` et `staging` via le script. Suit ARC-09.