### PR TITLE
chore(infra): consolider en un seul projet Vercel

### DIFF
--- a/docs/decisions/ARC-09-inversion-main-staging.md
+++ b/docs/decisions/ARC-09-inversion-main-staging.md
@@ -75,17 +75,17 @@ non par l'UI GitHub) pour rester reproductible.
 
 #### `staging` (intégration)
 
-| Option                             |                      Valeur                       | Justification                                                        |
-| ---------------------------------- | :-----------------------------------------------: | -------------------------------------------------------------------- |
-| `lock_branch`                      |                      `false`                      | Branche d'écriture via PR.                                           |
-| `required_linear_history`          |                      `true`                       | Rebase only (cohérent avec ARC-02 résiduel).                         |
-| `allow_force_pushes`               |                      `false`                      | Préserve l'historique partagé.                                       |
-| `allow_deletions`                  |                      `false`                      | Branche permanente.                                                  |
-| `required_conversation_resolution` |                      `true`                       | Pas de merge avec discussion ouverte.                                |
-| `required_pull_request_reviews`    |                     0 review                      | Solo dev ; 1 review obligatoire dès qu'un second mainteneur rejoint. |
-| `enforce_admins`                   |                      `false`                      | Permet un override admin documenté en cas d'incident.                |
-| `required_status_checks.strict`    |                      `true`                       | La PR doit être à jour avec `staging`.                               |
-| `required_status_checks.contexts`  | CI complète + `Vercel – kraak-consulting-staging` | La staging Preview est obligatoire.                                  |
+| Option                             |                  Valeur                   | Justification                                                          |
+| ---------------------------------- | :---------------------------------------: | ---------------------------------------------------------------------- |
+| `lock_branch`                      |                  `false`                  | Branche d'écriture via PR.                                             |
+| `required_linear_history`          |                  `true`                   | Rebase only (cohérent avec ARC-02 résiduel).                           |
+| `allow_force_pushes`               |                  `false`                  | Préserve l'historique partagé.                                         |
+| `allow_deletions`                  |                  `false`                  | Branche permanente.                                                    |
+| `required_conversation_resolution` |                  `true`                   | Pas de merge avec discussion ouverte.                                  |
+| `required_pull_request_reviews`    |                 0 review                  | Solo dev ; 1 review obligatoire dès qu'un second mainteneur rejoint.   |
+| `enforce_admins`                   |                  `false`                  | Permet un override admin documenté en cas d'incident.                  |
+| `required_status_checks.strict`    |                  `true`                   | La PR doit être à jour avec `staging`.                                 |
+| `required_status_checks.contexts`  | CI complète + `Vercel – kraak-consulting` | La staging Preview est obligatoire (cf. ARC-11, projet Vercel unique). |
 
 #### `main` (release)
 

--- a/docs/decisions/ARC-10-feature-flag-participant-area.md
+++ b/docs/decisions/ARC-10-feature-flag-participant-area.md
@@ -24,7 +24,7 @@ L'équipe souhaite **mettre en production le site vitrine immédiatement**, sans
 attendre la stabilisation de l'espace participant, tout en continuant à itérer
 sur ce dernier sur l'environnement de **staging** (cf. ARC-08).
 
-Les deux projets Vercel (`kraak-consulting` prod, `kraak-consulting-staging`)
+Le projet Vercel unique `kraak-consulting` (cf. ARC-11)
 partagent **le même artefact de build** : la sélection ne peut donc pas se
 faire au build-time. Une bascule **runtime** est requise.
 
@@ -54,12 +54,17 @@ encapsule la lecture et le défaut sécurisé `false`.
 
 ### 2.3 Configuration par environnement
 
-| Environnement             | Projet Vercel              | Valeur du flag    |
-| ------------------------- | -------------------------- | ----------------- |
-| Production                | `kraak-consulting`         | `false`           |
-| Preview                   | `kraak-consulting`         | `false`           |
-| Staging (prod et preview) | `kraak-consulting-staging` | `true`            |
-| Local dev                 | `apps/client/.env`         | `true` recommandé |
+Toutes les valeurs sont configurées sur le projet Vercel unique
+`kraak-consulting` (cf. ARC-11), avec un override par branche pour le
+déploiement Preview de `staging` :
+
+| Environnement Vercel                 | `gitBranch` | Valeur du flag    |
+| ------------------------------------ | ----------- | ----------------- |
+| `production` (branche `main`)        | —           | `false`           |
+| `preview` (override branche staging) | `staging`   | `true`            |
+| `preview` (autres branches/PR)       | —           | `false`           |
+| `development` (`vercel dev`)         | —           | `true`            |
+| Local dev (`apps/client/.env`)       | —           | `true` recommandé |
 
 ### 2.4 Implémentation
 
@@ -101,7 +106,8 @@ Le flag est **temporaire**. Il sera retiré dès que :
 
 La suppression consistera à : retirer le flag de `runtime-config`, dégrader
 `buildRoutes` en `routes` constant unique, retirer le `@if` dans la navbar,
-nettoyer les `.env*`, supprimer la variable Vercel sur les deux projets.
+nettoyer les `.env*`, supprimer la variable Vercel (les 4 entrées du projet
+unique `kraak-consulting`).
 
 ---
 

--- a/docs/decisions/ARC-11-consolidation-vercel-projet-unique.md
+++ b/docs/decisions/ARC-11-consolidation-vercel-projet-unique.md
@@ -1,0 +1,150 @@
+# ARC-11 — Consolidation des projets Vercel en un seul projet
+
+- **Statut** : Acceptée
+- **Date** : 2026-05-03
+- **Remplace** : aspect "deux projets Vercel" d'ARC-08 et ARC-09
+- **Lié** : ARC-07 (release prod tag-based), ARC-10 (feature flag espace participant)
+
+---
+
+## 1 · Contexte
+
+Jusqu'ici, deux projets Vercel coexistaient pour ce dépôt :
+
+| Projet                     | Branche prod | Rôle                         |
+| -------------------------- | ------------ | ---------------------------- |
+| `kraak-consulting`         | `main`       | Production (déploy CLI prod) |
+| `kraak-consulting-staging` | `staging`    | Staging auto-deploy sur push |
+
+Cette duplication a été motivée historiquement par le besoin d'environnements
+strictement isolés. À l'usage, elle apporte plus de coût opérationnel que de
+valeur :
+
+- duplication des variables d'environnement (rebascule manuelle à chaque ajout) ;
+- deux dashboards à surveiller pour un site vitrine MVP ;
+- deux URLs `*.vercel.app` à maintenir et documenter ;
+- deux check GitHub à câbler dans les protections de branche ;
+- aucun besoin réel d'isolation totale (pas de cron, pas d'ISR avancée, pas de
+  quota séparé requis pour un MVP).
+
+Le modèle natif Vercel **un projet = un repo, plusieurs environnements**
+suffit largement pour notre cible. Les variables d'environnement Vercel
+supportent un override **par branche Git** (champ `gitBranch`), ce qui permet
+d'injecter des valeurs propres au déploiement Preview de la branche `staging`
+sans dupliquer le projet.
+
+---
+
+## 2 · Décision
+
+### 2.1 Modèle cible
+
+- **Un seul projet Vercel** : `kraak-consulting`.
+- Branche de production : `main`. Aucune auto-deploy : la prod passe
+  exclusivement par `release-prod.yml` (`vercel deploy --prebuilt --prod`),
+  conformément à ARC-07.
+- Branche `staging` : auto-déploiement Preview à chaque push. C'est l'URL de
+  référence pour la recette interne.
+- Toutes les autres branches (PR, `feat/*`, etc.) : **pas** d'auto-deploy
+  (économie de quota et de bruit). Géré via `ignoreCommand` dans `vercel.json`.
+
+### 2.2 Variables d'environnement
+
+Pour chaque variable nécessitant une valeur différente entre prod et staging,
+on crée trois entrées sur le projet `kraak-consulting` :
+
+| Cible (`target`) | `gitBranch` | Rôle                             |
+| ---------------- | ----------- | -------------------------------- |
+| `production`     | (vide)      | Valeur prod                      |
+| `preview`        | `staging`   | Valeur staging (override branch) |
+| `preview`        | (vide)      | Valeur fallback PR / branches    |
+| `development`    | (vide)      | Valeur `vercel dev` local        |
+
+Exemple `CLIENT_FEATURE_PARTICIPANT_AREA` :
+
+| Cible         | `gitBranch` | Valeur  |
+| ------------- | ----------- | ------- |
+| `production`  | —           | `false` |
+| `preview`     | `staging`   | `true`  |
+| `preview`     | —           | `false` |
+| `development` | —           | `true`  |
+
+### 2.3 `ignoreCommand`
+
+```jsonc
+"ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in staging) exit 1 ;; *) exit 0 ;; esac"
+```
+
+- Sur push `staging` → `exit 1` → Vercel construit (Preview).
+- Sur push `main` → `exit 0` → Vercel ignore. La prod est déclenchée par CI
+  via `vercel deploy --prebuilt --prod`.
+- Sur toute autre ref → `exit 0` → Vercel ignore.
+
+### 2.4 Check GitHub
+
+- Le check `Vercel – kraak-consulting-staging` n'existe plus.
+- Le check requis sur les PR vers `staging` devient `Vercel – kraak-consulting`
+  (Preview de la branche source de la PR).
+- Aucun check Vercel n'est requis sur les PR vers `main` (ARC-07 / ARC-09).
+
+### 2.5 Domaines
+
+- `kraak-consulting.vercel.app` : URL prod historique conservée.
+- `kraak-consulting-git-staging-<scope>.vercel.app` : URL stable auto-générée
+  par Vercel pour la branche `staging`. Remplace
+  `kraak-consulting-staging.vercel.app`.
+- Domaines custom à venir : associés au projet unique, par environnement.
+
+---
+
+## 3 · Conséquences
+
+### 3.1 Positives
+
+- Une seule source de vérité Vercel pour les variables d'environnement.
+- Suppression de la duplication des dashboards, secrets et configurations.
+- Modèle natif Vercel respecté → meilleure compatibilité avec les évolutions
+  futures (Analytics, Speed Insights, Image Optimization).
+- Réduction du nombre de projets soumis à quota gratuit.
+
+### 3.2 Négatives / dette
+
+- L'URL stable de staging change : passage de `kraak-consulting-staging.vercel.app`
+  à `kraak-consulting-git-staging-*.vercel.app`. Documenter et mettre à jour
+  les références (runbooks, e2e, communications internes).
+- Le check GitHub change de nom : nécessite mise à jour des règles de
+  protection de branche `staging` (manuelle dans GitHub Settings ou via
+  `scripts/github/update-branch-protection.mjs`).
+
+### 3.3 Sortie
+
+- Cette décision est définitive tant que le MVP reste un site vitrine
+  Angular sans besoin d'environnements totalement isolés (cron, quotas
+  séparés, comptes facturation distincts). En cas de bascule vers une
+  plateforme nécessitant cette isolation, créer un nouvel ADR.
+
+---
+
+## 4 · Alternatives écartées
+
+- **Statu quo (deux projets)** : duplication permanente et sources d'erreur
+  pour un gain d'isolation que le MVP n'exploite pas.
+- **Trois projets ou plus (par feature env)** : sur-ingénierie, hors périmètre
+  MVP.
+- **Un projet sans `ignoreCommand`** : Vercel auto-déployerait toutes les
+  branches → coût et bruit inutiles, et créerait une race condition possible
+  avec le déploiement prod CLI sur `main`.
+
+---
+
+## 5 · Migration appliquée
+
+1. Variables `CLIENT_FEATURE_PARTICIPANT_AREA` reconfigurées sur
+   `kraak-consulting` selon le tableau §2.2.
+2. `vercel.json` : `ignoreCommand` mis à jour (§2.3).
+3. ARC-09 (§2.3 staging) et ARC-10 (§2.3 configuration par environnement) mis
+   à jour pour refléter le projet unique.
+4. `scripts/github/update-branch-protection.mjs` : check
+   `Vercel – kraak-consulting-staging` retiré, remplacé par
+   `Vercel – kraak-consulting`.
+5. Projet `kraak-consulting-staging` supprimé via API Vercel.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -20,5 +20,7 @@ Ce répertoire centralise les décisions d'architecture formelles du projet KRAA
 | `ARC-06` | Gating natif notifications push mobile sur Firebase  | Acceptée                                      | 2026-04-10 |
 | `ARC-07` | Stratégie de release production basée sur les tags   | Acceptée                                      | 2026-05-02 |
 | `ARC-08` | Environnement staging et branche longue `staging`    | Acceptée (partiellement remplacée par ARC-09) | 2026-05-03 |
-| `ARC-09` | Inversion `main` ↔ `staging` (staging = intégration) | Acceptée                                      | 2026-05-03 |
+| `ARC-09` | Inversion `main` ↔ `staging` (staging = intégration) | Acceptée (partiellement remplacée par ARC-11) | 2026-05-03 |
+| `ARC-10` | Feature flag `CLIENT_FEATURE_PARTICIPANT_AREA`       | Acceptée                                      | 2026-05-03 |
+| `ARC-11` | Consolidation des projets Vercel en un seul projet   | Acceptée                                      | 2026-05-03 |
 | `ARC-10` | Feature flag espace participant                      | Acceptée                                      | 2026-05-01 |

--- a/scripts/github/update-branch-protection.mjs
+++ b/scripts/github/update-branch-protection.mjs
@@ -58,7 +58,7 @@ const COMMON_CHECKS_STAGING = [
   "Tests unitaires",
   "Tests E2E",
   "Android Debug APK",
-  "Vercel – kraak-consulting-staging",
+  "Vercel – kraak-consulting",
 ];
 
 const COMMON_CHECKS_MAIN = [

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,5 @@
   "buildCommand": "pnpm -r --filter \"./packages/**\" build && pnpm --filter @kraak/client run build",
   "outputDirectory": "apps/client/dist/web/browser",
   "framework": null,
-  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in staging) exit 1 ;; *) exit 0 ;; esac"
 }


### PR DESCRIPTION
Migration vers le projet unique `kraak-consulting`.

## Changements
- Variables Vercel reconfigurées (`CLIENT_FEATURE_PARTICIPANT_AREA`) avec override `gitBranch=staging` sur la cible `preview` (= `true` uniquement sur staging, `false` partout ailleurs).
- `vercel.json`: `ignoreCommand` limite l'auto-deploy à la branche `staging` (la prod reste tag-based via `vercel deploy --prebuilt --prod`).
- ADR `ARC-11` créé ; `ARC-09`, `ARC-10`, README ADR mis à jour.
- `scripts/github/update-branch-protection.mjs`: check renommé en `Vercel – kraak-consulting`.

## Étapes restantes après merge
1. Vérifier que le déploiement Preview de `staging` fonctionne sur le projet `kraak-consulting`.
2. Mettre à jour la règle de protection de branche `staging` (check Vercel renommé) via le script.
3. Supprimer le projet `kraak-consulting-staging` via API Vercel.

## Réf
- Voir `docs/decisions/ARC-11-consolidation-vercel-projet-unique.md`.