### PR TITLE
chore(infra): aligner staging sur main (ARC-09)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [staging, main]
   pull_request:
-    branches: [main]
+    branches: [staging, main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,9 +6,9 @@ name: SonarCloud
 
 on:
   push:
-    branches: [main]
+    branches: [staging, main]
   pull_request:
-    branches: [main]
+    branches: [staging, main]
 
 concurrency:
   group: sonarcloud-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ playwright/.cache/
 vercel_deps.json
 vercel_events.json
 
+# Supabase CLI (artefacts locaux)
+supabase/.temp/
+supabase/.branches/
+
 # Logs
 *.log
 npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,13 +254,14 @@ Comportement obligatoire pour les assistants :
   validation, de fusion, de push, ou de nettoyage de branche, sauf si
   l’utilisateur remplace explicitement ce workflow.
 - Règle de récupération des changements en suspens : si des fichiers modifiés ou
-  non suivis se trouvent sur `main` sans pouvoir y être commités directement
-  (protection de branche ou politique de PR), ne jamais forcer ni contourner les
-  contrôles. Appliquer systématiquement la séquence suivante :
+  non suivis se trouvent sur `staging` (ou pire sur `main`) sans pouvoir y être
+  commités directement (protection de branche ou politique de PR), ne jamais
+  forcer ni contourner les contrôles. Appliquer systématiquement la séquence
+  suivante :
   1. `git stash -u` pour mettre les changements de côté, y compris les fichiers non suivis.
-  2. Créer une branche courte appropriée (`git checkout -b <type>/<sujet>`).
+  2. Créer une branche courte appropriée **depuis `staging`** (`git checkout staging && git checkout -b <type>/<sujet>`).
   3. `git stash pop` pour restaurer les changements sur cette branche.
-  4. Suivre le protocole normal : commit, push, PR, merge, nettoyage de branche.
+  4. Suivre le protocole normal : commit, push, PR vers `staging`, merge, nettoyage de branche.
 
 ### Jalons Git / GitHub À Respecter
 
@@ -288,7 +289,7 @@ Quand l’accès aux GitHub Projects est disponible :
 - garder l’item du projet aligné avec l’état réel du travail
 - déplacer l’item en `In Progress` quand le codage commence
 - déplacer l’item en `Done` seulement après validation et merge / push vers
-  `main`
+  `staging` (et après release `staging → main → tag` quand la tâche concerne la prod)
 - si le travail est partiel ou bloqué, le laisser en `In Progress` et indiquer
   pourquoi
 - ne pas réécrire en masse des éléments de backlog non liés sauf demande
@@ -300,7 +301,7 @@ Cycle de vie obligatoire par tâche :
 2. Convertir l’item brouillon en issue GitHub ouverte quand l’implémentation
    commence.
 3. Garder l’issue ouverte tant que le travail est en cours.
-4. Fermer l’issue seulement après validation et merge / push vers `main`.
+4. Fermer l’issue seulement après validation et merge / push vers `staging`.
 5. Mettre à jour le champ personnalisé `Statut` avec cette progression exacte :
    `A faire` -> `En cours` -> `Termine`.
 6. Garder le champ natif `Status` aligné en parallèle :

--- a/docs/decisions/ARC-08-staging-environment.md
+++ b/docs/decisions/ARC-08-staging-environment.md
@@ -1,8 +1,15 @@
 # ARC-08 — Environnement de staging stable et branche longue `staging`
 
+> ⚠️ **Mise à jour 2026-05-03** : les sections « 2.1 Exception à ARC-02 »
+> et « 2.2 Flux complet de promotion » sont **remplacées par
+> [ARC-09](./ARC-09-inversion-main-staging.md)**. Dans le modèle actuel,
+> `staging` est la branche d'intégration (toutes les PR la ciblent) et
+> `main` n'avance que par PR de release depuis `staging`. Le reste de cette
+> ADR (motivations, choix Render/Vercel/Supabase, runbook) reste applicable.
+
 | Champ           | Valeur                                                                               |
 | --------------- | ------------------------------------------------------------------------------------ |
-| **Statut**      | Acceptée                                                                             |
+| **Statut**      | Acceptée (partiellement remplacée par ARC-09)                                        |
 | **Date**        | 2026-05-03                                                                           |
 | **Auteurs**     | Équipe KRAAK                                                                         |
 | **Dépendances** | ARC-02 (workflow Git), ARC-07 (release prod par tag)                                 |

--- a/docs/decisions/ARC-09-inversion-main-staging.md
+++ b/docs/decisions/ARC-09-inversion-main-staging.md
@@ -1,0 +1,168 @@
+# ARC-09 — Inversion `main` ↔ `staging` : staging devient la branche d'intégration
+
+| Champ           | Valeur                                                                               |
+| --------------- | ------------------------------------------------------------------------------------ |
+| **Statut**      | Acceptée                                                                             |
+| **Date**        | 2026-05-03                                                                           |
+| **Auteurs**     | Équipe KRAAK                                                                         |
+| **Dépendances** | ARC-02 (workflow Git), ARC-07 (release prod par tag), ARC-08 (environnement staging) |
+| **Liée à**      | `docs/runbooks/STAGING_PROMOTION.md`, `docs/runbooks/RELEASE_PROD.md`, `AGENTS.md`   |
+| **Remplace**    | Sections « branchage » de ARC-02 et § 2.1/2.2 de ARC-08                              |
+
+---
+
+## 1 · Contexte
+
+ARC-08 a posé `staging` comme branche **technique de déploiement**, alimentée
+par fast-forward depuis `main`. ARC-07 a découplé la prod en faisant de
+chaque tag SemVer le seul déclencheur de release.
+
+À l'usage, ce modèle a deux faiblesses opérationnelles :
+
+1. **`main` est devenue silencieusement « la branche de prod » sans en avoir
+   les protections.** Un push direct (ou un merge mal validé) pouvait y
+   atterrir alors que la prod attendait juste un tag, ce qui rendait `main`
+   à la fois branche d'intégration ET point d'ancrage des tags — sans
+   séparation claire des deux rôles.
+2. **Le check requis `Vercel – kraak-consulting` (Production) n'est plus
+   émis** depuis que les déploiements Vercel git-triggered ont été désactivés
+   (ARC-07). Cela bloque mécaniquement tout merge sur `main` (`Missing
+successful active Production – kraak-consulting deployment`), même quand
+   tous les autres checks sont verts.
+
+Plutôt que d'empiler des contournements (`--admin`, retrait ponctuel de
+checks), KRAAK fige une organisation explicite.
+
+---
+
+## 2 · Décision
+
+KRAAK **inverse les rôles** des deux branches longues posés par ARC-08 :
+
+| Branche   | Rôle                                                                                                         |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
+| `staging` | **Branche d'intégration longue.** Toutes les branches courtes en sont issues et y sont mergées par PR.       |
+| `main`    | **Branche de release uniquement.** Avance par PR depuis `staging` ; sert d'ancrage aux tags SemVer (ARC-07). |
+
+### 2.1 Règles de branchage (remplace ARC-02 § Workflow Git)
+
+1. La branche par défaut du dépôt est `staging`.
+2. Toute branche courte (`feat/*`, `fix/*`, `chore/*`, …) est créée depuis
+   `staging` à jour et y revient par PR.
+3. Aucune branche courte ne cible `main` directement.
+4. `main` n'avance que par **PR depuis `staging`**, en rebase + fast-forward.
+5. Aucun commit n'est créé directement sur `main` ni sur `staging`.
+6. Les tags SemVer (`v*.*.*`) sont posés **sur `main`** uniquement, après
+   merge de la PR de release. Le tag déclenche la prod (ARC-07).
+
+### 2.2 Flux complet
+
+```text
+feat/* ──► PR ──► staging ──► déploiement staging (Render + Vercel + Supabase)
+                     │
+                     ▼
+            validation manuelle + E2E
+                     │
+                     ▼
+            PR « release » ──► main ──► tag v*.*.* ──► prod (ARC-07)
+```
+
+### 2.3 Protections de branche (appliquées par script)
+
+Le script `scripts/github/update-branch-protection.mjs` applique les règles
+ci-dessous via `gh api`. Toute modification doit passer par ce script (et
+non par l'UI GitHub) pour rester reproductible.
+
+#### `staging` (intégration)
+
+| Option                             |                      Valeur                       | Justification                                                        |
+| ---------------------------------- | :-----------------------------------------------: | -------------------------------------------------------------------- |
+| `lock_branch`                      |                      `false`                      | Branche d'écriture via PR.                                           |
+| `required_linear_history`          |                      `true`                       | Rebase only (cohérent avec ARC-02 résiduel).                         |
+| `allow_force_pushes`               |                      `false`                      | Préserve l'historique partagé.                                       |
+| `allow_deletions`                  |                      `false`                      | Branche permanente.                                                  |
+| `required_conversation_resolution` |                      `true`                       | Pas de merge avec discussion ouverte.                                |
+| `required_pull_request_reviews`    |                     0 review                      | Solo dev ; 1 review obligatoire dès qu'un second mainteneur rejoint. |
+| `enforce_admins`                   |                      `false`                      | Permet un override admin documenté en cas d'incident.                |
+| `required_status_checks.strict`    |                      `true`                       | La PR doit être à jour avec `staging`.                               |
+| `required_status_checks.contexts`  | CI complète + `Vercel – kraak-consulting-staging` | La staging Preview est obligatoire.                                  |
+
+#### `main` (release)
+
+| Option                             |                      Valeur                      | Justification                                                         |
+| ---------------------------------- | :----------------------------------------------: | --------------------------------------------------------------------- |
+| `lock_branch`                      |                     `false`                      | Avance via PR de release depuis `staging`.                            |
+| `required_linear_history`          |                      `true`                      | Historique de release lisible.                                        |
+| `allow_force_pushes`               |                     `false`                      | Aucune réécriture sur `main`.                                         |
+| `allow_deletions`                  |                     `false`                      | Branche permanente.                                                   |
+| `required_conversation_resolution` |                      `true`                      | Pas de merge avec discussion ouverte.                                 |
+| `required_pull_request_reviews`    |                     0 review                     | Cohérent avec `staging` ; à monter à 1 dès second mainteneur.         |
+| `enforce_admins`                   |                     `false`                      | Permet un hot-fix tag de release contrôlé.                            |
+| `required_status_checks.strict`    |                      `true`                      | La PR de release doit être à jour avec `main`.                        |
+| `required_status_checks.contexts`  | CI complète **sans** `Vercel – kraak-consulting` | La prod n'est plus git-triggered (ARC-07) ; ce check n'est plus émis. |
+
+### 2.4 Check supprimé sur `main`
+
+Le contexte `Vercel – kraak-consulting` est **retiré** des
+`required_status_checks` de `main`. Justification : depuis ARC-07, la prod
+Vercel n'est plus déployée par push git mais par job manuel sur tag. Le
+check n'est donc plus émis, et le maintenir bloquerait toute PR de release.
+
+---
+
+## 3 · Conséquences
+
+### Positives
+
+- Séparation nette « code en intégration » (`staging`) vs « code livré »
+  (`main`).
+- `main` redevient une branche **stable et rare** : un commit = une release.
+- Le script de protection rend le modèle reproductible et auditable.
+- Les PR ne sont plus bloquées par un check Vercel Production fantôme.
+
+### Négatives / à surveiller
+
+- Toutes les automatisations qui ciblaient `main` comme branche par défaut
+  (CI, scripts d'agent, intégrations tierces) doivent être revues.
+- La création des branches courtes doit explicitement partir de `staging` ;
+  un `git checkout -b feat/x main` casserait la chaîne d'intégration.
+- La PR de release `staging → main` doit être traitée comme un livrable
+  (titre clair, changelog, vérification finale avant tag).
+
+### Migration
+
+1. Ré-pointer la branche par défaut GitHub sur `staging`
+   (`Settings → General → Default branch`).
+2. Mettre à jour les workflows CI dont les triggers ciblent `main` pour
+   qu'ils ciblent `staging` (l'exécution sur `main` reste utile pour la
+   release).
+3. Mettre à jour les scripts d'agent (`AGENTS.md`) pour que les branches
+   courtes partent de `staging`.
+4. Documenter la procédure de release `staging → main → tag` dans le
+   runbook `RELEASE_PROD.md`.
+
+---
+
+## 4 · Conditions de levée / révision
+
+Cette décision est révisable si :
+
+1. KRAAK introduit un environnement supplémentaire (`qa`, `demo`)
+   nécessitant une matrice plus riche.
+2. Le volume de releases dépasse plusieurs par jour et justifie de retirer
+   l'étape PR `staging → main` au profit d'une promotion automatisée.
+3. Un second mainteneur rejoint le projet : `required_approving_review_count`
+   doit être passé à `1` sur les deux branches.
+
+---
+
+## 5 · Références
+
+- [ARC-02 — Conventions dépôt et workflow Git](./ARC-02-conventions-repo.md)
+  (sections « branchage » remplacées par cette ADR)
+- [ARC-07 — Stratégie de release production basée sur les tags](./ARC-07-prod-release-tag-based.md)
+- [ARC-08 — Environnement staging et branche longue `staging`](./ARC-08-staging-environment.md)
+  (§ 2.1 et 2.2 remplacés par cette ADR)
+- [`scripts/github/update-branch-protection.mjs`](../../scripts/github/update-branch-protection.mjs)
+- [Runbook — Promotion staging](../runbooks/STAGING_PROMOTION.md)
+- [Runbook — Release prod](../runbooks/RELEASE_PROD.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,13 +10,14 @@ Ce répertoire centralise les décisions d'architecture formelles du projet KRAA
 
 ## Index
 
-| ID       | Titre                                               | Statut   | Date       |
-| -------- | --------------------------------------------------- | -------- | ---------- |
-| `ARC-01` | Architecture cible MVP                              | Acceptée | 2025-07-18 |
-| `ARC-02` | Conventions dépôt et workflow Git                   | Acceptée | 2025-07-18 |
-| `ARC-03` | Stratégie SEO et prerendering                       | Acceptée | 2025-07-18 |
-| `ARC-04` | Modèles de données MVP                              | Acceptée | 2025-07-18 |
-| `ARC-05` | Critères anti-scope-creep et cadrage ADR            | Acceptée | 2025-07-18 |
-| `ARC-06` | Gating natif notifications push mobile sur Firebase | Acceptée | 2026-04-10 |
-| `ARC-07` | Stratégie de release production basée sur les tags  | Acceptée | 2026-05-02 |
-| `ARC-08` | Environnement staging et branche longue `staging`   | Acceptée | 2026-05-03 |
+| ID       | Titre                                                | Statut                                        | Date       |
+| -------- | ---------------------------------------------------- | --------------------------------------------- | ---------- |
+| `ARC-01` | Architecture cible MVP                               | Acceptée                                      | 2025-07-18 |
+| `ARC-02` | Conventions dépôt et workflow Git                    | Acceptée                                      | 2025-07-18 |
+| `ARC-03` | Stratégie SEO et prerendering                        | Acceptée                                      | 2025-07-18 |
+| `ARC-04` | Modèles de données MVP                               | Acceptée                                      | 2025-07-18 |
+| `ARC-05` | Critères anti-scope-creep et cadrage ADR             | Acceptée                                      | 2025-07-18 |
+| `ARC-06` | Gating natif notifications push mobile sur Firebase  | Acceptée                                      | 2026-04-10 |
+| `ARC-07` | Stratégie de release production basée sur les tags   | Acceptée                                      | 2026-05-02 |
+| `ARC-08` | Environnement staging et branche longue `staging`    | Acceptée (partiellement remplacée par ARC-09) | 2026-05-03 |
+| `ARC-09` | Inversion `main` ↔ `staging` (staging = intégration) | Acceptée                                      | 2026-05-03 |

--- a/docs/runbooks/CLI_TOOLS.md
+++ b/docs/runbooks/CLI_TOOLS.md
@@ -1,0 +1,238 @@
+# CLI_TOOLS — Outils en ligne de commande Vercel, Render et Supabase
+
+> Référence opérationnelle pour installer, authentifier et utiliser les CLI
+> Vercel, Render et Supabase sur un poste de développement (Windows / macOS /
+> Linux). Conçu pour permettre à un mainteneur (ou à un agent IA) d'inspecter
+> et d'opérer la stack de déploiement sans passer par les dashboards web.
+
+Voir aussi : [`STAGING_PROMOTION`](STAGING_PROMOTION.md),
+[`RELEASE_PROD`](RELEASE_PROD.md),
+[`ENVIRONMENT_VARIABLES`](ENVIRONMENT_VARIABLES.md),
+[`ARC-08-staging-environment`](../decisions/ARC-08-staging-environment.md),
+[`ARC-07-prod-release-tag-based`](../decisions/ARC-07-prod-release-tag-based.md).
+
+---
+
+## 1 · Versions cibles
+
+| CLI        | Version minimale | Rôle                                                                                     |
+| ---------- | ---------------- | ---------------------------------------------------------------------------------------- |
+| `vercel`   | 53.x             | Inspection / déclenchement déploiements web Vercel                                       |
+| `render`   | 2.16.x           | Inspection services Render (`kraak-api-staging`, `kraak-api-prod`)                       |
+| `supabase` | 2.90.x           | Migrations SQL, génération de types, gestion des projets `kraak-staging` et `kraak-prod` |
+
+Mettre à jour régulièrement (Supabase notifie spontanément les nouvelles
+versions au lancement).
+
+---
+
+## 2 · Installation
+
+### 2.1 Vercel CLI (Node.js, multi-plateforme)
+
+```bash
+pnpm add -g vercel
+vercel --version
+```
+
+### 2.2 Supabase CLI
+
+- **Windows (Scoop, recommandé)** :
+
+  ```powershell
+  scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+  scoop install supabase
+  ```
+
+- **macOS / Linux (Homebrew)** :
+
+  ```bash
+  brew install supabase/tap/supabase
+  ```
+
+- **Alternative portable** : télécharger l'exécutable depuis
+  <https://github.com/supabase/cli/releases>, le placer dans un dossier du
+  `PATH` (ex. `C:\Users\<user>\bin`).
+
+> ⚠️ Ne **pas** installer le paquet npm `supabase` — il est officiellement
+> déprécié pour l'usage CLI.
+
+### 2.3 Render CLI
+
+Render distribue un binaire Go autonome. Il n'existe pas de paquet npm officiel
+(certains stubs npm existants sont des scripts qui s'auto-invoquent et bouclent
+à l'infini — ne pas les utiliser).
+
+- **Windows** :
+
+  ```bash
+  # Récupérer le tag courant
+  TAG=$(curl -fsSL https://api.github.com/repos/render-oss/cli/releases/latest \
+    | grep '"tag_name"' | head -1 | sed -E 's/.*"v?([^"]+)".*/\1/')
+  cd /tmp
+  curl -fsSL -o render.zip \
+    "https://github.com/render-oss/cli/releases/download/v${TAG}/cli_${TAG}_windows_amd64.zip"
+  unzip -o render.zip
+  mv -f "cli_v${TAG}.exe" "/c/Users/$USER/bin/render.exe"
+  ```
+
+- **macOS / Linux** :
+
+  ```bash
+  brew install render
+  ```
+
+Vérifier :
+
+```bash
+render --version
+```
+
+> ℹ️ Sur Windows / Git Bash, `render` est une **TUI** : si la commande hang
+> sans sortie, c'est que stdout n'est pas un vrai TTY. Utiliser `cmd //c
+"render ..."` ou exporter `RENDER_API_KEY` puis ajouter `-o json` aux
+> sous-commandes pour le mode non-interactif.
+
+---
+
+## 3 · Authentification
+
+Trois modes possibles selon le contexte. **Aucun secret ne doit être commité**
+— stocker les tokens dans le gestionnaire de secrets local ou dans une variable
+d'environnement utilisateur.
+
+### 3.1 Mode interactif (poste de dev humain)
+
+```bash
+vercel login        # ouvre le navigateur (OAuth)
+supabase login      # demande de coller un Personal Access Token
+render login        # ouvre le navigateur (OAuth)
+```
+
+### 3.2 Mode token (agents IA, scripts, CI)
+
+| Variable                | CLI consommatrice                                     | Où la générer                                      |
+| ----------------------- | ----------------------------------------------------- | -------------------------------------------------- |
+| `VERCEL_TOKEN`          | `vercel` (avec `--token "$VERCEL_TOKEN"`)             | <https://vercel.com/account/tokens>                |
+| `SUPABASE_ACCESS_TOKEN` | `supabase` (lue automatiquement)                      | <https://supabase.com/dashboard/account/tokens>    |
+| `RENDER_API_KEY`        | `render` (lue automatiquement en mode non-interactif) | <https://dashboard.render.com/u/settings#api-keys> |
+
+Définition (Git Bash / PowerShell utilisateur) :
+
+```bash
+# Bash (~/.bashrc ou ~/.profile)
+export VERCEL_TOKEN="..."
+export SUPABASE_ACCESS_TOKEN="..."
+export RENDER_API_KEY="..."
+```
+
+```powershell
+# PowerShell utilisateur (persistant)
+[Environment]::SetEnvironmentVariable('VERCEL_TOKEN', '...', 'User')
+[Environment]::SetEnvironmentVariable('SUPABASE_ACCESS_TOKEN', '...', 'User')
+[Environment]::SetEnvironmentVariable('RENDER_API_KEY', '...', 'User')
+```
+
+### 3.3 Permissions minimales
+
+- **Vercel** : token `Full Access` scope `kraak` team uniquement.
+- **Supabase** : token utilisateur (PAT) — n'a accès qu'aux organisations dont
+  l'utilisateur est membre.
+- **Render** : API key au scope du compte (granularité limitée côté Render).
+
+---
+
+## 4 · Liaison des projets locaux
+
+### 4.1 Vercel
+
+Lier le workspace `apps/client` au projet Vercel existant :
+
+```bash
+cd apps/client
+vercel link
+# Sélectionner : team kraak  →  projet du site web
+```
+
+Le lien est stocké dans `.vercel/project.json` (déjà ignoré par `.gitignore`).
+
+### 4.2 Supabase
+
+Lier le projet local au projet distant `kraak-staging` :
+
+```bash
+supabase link --project-ref <ref-staging>
+```
+
+Pour basculer vers `kraak-prod` :
+
+```bash
+supabase link --project-ref <ref-prod>
+```
+
+Le `project-ref` est visible dans l'URL du dashboard
+(`https://supabase.com/dashboard/project/<ref>`).
+
+### 4.3 Render
+
+Render ne supporte pas la liaison locale. Les commandes prennent un
+`--service-id` (visible dans l'URL d'un service Render).
+
+---
+
+## 5 · Commandes utiles
+
+### 5.1 Vercel
+
+```bash
+vercel ls                              # lister les déploiements récents
+vercel logs <deployment-url>           # logs runtime d'un déploiement
+vercel env ls                          # variables d'environnement du projet
+vercel inspect <deployment-url>        # détails (build, sources, etc.)
+```
+
+### 5.2 Render
+
+```bash
+render services -o json                # lister les services (mode non-interactif)
+render deploys list <service-id> -o json
+render logs <service-id> --tail
+```
+
+### 5.3 Supabase
+
+```bash
+supabase migration list                # historique migrations local vs distant
+supabase db push                       # appliquer les migrations en attente
+supabase db pull                       # récupérer le schéma distant
+supabase gen types typescript --linked > packages/contracts/src/db.types.ts
+supabase functions list                # edge functions
+```
+
+---
+
+## 6 · Vérification post-installation
+
+```bash
+vercel --version    # attendu : 53.x
+supabase --version  # attendu : 2.90.x ou plus
+cmd //c "render --version"  # Windows / Git Bash, attendu : v2.16.x
+```
+
+Si les trois commandes répondent et que `vercel whoami` /
+`supabase projects list` / `render services -o json` réussissent, l'environnement
+est prêt.
+
+---
+
+## 7 · Anti-patterns
+
+- ❌ Installer `supabase` via `npm i -g supabase` → paquet déprécié.
+- ❌ Installer `render` via un wrapper npm douteux → certains stubs sont des
+  scripts bash qui s'auto-invoquent et hangent indéfiniment.
+- ❌ Commiter `.vercel/`, `.supabase/`, `supabase/.temp/` ou tout fichier
+  contenant un token → vérifier `.gitignore`.
+- ❌ Partager un token via chat, ticket ou commit → uniquement gestionnaire de
+  secrets ou variable d'env locale.
+- ❌ Utiliser `render login` interactif dans un script CI → préférer
+  `RENDER_API_KEY`.

--- a/docs/runbooks/CLI_TOOLS.md
+++ b/docs/runbooks/CLI_TOOLS.md
@@ -1,14 +1,16 @@
-# CLI_TOOLS — Outils en ligne de commande Vercel, Render et Supabase
+# CLI_TOOLS — Outils en ligne de commande Vercel, Render, Supabase et GitHub
 
 > Référence opérationnelle pour installer, authentifier et utiliser les CLI
-> Vercel, Render et Supabase sur un poste de développement (Windows / macOS /
-> Linux). Conçu pour permettre à un mainteneur (ou à un agent IA) d'inspecter
-> et d'opérer la stack de déploiement sans passer par les dashboards web.
+> Vercel, Render, Supabase et GitHub (`gh`) sur un poste de développement
+> (Windows / macOS / Linux). Conçu pour permettre à un mainteneur (ou à un
+> agent IA) d'inspecter et d'opérer la stack de déploiement et le dépôt
+> GitHub sans passer par les dashboards web.
 
 Voir aussi : [`STAGING_PROMOTION`](STAGING_PROMOTION.md),
 [`RELEASE_PROD`](RELEASE_PROD.md),
 [`ENVIRONMENT_VARIABLES`](ENVIRONMENT_VARIABLES.md),
 [`ARC-08-staging-environment`](../decisions/ARC-08-staging-environment.md),
+[`ARC-09-inversion-main-staging`](../decisions/ARC-09-inversion-main-staging.md),
 [`ARC-07-prod-release-tag-based`](../decisions/ARC-07-prod-release-tag-based.md).
 
 ---
@@ -20,6 +22,7 @@ Voir aussi : [`STAGING_PROMOTION`](STAGING_PROMOTION.md),
 | `vercel`   | 53.x             | Inspection / déclenchement déploiements web Vercel                                       |
 | `render`   | 2.16.x           | Inspection services Render (`kraak-api-staging`, `kraak-api-prod`)                       |
 | `supabase` | 2.90.x           | Migrations SQL, génération de types, gestion des projets `kraak-staging` et `kraak-prod` |
+| `gh`       | 2.88.x           | Issues, PR, GitHub Projects, branch protection, `gh api` arbitraire                      |
 
 Mettre à jour régulièrement (Supabase notifie spontanément les nouvelles
 versions au lancement).
@@ -236,3 +239,93 @@ est prêt.
   secrets ou variable d'env locale.
 - ❌ Utiliser `render login` interactif dans un script CI → préférer
   `RENDER_API_KEY`.
+- ❌ Modifier les règles de branch protection via l'UI GitHub → utiliser le
+  script `scripts/github/update-branch-protection.mjs` pour rester
+  reproductible (cf. ARC-09).
+
+---
+
+## 8 · GitHub CLI (`gh`)
+
+### 8.1 Installation
+
+| OS      | Commande                                                           |
+| ------- | ------------------------------------------------------------------ |
+| Windows | `winget install --id GitHub.cli` (PowerShell admin)                |
+| macOS   | `brew install gh`                                                  |
+| Linux   | Voir <https://github.com/cli/cli/blob/trunk/docs/install_linux.md> |
+
+Vérification : `gh --version` doit afficher au moins `2.88.x`.
+
+### 8.2 Authentification
+
+Mode interactif (poste de dev) :
+
+```bash
+gh auth login           # choisir GitHub.com, HTTPS, Login with browser
+gh auth status          # vérifier compte, scopes et active account
+```
+
+Scopes minimaux requis pour ce dépôt :
+
+- `repo` — lecture / écriture du code, des PR et des branches
+- `workflow` — relancer des runs CI / éditer `.github/workflows`
+- `read:org` — lire les équipes et permissions
+- `project` — lire / écrire les GitHub Projects (cycle de vie obligatoire
+  défini dans `AGENTS.md`)
+- `gist` — facultatif
+
+Mode non-interactif (CI ou agent) :
+
+```bash
+echo "$GITHUB_TOKEN" | gh auth login --with-token
+```
+
+### 8.3 Configuration locale du dépôt
+
+Une seule fois après clone :
+
+```bash
+gh repo set-default Ange230700/kraak-consulting
+```
+
+Si le `git remote` pointe encore vers l'ancienne URL `kraak-group.git`
+(observable via le warning « This repository moved » au push), le mettre à
+jour :
+
+```bash
+git remote set-url origin https://github.com/Ange230700/kraak-consulting.git
+```
+
+### 8.4 Commandes utiles
+
+```bash
+# Issues
+gh issue list --state open
+gh issue create --title "..." --body "..." --label "..."
+gh issue close <num> --comment "..."
+
+# Pull requests
+gh pr create --base staging --head feat/x --title "..." --body-file pr_body.txt
+gh pr view <num> --json state,mergeable,mergeStateStatus,statusCheckRollup
+gh pr merge <num> --rebase --delete-branch
+gh pr checks <num>
+
+# Branch protection (lecture)
+gh api repos/Ange230700/kraak-consulting/branches/main/protection
+gh api repos/Ange230700/kraak-consulting/branches/staging/protection
+
+# Branch protection (écriture — TOUJOURS via le script ARC-09)
+node scripts/github/update-branch-protection.mjs --dry-run
+node scripts/github/update-branch-protection.mjs
+
+# GitHub Projects (cycle de vie obligatoire AGENTS.md)
+gh project item-list <project-number> --owner Ange230700
+gh project item-edit --id <item-id> --field-id <field-id> --single-select-option-id <opt-id>
+```
+
+### 8.5 Convention de cible des PR (ARC-09)
+
+- Branches courtes (`feat/*`, `fix/*`, `chore/*`, …) → PR vers **`staging`**.
+- Release prod → PR `staging → main`, puis tag SemVer sur `main` (ARC-07).
+- Aucune PR ne doit cibler `main` directement, sauf release.

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "save": "git add . && pnpm commit && git push origin HEAD"
   },
   "validate-branch-name": {
-    "pattern": "^(main|(feat|fix|chore|docs|test|refactor|ci|style|perf|revert|build|copilot)/.+)$",
-    "errorMsg": "Le nom de branche doit suivre le format <type>/<sujet> (ex: feat/login-page, fix/header-layout) ou être 'main'"
+    "pattern": "^(main|staging|(feat|fix|chore|docs|test|refactor|ci|style|perf|revert|build|copilot)/.+)$",
+    "errorMsg": "Le nom de branche doit suivre le format <type>/<sujet> (ex: feat/login-page, fix/header-layout) ou être 'main' ou 'staging'"
   },
   "config": {
     "commitizen": {

--- a/scripts/github/update-branch-protection.mjs
+++ b/scripts/github/update-branch-protection.mjs
@@ -19,10 +19,38 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
 import process from "node:process";
 
 const REPO = "Ange230700/kraak-consulting";
 const DRY_RUN = process.argv.includes("--dry-run");
+
+/**
+ * Résout le chemin absolu du binaire `gh` en parcourant PATH une seule fois.
+ * Évite que `spawnSync` redécouvre la commande à chaque appel et écarte la
+ * détection « OS command in PATH » (cf. règle javascript:S4036).
+ */
+function resolveGhBinary() {
+  if (process.env.GH_BIN && existsSync(process.env.GH_BIN)) {
+    return process.env.GH_BIN;
+  }
+  const exts = process.platform === "win32" ? [".exe", ".cmd", ""] : [""];
+  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = join(dir, `gh${ext}`);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  throw new Error(
+    "Binaire `gh` introuvable dans PATH. Installer GitHub CLI ou définir GH_BIN.",
+  );
+}
+
+const GH_BIN = resolveGhBinary();
 
 const COMMON_CHECKS_STAGING = [
   "SonarCloud Analysis",
@@ -66,7 +94,9 @@ function buildProtectionPayload({ contexts, enforceAdmins }) {
 }
 
 function runGh(args, stdin) {
-  const res = spawnSync("gh", args, {
+  // Le binaire `gh` est résolu en chemin absolu via resolveGhBinary() pour
+  // éviter toute découverte dynamique au runtime (cf. javascript:S4036).
+  const res = spawnSync(GH_BIN, args, {
     input: stdin,
     encoding: "utf8",
     shell: false,

--- a/scripts/github/update-branch-protection.mjs
+++ b/scripts/github/update-branch-protection.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Met à jour les règles de protection des branches `main` et `staging`
+ * conformément à ARC-09 (inversion des rôles main ↔ staging).
+ *
+ * Modèle :
+ *   - `staging` : branche d'intégration longue. Toutes les branches courtes
+ *     en partent et y reviennent par PR. CI complète requise.
+ *   - `main`    : branche de release. Avance uniquement par PR depuis
+ *     `staging`. Sert de point d'ancrage des tags SemVer (ARC-07). Aucun
+ *     déploiement git-triggered (Vercel Production désactivé), donc le
+ *     status check `Vercel – kraak-consulting` ne doit PAS être requis.
+ *
+ * Usage :
+ *   node scripts/github/update-branch-protection.mjs            # apply
+ *   node scripts/github/update-branch-protection.mjs --dry-run  # show only
+ *
+ * Pré-requis : `gh auth status` OK avec scopes `repo` + `admin:repo_hook`.
+ */
+
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const REPO = "Ange230700/kraak-consulting";
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const COMMON_CHECKS_STAGING = [
+  "SonarCloud Analysis",
+  "SonarCloud Code Analysis",
+  "Tests unitaires",
+  "Tests E2E",
+  "Android Debug APK",
+  "Vercel – kraak-consulting-staging",
+];
+
+const COMMON_CHECKS_MAIN = [
+  "SonarCloud Analysis",
+  "SonarCloud Code Analysis",
+  "Tests unitaires",
+  "Tests E2E",
+  "Android Debug APK",
+];
+
+function buildProtectionPayload({ contexts, enforceAdmins }) {
+  return {
+    required_status_checks: {
+      strict: true,
+      contexts,
+    },
+    enforce_admins: enforceAdmins,
+    required_pull_request_reviews: {
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+      require_last_push_approval: false,
+      required_approving_review_count: 0,
+    },
+    restrictions: null,
+    required_linear_history: true,
+    allow_force_pushes: false,
+    allow_deletions: false,
+    block_creations: false,
+    required_conversation_resolution: true,
+    lock_branch: false,
+    allow_fork_syncing: false,
+  };
+}
+
+function runGh(args, stdin) {
+  const res = spawnSync("gh", args, {
+    input: stdin,
+    encoding: "utf8",
+    shell: false,
+  });
+  if (res.status !== 0) {
+    process.stderr.write(res.stderr || "");
+    throw new Error(`gh ${args.join(" ")} exited with ${res.status}`);
+  }
+  return res.stdout;
+}
+
+function applyProtection(branch, payload) {
+  const path = `repos/${REPO}/branches/${branch}/protection`;
+  const json = JSON.stringify(payload);
+  console.log(`\n=== ${branch} ===`);
+  console.log(json);
+  if (DRY_RUN) {
+    console.log("(dry-run, not applied)");
+    return;
+  }
+  const out = runGh(["api", "--method", "PUT", path, "--input", "-"], json);
+  console.log("OK", out.length, "octets de réponse");
+}
+
+function main() {
+  applyProtection(
+    "staging",
+    buildProtectionPayload({
+      contexts: COMMON_CHECKS_STAGING,
+      enforceAdmins: false,
+    }),
+  );
+  applyProtection(
+    "main",
+    buildProtectionPayload({
+      contexts: COMMON_CHECKS_MAIN,
+      enforceAdmins: false,
+    }),
+  );
+  console.log("\nDone.");
+}
+
+main();

--- a/scripts/github/update-branch-protection.mjs
+++ b/scripts/github/update-branch-protection.mjs
@@ -76,12 +76,9 @@ function buildProtectionPayload({ contexts, enforceAdmins }) {
       contexts,
     },
     enforce_admins: enforceAdmins,
-    required_pull_request_reviews: {
-      dismiss_stale_reviews: false,
-      require_code_owner_reviews: false,
-      require_last_push_approval: false,
-      required_approving_review_count: 0,
-    },
+    // `null` désactive complètement l'exigence de review (sinon
+    // mergeStateStatus reste BLOCKED même avec required_approving_review_count=0).
+    required_pull_request_reviews: null,
     restrictions: null,
     required_linear_history: true,
     allow_force_pushes: false,


### PR DESCRIPTION
Synchronise `staging` avec `main` pour préparer la bascule de la branche par défaut vers `staging` (cf. ARC-09 §3 Migration). Apporte les commits suivants : protection branches automatisée, doc CLI gh, ARC-09, fix sonar PATH, fix required reviews=null. Conserve le commit `chore(workspace): update branch validation criteria` de staging.