### PR TITLE
ci(infra): bump Vercel CLI to 53.1.0 for Node 22 support

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -27,7 +27,7 @@ env:
   # Versions CLI épinglées : reproductibilité de la release et des rollbacks.
   # Toute mise à jour doit faire l'objet d'une PR dédiée.
   SUPABASE_CLI_VERSION: '1.200.3'
-  VERCEL_CLI_VERSION: '37.14.0'
+  VERCEL_CLI_VERSION: '53.1.0'
 
 jobs:
   # ──────────────────────────────────────────────


### PR DESCRIPTION
Le job `Déployer web (Vercel prod)` a échoué sur le tag v0.1.0 :

```
Error: Found invalid Node.js Version: ">=22.0.0". Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.
```

La CLI `37.14.0` (fin 2024) ne reconnaît pas Node 22. Le repo exige `engines.node >= 22.0.0`. Bump vers `53.1.0` (dernière stable) pour débloquer la release prod.