### PR TITLE
chore(client): ignorer .vercel et .env*.local

### DIFF
--- a/apps/client/.gitignore
+++ b/apps/client/.gitignore
@@ -12,3 +12,6 @@ android/build/
 android/local.properties
 ios/App/Pods/
 ios/DerivedData/
+
+.vercel
+.env*.local


### PR DESCRIPTION
Pérennise les règles ajoutées automatiquement par `vercel link` (cf. runbook CLI_TOOLS.md §6.5). Évite que tout dev qui exécute `vercel link` depuis `apps/client/` doive régénérer ces lignes manuellement et risque de versionner accidentellement `.vercel/` ou `.env.local`. Cible `staging` (ARC-09).