### PR TITLE
feat(web): feature flag espace participant (#297)

### DIFF
--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -17,3 +17,10 @@ SUPABASE_PUBLISHABLE_KEY=
 
 # Port du serveur de développement Angular (utilisé par Playwright)
 KRAAK_WEB_PORT=4200
+
+# Feature flag — Espace participant (auth + dashboard)
+# - true : routes /participant, /connexion, /inscription, /mot-de-passe-oublie
+#          actives + CTA navbar visible (utilise pour staging)
+# - false ou non defini : routes absentes (404 redirect vers home),
+#          CTA navbar masque (defaut prod)
+CLIENT_FEATURE_PARTICIPANT_AREA=true

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -31,9 +31,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `npx ng serve web --port ${localWebPort}`,
+    command: `node ../../scripts/generate-client-runtime-config.mjs --env local && npx ng serve web --port ${localWebPort}`,
     url: localWebBaseUrl,
     reuseExistingServer,
     timeout: 120_000,
+    env: {
+      CLIENT_FEATURE_PARTICIPANT_AREA: 'true',
+    },
   },
 });

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -1,11 +1,15 @@
-import { routes } from './app.routes';
+import {
+  buildMarketingRoute,
+  buildRoutes,
+  participantAreaCanMatch,
+  routes,
+} from './app.routes';
 import {
   participantRoleGuard,
   participantRoleChildGuard,
 } from './core/auth/auth.guard';
 
 describe('Web routes', () => {
-  const paths = routes.map((r) => r.path);
   const marketingPaths = [
     '',
     'a-propos',
@@ -14,27 +18,35 @@ describe('Web routes', () => {
     'ressources',
     'contact',
   ];
+  const participantPaths = [
+    'connexion',
+    'inscription',
+    'mot-de-passe-oublie',
+    'participant',
+  ];
+  const builtRoutes = buildRoutes();
+  const paths = builtRoutes.map((r) => r.path);
 
-  it('should define all public marketing routes', () => {
+  it('When inspecting routes Then all public marketing routes are defined', () => {
     for (const path of marketingPaths) {
       expect(paths).toContain(path);
     }
   });
 
-  it('should define public auth routes', () => {
-    expect(paths).toContain('connexion');
-    expect(paths).toContain('inscription');
-    expect(paths).toContain('mot-de-passe-oublie');
+  it('When inspecting routes Then participant and auth routes are defined', () => {
+    for (const path of participantPaths) {
+      expect(paths).toContain(path);
+    }
   });
 
-  it('should have a wildcard fallback redirecting to home', () => {
-    const wildcard = routes.find((r) => r.path === '**');
+  it('When inspecting routes Then a wildcard fallback redirects to home', () => {
+    const wildcard = builtRoutes.find((r) => r.path === '**');
     expect(wildcard).toBeDefined();
     expect(wildcard!.redirectTo).toBe('');
   });
 
-  it('should lazy-load every page component', () => {
-    const pageRoutes = routes.filter(
+  it('When inspecting page routes Then every page component is lazy-loaded', () => {
+    const pageRoutes = builtRoutes.filter(
       (r) => r.path !== '**' && r.path !== 'participant',
     );
     for (const route of pageRoutes) {
@@ -42,8 +54,8 @@ describe('Web routes', () => {
     }
   });
 
-  it('should attach a title and SEO metadata to every public marketing route', () => {
-    const pageRoutes = routes.filter((route) =>
+  it('When inspecting marketing routes Then every route exposes a title and SEO metadata', () => {
+    const pageRoutes = builtRoutes.filter((route) =>
       marketingPaths.includes(route.path ?? ''),
     );
 
@@ -53,9 +65,21 @@ describe('Web routes', () => {
     }
   });
 
+  it('When inspecting participant routes Then they are gated by the feature flag canMatch guard', () => {
+    const gated = builtRoutes.filter((r) =>
+      participantPaths.includes(r.path ?? ''),
+    );
+    expect(gated.length).toBe(participantPaths.length);
+    for (const route of gated) {
+      expect(route.canMatch).toContain(participantAreaCanMatch);
+    }
+  });
+
   describe('Participant authenticated routes', () => {
-    it('should define a protected participant route with auth guards', () => {
-      const participantRoute = routes.find((r) => r.path === 'participant');
+    it('When inspecting the participant route Then it is protected by both auth guards', () => {
+      const participantRoute = builtRoutes.find(
+        (r) => r.path === 'participant',
+      );
       expect(participantRoute).toBeDefined();
       expect(participantRoute!.canActivate).toContain(participantRoleGuard);
       expect(participantRoute!.canActivateChild).toContain(
@@ -63,8 +87,10 @@ describe('Web routes', () => {
       );
     });
 
-    it('should have a dashboard child route under participant', () => {
-      const participantRoute = routes.find((r) => r.path === 'participant');
+    it('When inspecting the participant route Then a dashboard child route exists', () => {
+      const participantRoute = builtRoutes.find(
+        (r) => r.path === 'participant',
+      );
       const dashboardRoute = participantRoute!.children?.find(
         (r) => r.path === 'dashboard',
       );
@@ -72,14 +98,75 @@ describe('Web routes', () => {
       expect(dashboardRoute!.loadComponent).toBeDefined();
     });
 
-    it('should redirect from /participant to /participant/dashboard', () => {
-      const participantRoute = routes.find((r) => r.path === 'participant');
+    it('When navigating to /participant Then the default child redirects to /participant/dashboard', () => {
+      const participantRoute = builtRoutes.find(
+        (r) => r.path === 'participant',
+      );
       const defaultRedirect = participantRoute!.children?.find(
         (r) => r.path === '',
       );
       expect(defaultRedirect).toBeDefined();
       expect(defaultRedirect!.redirectTo).toBe('dashboard');
       expect(defaultRedirect!.pathMatch).toBe('full');
+    });
+  });
+
+  describe('participantAreaCanMatch guard', () => {
+    const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
+
+    afterEach(() => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
+    });
+
+    it('When the flag is enabled Then the guard allows the route to match', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(participantAreaCanMatch(null as any, [] as any)).toBe(true);
+    });
+
+    it('When the flag is disabled Then the guard prevents the route from matching', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(participantAreaCanMatch(null as any, [] as any)).toBe(false);
+    });
+  });
+
+  it('exports the runtime routes constant', () => {
+    expect(routes.length).toBe(builtRoutes.length);
+  });
+
+  describe('buildMarketingRoute', () => {
+    it('When the path has no SEO entry Then it throws a descriptive error', () => {
+      expect(() =>
+        buildMarketingRoute('inconnu-sans-seo', () =>
+          Promise.resolve({ default: class {} }),
+        ),
+      ).toThrowError(/Missing SEO configuration/);
+    });
+  });
+
+  describe('Lazy-loaded route components', () => {
+    it('When each marketing route loadComponent is invoked Then it resolves to a component', async () => {
+      const targets = builtRoutes.filter(
+        (r) => r.path !== '**' && r.path !== 'participant' && r.loadComponent,
+      );
+      for (const route of targets) {
+        const loaded = await (route.loadComponent as () => Promise<unknown>)();
+        expect(loaded).toBeTruthy();
+      }
+    });
+
+    it('When the participant dashboard child loadComponent is invoked Then it resolves to a component', async () => {
+      const participantRoute = builtRoutes.find(
+        (r) => r.path === 'participant',
+      );
+      const dashboard = participantRoute!.children!.find(
+        (c) => c.path === 'dashboard',
+      );
+      const loaded = await (
+        dashboard!.loadComponent as () => Promise<unknown>
+      )();
+      expect(loaded).toBeTruthy();
     });
   });
 });

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -1,12 +1,16 @@
-import { Route, Routes } from '@angular/router';
+import { CanMatchFn, Route, Routes } from '@angular/router';
 
 import {
   participantRoleGuard,
   participantRoleChildGuard,
 } from './core/auth/auth.guard';
+import { isParticipantAreaEnabled } from './core/runtime/runtime-config';
 import { findSeoPageByPath } from './seo/site-seo';
 
-const buildMarketingRoute = (
+export const participantAreaCanMatch: CanMatchFn = () =>
+  isParticipantAreaEnabled();
+
+export const buildMarketingRoute = (
   path: string,
   loadComponent: Route['loadComponent'],
 ): Route => {
@@ -24,24 +28,9 @@ const buildMarketingRoute = (
   };
 };
 
-export const routes: Routes = [
+const marketingRoutes: Routes = [
   buildMarketingRoute('', () => import('./features/home/home.page')),
   buildMarketingRoute('a-propos', () => import('./features/about/about.page')),
-  {
-    path: 'connexion',
-    title: 'Connexion | KRAAK',
-    loadComponent: () => import('./features/auth/sign-in.page'),
-  },
-  {
-    path: 'inscription',
-    title: 'Inscription | KRAAK',
-    loadComponent: () => import('./features/auth/sign-up.page'),
-  },
-  {
-    path: 'mot-de-passe-oublie',
-    title: 'Mot de passe oubli\u00E9 | KRAAK',
-    loadComponent: () => import('./features/auth/password-reset.page'),
-  },
   buildMarketingRoute(
     'services',
     () => import('./features/services/services.page'),
@@ -58,8 +47,30 @@ export const routes: Routes = [
     'contact',
     () => import('./features/contact/contact.page'),
   ),
+];
+
+const participantAreaRoutes: Routes = [
+  {
+    path: 'connexion',
+    title: 'Connexion | KRAAK',
+    canMatch: [participantAreaCanMatch],
+    loadComponent: () => import('./features/auth/sign-in.page'),
+  },
+  {
+    path: 'inscription',
+    title: 'Inscription | KRAAK',
+    canMatch: [participantAreaCanMatch],
+    loadComponent: () => import('./features/auth/sign-up.page'),
+  },
+  {
+    path: 'mot-de-passe-oublie',
+    title: 'Mot de passe oubli\u00E9 | KRAAK',
+    canMatch: [participantAreaCanMatch],
+    loadComponent: () => import('./features/auth/password-reset.page'),
+  },
   {
     path: 'participant',
+    canMatch: [participantAreaCanMatch],
     canActivate: [participantRoleGuard],
     canActivateChild: [participantRoleChildGuard],
     children: [
@@ -75,8 +86,17 @@ export const routes: Routes = [
       },
     ],
   },
-  {
-    path: '**',
-    redirectTo: '',
-  },
 ];
+
+export function buildRoutes(): Routes {
+  return [
+    ...marketingRoutes,
+    ...participantAreaRoutes,
+    {
+      path: '**',
+      redirectTo: '',
+    },
+  ];
+}
+
+export const routes: Routes = buildRoutes();

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.spec.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.spec.ts
@@ -1,0 +1,38 @@
+import { getRuntimeConfig, isParticipantAreaEnabled } from './runtime-config';
+
+describe('Runtime config helpers', () => {
+  const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
+
+  afterEach(() => {
+    globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
+  });
+
+  describe('Given the runtime config is undefined', () => {
+    it('When getRuntimeConfig is called Then it returns an empty object', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      expect(getRuntimeConfig()).toEqual({});
+    });
+
+    it('When isParticipantAreaEnabled is called Then it returns false', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      expect(isParticipantAreaEnabled()).toBe(false);
+    });
+  });
+
+  describe('Given enableParticipantArea is true', () => {
+    it('When isParticipantAreaEnabled is called Then it returns true', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+      expect(isParticipantAreaEnabled()).toBe(true);
+    });
+  });
+
+  describe('Given enableParticipantArea is false or absent', () => {
+    it('When isParticipantAreaEnabled is called Then it returns false', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+      expect(isParticipantAreaEnabled()).toBe(false);
+
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = {};
+      expect(isParticipantAreaEnabled()).toBe(false);
+    });
+  });
+});

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
@@ -1,0 +1,18 @@
+interface KraakRuntimeConfig {
+  readonly apiBaseUrl?: string;
+  readonly supabaseUrl?: string;
+  readonly supabasePublishableKey?: string;
+  readonly enableParticipantArea?: boolean;
+}
+
+declare global {
+  var __KRAAK_RUNTIME_CONFIG__: KraakRuntimeConfig | undefined;
+}
+
+export function getRuntimeConfig(): KraakRuntimeConfig {
+  return globalThis.__KRAAK_RUNTIME_CONFIG__ ?? {};
+}
+
+export function isParticipantAreaEnabled(): boolean {
+  return getRuntimeConfig().enableParticipantArea === true;
+}

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.html
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.html
@@ -48,14 +48,16 @@
       <div
         class="border-brand-blue/10 mt-3 border-t pt-3 lg:mt-0 lg:border-0 lg:pt-0"
       >
-        <a
-          routerLink="/participant"
-          aria-label="Espace participant"
-          class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
-          (click)="closeMobileMenu()"
-        >
-          Espace participant
-        </a>
+        @if (participantAreaEnabled) {
+          <a
+            routerLink="/participant"
+            aria-label="Espace participant"
+            class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
+            (click)="closeMobileMenu()"
+          >
+            Espace participant
+          </a>
+        }
       </div>
     </div>
 

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.spec.ts
@@ -3,47 +3,103 @@ import { provideRouter } from '@angular/router';
 
 import { Navbar } from './navbar';
 
+async function compile() {
+  await TestBed.configureTestingModule({
+    imports: [Navbar],
+    providers: [provideRouter([])],
+  }).compileComponents();
+}
+
 describe('Navbar', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [Navbar],
-      providers: [provideRouter([])],
-    }).compileComponents();
+  const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
+
+  afterEach(() => {
+    globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
   });
 
-  it('should render lightweight navigation actions for key paths', () => {
-    const fixture = TestBed.createComponent(Navbar);
-    fixture.detectChanges();
+  describe('Given the participant area feature flag is enabled', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+      await compile();
+    });
 
-    const element = fixture.nativeElement as HTMLElement;
-    const brandImage = element.querySelector(
-      'img[alt="Logo KRAAK Consulting"]',
-    ) as HTMLImageElement | null;
-    const primaryCta = element.querySelector(
-      'a[aria-label="Espace participant"]',
-    ) as HTMLAnchorElement | null;
-    const menuToggle = element.querySelector(
-      'button[aria-label="Menu de navigation"]',
-    ) as HTMLButtonElement | null;
+    it('When the navbar renders Then it shows the participant CTA', () => {
+      const fixture = TestBed.createComponent(Navbar);
+      fixture.detectChanges();
 
-    expect(element.querySelectorAll('.p-button').length).toBe(0);
-    expect(menuToggle).toBeTruthy();
-    expect(element.textContent).toContain('Espace participant');
-    expect(brandImage?.getAttribute('src')).toContain('kraak-logo.png');
-    expect(primaryCta).toBeTruthy();
-    expect(element.textContent).not.toContain('Accueil');
-    expect(element.textContent).toContain('\u00C0 propos');
+      const element = fixture.nativeElement as HTMLElement;
+      const brandImage = element.querySelector(
+        'img[alt="Logo KRAAK Consulting"]',
+      ) as HTMLImageElement | null;
+      const primaryCta = element.querySelector(
+        'a[aria-label="Espace participant"]',
+      ) as HTMLAnchorElement | null;
+      const menuToggle = element.querySelector(
+        'button[aria-label="Menu de navigation"]',
+      ) as HTMLButtonElement | null;
+
+      expect(element.querySelectorAll('.p-button').length).toBe(0);
+      expect(menuToggle).toBeTruthy();
+      expect(element.textContent).toContain('Espace participant');
+      expect(brandImage?.getAttribute('src')).toContain('kraak-logo.png');
+      expect(primaryCta).toBeTruthy();
+      expect(element.textContent).not.toContain('Accueil');
+      expect(element.textContent).toContain('\u00C0 propos');
+    });
   });
 
-  it('should provide a named navigation landmark', () => {
-    const fixture = TestBed.createComponent(Navbar);
-    fixture.detectChanges();
+  describe('Given the participant area feature flag is disabled', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+      await compile();
+    });
 
-    const element = fixture.nativeElement as HTMLElement;
-    const navigation = element.querySelector('nav');
+    it('When the navbar renders Then the participant CTA is hidden', () => {
+      const fixture = TestBed.createComponent(Navbar);
+      fixture.detectChanges();
 
-    expect(navigation?.getAttribute('aria-label')).toBe(
-      'Navigation principale',
-    );
+      const element = fixture.nativeElement as HTMLElement;
+      const primaryCta = element.querySelector(
+        'a[aria-label="Espace participant"]',
+      );
+      const menuToggle = element.querySelector(
+        'button[aria-label="Menu de navigation"]',
+      );
+
+      expect(primaryCta).toBeNull();
+      expect(element.textContent).not.toContain('Espace participant');
+      expect(menuToggle).toBeTruthy();
+      expect(element.textContent).toContain('\u00C0 propos');
+    });
+  });
+
+  describe('Given the runtime config is missing', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      await compile();
+    });
+
+    it('When the navbar renders Then it provides a named navigation landmark', () => {
+      const fixture = TestBed.createComponent(Navbar);
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement as HTMLElement;
+      const navigation = element.querySelector('nav');
+
+      expect(navigation?.getAttribute('aria-label')).toBe(
+        'Navigation principale',
+      );
+    });
+
+    it('When the navbar renders Then the participant CTA stays hidden by default', () => {
+      const fixture = TestBed.createComponent(Navbar);
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement as HTMLElement;
+      const primaryCta = element.querySelector(
+        'a[aria-label="Espace participant"]',
+      );
+      expect(primaryCta).toBeNull();
+    });
   });
 });

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.ts
@@ -1,6 +1,8 @@
 import { Component, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
+import { isParticipantAreaEnabled } from '../../core/runtime/runtime-config';
+
 interface NavLink {
   label: string;
   path: string;
@@ -21,6 +23,7 @@ export class Navbar {
   ];
 
   protected readonly mobileMenuOpen = signal(false);
+  protected readonly participantAreaEnabled = isParticipantAreaEnabled();
 
   protected toggleMobileMenu(): void {
     this.mobileMenuOpen.update((v) => !v);

--- a/apps/client/projects/web/src/main.server.ts
+++ b/apps/client/projects/web/src/main.server.ts
@@ -5,6 +5,21 @@ import {
 import { App } from './app/app';
 import { config } from './app/app.config.server';
 
+// Hydrate the runtime config on the SSR side from process.env when the browser
+// asset script has not yet run (the asset only sets globalThis on the client).
+// Keeps single source of truth for feature flags between server and browser.
+if (
+  typeof globalThis !== 'undefined' &&
+  !globalThis.__KRAAK_RUNTIME_CONFIG__ &&
+  typeof process !== 'undefined' &&
+  process.env
+) {
+  const flag = process.env['CLIENT_FEATURE_PARTICIPANT_AREA'];
+  globalThis.__KRAAK_RUNTIME_CONFIG__ = Object.freeze({
+    enableParticipantArea: typeof flag === 'string' && flag.trim() === 'true',
+  });
+}
+
 const bootstrap = (context: BootstrapContext) =>
   bootstrapApplication(App, config, context);
 

--- a/docs/decisions/ARC-10-feature-flag-participant-area.md
+++ b/docs/decisions/ARC-10-feature-flag-participant-area.md
@@ -1,0 +1,117 @@
+# ARC-10 — Feature flag espace participant
+
+| Champ          | Valeur                      |
+| -------------- | --------------------------- |
+| **Statut**     | Acceptée                    |
+| **Date**       | 2026-05-01                  |
+| **Auteurs**    | Équipe KRAAK                |
+| **Dépendance** | ARC-08, ARC-09              |
+| **Liée à**     | ARC-01, ARC-07 ; issue #297 |
+
+---
+
+## 1 · Contexte
+
+Le MVP comporte deux surfaces fonctionnelles distinctes :
+
+1. **Site vitrine** (marketing) — accueil, à propos, services, programmes,
+   ressources, contact. Stable, prêt pour la production.
+2. **Espace participant** (authentifié) — connexion, inscription, mot de passe
+   oublié, dashboard. Encore en cours de stabilisation, dépend de Supabase Auth
+   et de parcours métier non finalisés.
+
+L'équipe souhaite **mettre en production le site vitrine immédiatement**, sans
+attendre la stabilisation de l'espace participant, tout en continuant à itérer
+sur ce dernier sur l'environnement de **staging** (cf. ARC-08).
+
+Les deux projets Vercel (`kraak-consulting` prod, `kraak-consulting-staging`)
+partagent **le même artefact de build** : la sélection ne peut donc pas se
+faire au build-time. Une bascule **runtime** est requise.
+
+---
+
+## 2 · Décision
+
+### 2.1 Mécanisme — feature flag runtime
+
+Un drapeau booléen `CLIENT_FEATURE_PARTICIPANT_AREA` est injecté à
+l'application Angular via `runtime-config.js` (généré par
+[`scripts/generate-client-runtime-config.mjs`](../../scripts/generate-client-runtime-config.mjs))
+et exposé sous la clé `enableParticipantArea` de
+`globalThis.__KRAAK_RUNTIME_CONFIG__`.
+
+L'accesseur typé [`isParticipantAreaEnabled()`](../../apps/client/projects/web/src/app/core/runtime/runtime-config.ts)
+encapsule la lecture et le défaut sécurisé `false`.
+
+### 2.2 Comportement quand le flag est `false` (défaut prod)
+
+| Surface                                                                        | Comportement                                                                    |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| Routes `/connexion`, `/inscription`, `/mot-de-passe-oublie`, `/participant/**` | Absentes du `Routes` array → wildcard `**` redirige vers `/` (HTTP 200, racine) |
+| Lien "Espace participant" dans la navbar                                       | Masqué (`@if (participantAreaEnabled)`)                                         |
+| Sitemap / SEO                                                                  | Inchangé — ces routes n'ont jamais été listées                                  |
+| API / Supabase                                                                 | Inchangées — pas de chemin atteignable côté UI                                  |
+
+### 2.3 Configuration par environnement
+
+| Environnement             | Projet Vercel              | Valeur du flag    |
+| ------------------------- | -------------------------- | ----------------- |
+| Production                | `kraak-consulting`         | `false`           |
+| Preview                   | `kraak-consulting`         | `false`           |
+| Staging (prod et preview) | `kraak-consulting-staging` | `true`            |
+| Local dev                 | `apps/client/.env`         | `true` recommandé |
+
+### 2.4 Implémentation
+
+- [`apps/client/projects/web/src/app/app.routes.ts`](../../apps/client/projects/web/src/app/app.routes.ts) :
+  factory `buildRoutes(participantAreaEnabled)` qui compose `marketingRoutes`
+  (toujours actives) avec `participantAreaRoutes` (gardées par le flag).
+- [`apps/client/projects/web/src/app/layouts/navbar/navbar.ts`](../../apps/client/projects/web/src/app/layouts/navbar/navbar.ts) :
+  champ `participantAreaEnabled` consommé par le template.
+- Tests unitaires (Vitest) : `runtime-config.spec.ts`, `app.routes.spec.ts`,
+  `navbar.spec.ts` couvrent les deux états du flag.
+
+---
+
+## 3 · Conséquences
+
+### 3.1 Positives
+
+- **Time-to-market** : la prod ne dépend plus de la maturité de l'espace
+  participant.
+- **Itération continue** : le staging conserve l'intégralité du parcours
+  authentifié.
+- **Réversibilité** : bascule en O(1) en modifiant la variable Vercel.
+
+### 3.2 Négatives / dette
+
+- Code participant compilé et présent dans le bundle prod (poids marginal,
+  non chargé car routes absentes — Angular tree-shake les composants jamais
+  référencés par les `loadComponent` non instanciés).
+- Surface de test démultipliée : chaque test concernant routes / navbar doit
+  exercer les deux états du flag.
+
+### 3.3 Sortie du drapeau
+
+Le flag est **temporaire**. Il sera retiré dès que :
+
+1. L'espace participant aura passé sa revue produit + sécurité (notamment
+   parcours auth, gestion du mot de passe, RLS Supabase).
+2. La décision sera tracée dans un nouvel ADR ou dans la fiche de release.
+
+La suppression consistera à : retirer le flag de `runtime-config`, dégrader
+`buildRoutes` en `routes` constant unique, retirer le `@if` dans la navbar,
+nettoyer les `.env*`, supprimer la variable Vercel sur les deux projets.
+
+---
+
+## 4 · Alternatives écartées
+
+- **Build conditionnel** (`environment.prod.ts`) : nécessiterait deux
+  artefacts distincts → casse l'identité staging/prod et complexifie ARC-09.
+- **Garde de route Angular** retournant `false` : laisserait les fichiers JS
+  participant chargés au premier match d'URL, et exigerait un `redirect` au
+  niveau du `CanMatchFn` → équivalent fonctionnel mais plus verbeux que
+  l'absence de route.
+- **Reverse proxy / réécriture Vercel** : externaliserait la logique produit
+  hors du code, plus difficile à tester unitairement.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -21,3 +21,4 @@ Ce répertoire centralise les décisions d'architecture formelles du projet KRAA
 | `ARC-07` | Stratégie de release production basée sur les tags   | Acceptée                                      | 2026-05-02 |
 | `ARC-08` | Environnement staging et branche longue `staging`    | Acceptée (partiellement remplacée par ARC-09) | 2026-05-03 |
 | `ARC-09` | Inversion `main` ↔ `staging` (staging = intégration) | Acceptée                                      | 2026-05-03 |
+| `ARC-10` | Feature flag espace participant                      | Acceptée                                      | 2026-05-01 |

--- a/scripts/generate-client-runtime-config.mjs
+++ b/scripts/generate-client-runtime-config.mjs
@@ -129,9 +129,15 @@ export function loadClientRuntimeConfig(
     fileVariables,
     processEnv,
   );
+  const enableParticipantArea =
+    readRuntimeVariable(
+      'CLIENT_FEATURE_PARTICIPANT_AREA',
+      fileVariables,
+      processEnv,
+    ) === 'true';
 
   if (!apiBaseUrl && (!supabaseUrl || !supabasePublishableKey)) {
-    return {};
+    return { enableParticipantArea };
   }
 
   return {
@@ -142,6 +148,7 @@ export function loadClientRuntimeConfig(
           supabasePublishableKey,
         }
       : {}),
+    enableParticipantArea,
   };
 }
 

--- a/scripts/generate-client-runtime-config.spec.mjs
+++ b/scripts/generate-client-runtime-config.spec.mjs
@@ -50,6 +50,7 @@ runTest(
         apiBaseUrl: 'http://localhost:3000',
         supabaseUrl: 'http://127.0.0.1:54321',
         supabasePublishableKey: 'local-publishable-key',
+        enableParticipantArea: false,
       });
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
@@ -80,6 +81,7 @@ runTest(
         supabaseUrl: 'https://qgttdsnupelohowwkkwb.supabase.co',
         supabasePublishableKey:
           'sb_publishable_5CKjUPh9rFkuUlwHyLIYpQ_c_plqe57',
+        enableParticipantArea: false,
       });
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
@@ -88,7 +90,7 @@ runTest(
 );
 
 runTest(
-  'le runtime client renvoie une configuration vide en production quand aucune variable publique n est fournie',
+  'le runtime client renvoie uniquement le flag participant en production quand aucune variable publique n est fournie',
   () => {
     const tempRoot = mkdtempSync(
       path.join(os.tmpdir(), 'kraak-client-runtime-config-'),
@@ -100,7 +102,7 @@ runTest(
         processEnv: {},
       });
 
-      assert.deepEqual(runtimeConfig, {});
+      assert.deepEqual(runtimeConfig, { enableParticipantArea: false });
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }
@@ -135,6 +137,7 @@ runTest(
         apiBaseUrl: 'https://api.kraak.example',
         supabaseUrl: 'https://kraak.supabase.co',
         supabasePublishableKey: 'production-publishable-key',
+        enableParticipantArea: false,
       });
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
@@ -174,6 +177,7 @@ runTest(
         apiBaseUrl: 'https://from-file.example',
         supabaseUrl: 'https://from-file.supabase.co',
         supabasePublishableKey: 'from-file-key',
+        enableParticipantArea: false,
       });
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
@@ -209,7 +213,93 @@ runTest(
         apiBaseUrl: 'https://quoted.example',
         supabaseUrl: 'https://quoted.supabase.co',
         supabasePublishableKey: 'line-1\nline-2',
+        enableParticipantArea: false,
       });
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+runTest(
+  'le runtime client expose enableParticipantArea quand CLIENT_FEATURE_PARTICIPANT_AREA vaut "true"',
+  () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), 'kraak-client-runtime-config-'),
+    );
+
+    try {
+      const envFilePath = path.join(tempRoot, '.env.staging');
+      writeFileSync(
+        envFilePath,
+        [
+          'CLIENT_API_BASE_URL=https://api.staging.example',
+          'SUPABASE_URL=https://staging.supabase.co',
+          'SUPABASE_PUBLISHABLE_KEY=staging-key',
+          'CLIENT_FEATURE_PARTICIPANT_AREA=true',
+          '',
+        ].join('\n'),
+      );
+
+      const runtimeConfig = loadClientRuntimeConfig('staging', {
+        clientRootPath: tempRoot,
+        processEnv: {},
+      });
+
+      assert.equal(runtimeConfig.enableParticipantArea, true);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+runTest(
+  'le runtime client expose enableParticipantArea=false par defaut quand la variable est absente',
+  () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), 'kraak-client-runtime-config-'),
+    );
+
+    try {
+      const envFilePath = path.join(tempRoot, '.env.prod');
+      writeFileSync(
+        envFilePath,
+        [
+          'CLIENT_API_BASE_URL=https://api.prod.example',
+          'SUPABASE_URL=https://prod.supabase.co',
+          'SUPABASE_PUBLISHABLE_KEY=prod-key',
+          '',
+        ].join('\n'),
+      );
+
+      const runtimeConfig = loadClientRuntimeConfig('production', {
+        clientRootPath: tempRoot,
+        processEnv: {},
+      });
+
+      assert.equal(runtimeConfig.enableParticipantArea, false);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+runTest(
+  'le runtime client expose enableParticipantArea=false quand la variable vaut une valeur autre que "true"',
+  () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), 'kraak-client-runtime-config-'),
+    );
+
+    try {
+      const runtimeConfig = loadClientRuntimeConfig('production', {
+        clientRootPath: tempRoot,
+        processEnv: {
+          CLIENT_FEATURE_PARTICIPANT_AREA: 'false',
+        },
+      });
+
+      assert.equal(runtimeConfig.enableParticipantArea, false);
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }
@@ -223,6 +313,7 @@ runTest(
       apiBaseUrl: 'https://api.example',
       supabaseUrl: 'https://supabase.example',
       supabasePublishableKey: 'public-key',
+      enableParticipantArea: false,
     });
 
     assert.equal(
@@ -232,7 +323,8 @@ runTest(
         '{',
         '  "apiBaseUrl": "https://api.example",',
         '  "supabaseUrl": "https://supabase.example",',
-        '  "supabasePublishableKey": "public-key"',
+        '  "supabasePublishableKey": "public-key",',
+        '  "enableParticipantArea": false',
         '}',
         ');',
         '',


### PR DESCRIPTION
Closes #297.

Hide the participant area in production via runtime feature flag `CLIENT_FEATURE_PARTICIPANT_AREA`. Marketing site ships immediately; participant area stays available on staging for ongoing iteration.

## Changes
- Runtime config helper `isParticipantAreaEnabled()` reading `globalThis.__KRAAK_RUNTIME_CONFIG__` (browser-pure, hydrated on SSR from `process.env`)
- `canMatch` guard `participantAreaCanMatch` on each participant route (`connexion`, `inscription`, `mot-de-passe-oublie`, `participant`) — reads flag per-navigation so module load order is irrelevant
- Wildcard fallback redirects unknown paths to `/` (acts as 404-equivalent when flag is off)
- Navbar CTA "Espace participant" hidden when flag is off
- Vercel env vars set: prod=`false`, staging=`true` (production/preview/development)
- Playwright `webServer.env` injects flag for e2e
- ADR `ARC-10-feature-flag-participant-area.md`

## Validation
- 27 unit test files / 111+ tests green
- 22 e2e green (chromium)
- Lint clean, format clean
- Pre-push hook full suite green