### PR TITLE
fix(contact): corriger le 405 — utiliser resolveApiBaseUrl depuis le runtime config

### DIFF
--- a/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
+++ b/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
@@ -20,6 +20,7 @@ import type {
   UserRoleValue,
 } from '@kraak/contracts';
 import { environment } from '../../../environments/environment';
+import { resolveApiBaseUrl } from '../runtime/runtime-config';
 
 export const WEB_AUTH_STORAGE_KEY = 'kraak.web.session';
 
@@ -32,7 +33,7 @@ export class WebAuthService {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly restoredBundle = this.readStoredBundle();
   private readonly client = createApiClient({
-    baseUrl: environment.apiBaseUrl,
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
     getAuthToken: () => this.currentSession()?.accessToken ?? null,
   });
   private readonly sessionState = signal<AuthSessionTokensDto | null>(
@@ -57,161 +58,3 @@ export class WebAuthService {
     const role = this.currentRole();
     return role !== null && roles.includes(role);
   }
-
-  async signIn(body: SignInRequestDto): Promise<AuthSessionBundleDto> {
-    const bundle = await this.client.auth.signIn(body);
-    this.storeBundle(bundle);
-    return bundle;
-  }
-
-  async signUp(body: SignUpRequestDto): Promise<SignUpResponseDto> {
-    const response = await this.client.auth.signUp(body);
-
-    if (response.session && response.profile) {
-      this.storeBundle({
-        session: response.session,
-        profile: response.profile,
-      });
-    }
-
-    return response;
-  }
-
-  async refreshSession(): Promise<AuthSessionBundleDto | null> {
-    const session = this.currentSession();
-
-    if (!session) {
-      return null;
-    }
-
-    const bundle = await this.client.auth.refreshSession({
-      refreshToken: session.refreshToken,
-    });
-
-    this.storeBundle(bundle);
-    return bundle;
-  }
-
-  async requestPasswordReset(
-    body: PasswordResetRequestDto,
-  ): Promise<PasswordResetResponseDto> {
-    return this.client.auth.requestPasswordReset(body);
-  }
-
-  async getSession(): Promise<AuthSessionContextDto | null> {
-    if (!this.currentSession()) {
-      return null;
-    }
-
-    const context = await this.client.auth.getSession();
-    this.profileState.set(context.profile);
-    this.persistBundle();
-
-    return context;
-  }
-
-  clearSession(): void {
-    this.sessionState.set(null);
-    this.profileState.set(null);
-    this.getStorage()?.removeItem(WEB_AUTH_STORAGE_KEY);
-  }
-
-  private storeBundle(bundle: AuthSessionBundleDto): void {
-    this.sessionState.set(bundle.session);
-    this.profileState.set(bundle.profile);
-    this.persistBundle();
-  }
-
-  private persistBundle(): void {
-    const storage = this.getStorage();
-    const session = this.currentSession();
-    const profile = this.currentProfile();
-
-    if (!session || !profile) {
-      storage?.removeItem(WEB_AUTH_STORAGE_KEY);
-      return;
-    }
-
-    storage?.setItem(
-      WEB_AUTH_STORAGE_KEY,
-      JSON.stringify({ session, profile }),
-    );
-  }
-
-  private readStoredBundle(): AuthSessionBundleDto | null {
-    const storage = this.getStorage();
-    const rawValue = storage?.getItem(WEB_AUTH_STORAGE_KEY) ?? null;
-
-    if (!rawValue) {
-      return null;
-    }
-
-    try {
-      const parsedValue = JSON.parse(rawValue) as AuthSessionBundleDto;
-
-      if (
-        !parsedValue.session?.accessToken ||
-        !parsedValue.session?.refreshToken ||
-        !parsedValue.profile?.appUser?.id
-      ) {
-        storage?.removeItem(WEB_AUTH_STORAGE_KEY);
-        return null;
-      }
-
-      return parsedValue;
-    } catch {
-      storage?.removeItem(WEB_AUTH_STORAGE_KEY);
-      return null;
-    }
-  }
-
-  private getStorage(): Storage | null {
-    if (!isPlatformBrowser(this.platformId)) {
-      return null;
-    }
-
-    try {
-      return localStorage;
-    } catch {
-      return null;
-    }
-  }
-}
-
-export function resolveAuthErrorMessage(
-  error: unknown,
-  fallbackMessage: string,
-): string {
-  if (error instanceof ApiError && isObjectRecord(error.body)) {
-    const body = error.body;
-
-    if (
-      'message' in body &&
-      typeof body['message'] === 'string' &&
-      body['message'].trim().length > 0
-    ) {
-      return body['message'];
-    }
-
-    if ('errors' in body && Array.isArray(body['errors'])) {
-      const firstError = body['errors'].find(
-        (value: unknown): value is string =>
-          typeof value === 'string' && value.trim().length > 0,
-      );
-
-      if (firstError) {
-        return firstError;
-      }
-    }
-  }
-
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-
-  return fallbackMessage;
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
+++ b/apps/client/projects/web/src/app/core/auth/web-auth.service.ts
@@ -58,3 +58,161 @@ export class WebAuthService {
     const role = this.currentRole();
     return role !== null && roles.includes(role);
   }
+
+  async signIn(body: SignInRequestDto): Promise<AuthSessionBundleDto> {
+    const bundle = await this.client.auth.signIn(body);
+    this.storeBundle(bundle);
+    return bundle;
+  }
+
+  async signUp(body: SignUpRequestDto): Promise<SignUpResponseDto> {
+    const response = await this.client.auth.signUp(body);
+
+    if (response.session && response.profile) {
+      this.storeBundle({
+        session: response.session,
+        profile: response.profile,
+      });
+    }
+
+    return response;
+  }
+
+  async refreshSession(): Promise<AuthSessionBundleDto | null> {
+    const session = this.currentSession();
+
+    if (!session) {
+      return null;
+    }
+
+    const bundle = await this.client.auth.refreshSession({
+      refreshToken: session.refreshToken,
+    });
+
+    this.storeBundle(bundle);
+    return bundle;
+  }
+
+  async requestPasswordReset(
+    body: PasswordResetRequestDto,
+  ): Promise<PasswordResetResponseDto> {
+    return this.client.auth.requestPasswordReset(body);
+  }
+
+  async getSession(): Promise<AuthSessionContextDto | null> {
+    if (!this.currentSession()) {
+      return null;
+    }
+
+    const context = await this.client.auth.getSession();
+    this.profileState.set(context.profile);
+    this.persistBundle();
+
+    return context;
+  }
+
+  clearSession(): void {
+    this.sessionState.set(null);
+    this.profileState.set(null);
+    this.getStorage()?.removeItem(WEB_AUTH_STORAGE_KEY);
+  }
+
+  private storeBundle(bundle: AuthSessionBundleDto): void {
+    this.sessionState.set(bundle.session);
+    this.profileState.set(bundle.profile);
+    this.persistBundle();
+  }
+
+  private persistBundle(): void {
+    const storage = this.getStorage();
+    const session = this.currentSession();
+    const profile = this.currentProfile();
+
+    if (!session || !profile) {
+      storage?.removeItem(WEB_AUTH_STORAGE_KEY);
+      return;
+    }
+
+    storage?.setItem(
+      WEB_AUTH_STORAGE_KEY,
+      JSON.stringify({ session, profile }),
+    );
+  }
+
+  private readStoredBundle(): AuthSessionBundleDto | null {
+    const storage = this.getStorage();
+    const rawValue = storage?.getItem(WEB_AUTH_STORAGE_KEY) ?? null;
+
+    if (!rawValue) {
+      return null;
+    }
+
+    try {
+      const parsedValue = JSON.parse(rawValue) as AuthSessionBundleDto;
+
+      if (
+        !parsedValue.session?.accessToken ||
+        !parsedValue.session?.refreshToken ||
+        !parsedValue.profile?.appUser?.id
+      ) {
+        storage?.removeItem(WEB_AUTH_STORAGE_KEY);
+        return null;
+      }
+
+      return parsedValue;
+    } catch {
+      storage?.removeItem(WEB_AUTH_STORAGE_KEY);
+      return null;
+    }
+  }
+
+  private getStorage(): Storage | null {
+    if (!isPlatformBrowser(this.platformId)) {
+      return null;
+    }
+
+    try {
+      return localStorage;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function resolveAuthErrorMessage(
+  error: unknown,
+  fallbackMessage: string,
+): string {
+  if (error instanceof ApiError && isObjectRecord(error.body)) {
+    const body = error.body;
+
+    if (
+      'message' in body &&
+      typeof body['message'] === 'string' &&
+      body['message'].trim().length > 0
+    ) {
+      return body['message'];
+    }
+
+    if ('errors' in body && Array.isArray(body['errors'])) {
+      const firstError = body['errors'].find(
+        (value: unknown): value is string =>
+          typeof value === 'string' && value.trim().length > 0,
+      );
+
+      if (firstError) {
+        return firstError;
+      }
+    }
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.spec.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.spec.ts
@@ -1,4 +1,8 @@
-import { getRuntimeConfig, isParticipantAreaEnabled } from './runtime-config';
+import {
+  getRuntimeConfig,
+  isParticipantAreaEnabled,
+  resolveApiBaseUrl,
+} from './runtime-config';
 
 describe('Runtime config helpers', () => {
   const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
@@ -33,6 +37,31 @@ describe('Runtime config helpers', () => {
 
       globalThis.__KRAAK_RUNTIME_CONFIG__ = {};
       expect(isParticipantAreaEnabled()).toBe(false);
+    });
+  });
+
+  describe('Given the runtime config exposes apiBaseUrl', () => {
+    it('When resolveApiBaseUrl is called Then it returns the runtime value without trailing slash', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = {
+        apiBaseUrl: 'https://api.kraak.example/',
+      };
+      expect(resolveApiBaseUrl('https://fallback.example')).toBe(
+        'https://api.kraak.example',
+      );
+    });
+  });
+
+  describe('Given the runtime config has no apiBaseUrl', () => {
+    it('When resolveApiBaseUrl is called Then it returns the fallback value', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+      expect(resolveApiBaseUrl('https://fallback.example/')).toBe(
+        'https://fallback.example',
+      );
+    });
+
+    it('When resolveApiBaseUrl is called without fallback Then it returns an empty string', () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      expect(resolveApiBaseUrl()).toBe('');
     });
   });
 });

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
@@ -16,3 +16,13 @@ export function getRuntimeConfig(): KraakRuntimeConfig {
 export function isParticipantAreaEnabled(): boolean {
   return getRuntimeConfig().enableParticipantArea === true;
 }
+
+export function resolveApiBaseUrl(fallback = ''): string {
+  const runtimeApiBaseUrl = getRuntimeConfig().apiBaseUrl?.trim();
+
+  if (runtimeApiBaseUrl) {
+    return runtimeApiBaseUrl.replace(/\/+$/u, '');
+  }
+
+  return fallback.replace(/\/+$/u, '');
+}

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
@@ -17,12 +17,22 @@ export function isParticipantAreaEnabled(): boolean {
   return getRuntimeConfig().enableParticipantArea === true;
 }
 
+function stripTrailingSlashes(value: string): string {
+  let endIndex = value.length;
+
+  while (endIndex > 0 && value.codePointAt(endIndex - 1) === 47) {
+    endIndex -= 1;
+  }
+
+  return value.slice(0, endIndex);
+}
+
 export function resolveApiBaseUrl(fallback = ''): string {
   const runtimeApiBaseUrl = getRuntimeConfig().apiBaseUrl?.trim();
 
   if (runtimeApiBaseUrl) {
-    return runtimeApiBaseUrl.replace(/\/+$/u, '');
+    return stripTrailingSlashes(runtimeApiBaseUrl);
   }
 
-  return fallback.replace(/\/+$/u, '');
+  return stripTrailingSlashes(fallback);
 }

--- a/apps/client/projects/web/src/app/features/contact/contact.service.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.service.ts
@@ -3,6 +3,7 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import type { ContactFormDto } from '@kraak/contracts';
 
+import { resolveApiBaseUrl } from '../../core/runtime/runtime-config';
 import { environment } from '../../../environments/environment';
 
 export type ContactPayload = ContactFormDto;
@@ -15,7 +16,7 @@ export interface ContactResponse {
 @Injectable({ providedIn: 'root' })
 export class ContactService {
   private readonly http = inject(HttpClient);
-  private readonly endpoint = `${environment.apiBaseUrl}/contact`;
+  private readonly endpoint = `${resolveApiBaseUrl(environment.apiBaseUrl)}/contact`;
 
   submit(payload: ContactPayload): Observable<ContactResponse> {
     return this.http.post<ContactResponse>(this.endpoint, payload);

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
@@ -6,6 +6,7 @@ import type { DashboardAggregateDto } from '@kraak/contracts';
 import { loadDashboardAggregate } from '@kraak/domain';
 
 import { environment } from '../../../../environments/environment';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
 import { WebAuthService } from '../../../core/auth/web-auth.service';
 
 interface DashboardQuickLink {
@@ -45,7 +46,7 @@ export default class DashboardPage implements OnInit {
   private readonly authService = inject(WebAuthService);
   protected dashboardClient: Pick<ApiClient['dashboard'], 'getAggregate'> =
     createApiClient({
-      baseUrl: environment.apiBaseUrl,
+      baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
       getAuthToken: () =>
         this.authService.currentSession()?.accessToken ?? null,
     }).dashboard;

--- a/scripts/setup-android-env.mjs
+++ b/scripts/setup-android-env.mjs
@@ -14,10 +14,10 @@
  *   node scripts/setup-android-env.mjs --run "pnpm build:debug:android"
  */
 
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
-import os from 'os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import os from 'node:os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isWindows = os.platform() === 'win32';
@@ -26,20 +26,16 @@ const runCommand = process.argv[process.argv.indexOf('--run') + 1];
 
 // Configure paths
 const javaHome = isWindows
-  ? 'C:\\Program Files\\Java\\jdk-21'
+  ? String.raw`C:\Program Files\Java\jdk-21`
   : process.env.JAVA_HOME || '/usr/lib/jvm/java-21-openjdk';
 
 const androidHome = isWindows
-  ? 'C:\\Users\\USER\\AppData\\Local\\Android\\Sdk'
+  ? String.raw`C:\Users\USER\AppData\Local\Android\Sdk`
   : process.env.ANDROID_HOME || `${process.env.HOME}/Android/Sdk`;
 
 // Check if paths exist
-try {
-  // We won't throw here, just set them anyway
-  // The build system will fail with clear messaging if paths don't exist
-} catch (e) {
-  // Silently continue
-}
+// We won't throw here, just set them anyway
+// The build system will fail with clear messaging if paths don't exist
 
 // Output shell-compatible export statements
 if (isShell || !runCommand) {
@@ -66,7 +62,9 @@ if (isShell || !runCommand) {
 } else if (runCommand) {
   // Validate that runCommand is a non-empty string before execution
   if (typeof runCommand !== 'string' || runCommand.trim().length === 0) {
-    console.error('[android-env] Error: --run requires a non-empty command string.');
+    console.error(
+      '[android-env] Error: --run requires a non-empty command string.',
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
## Problème

En production (`kraak-consulting.vercel.app`), le clic sur **Envoyer une demande** déclenchait :

```
POST https://kraak-consulting.vercel.app/contact  405 Method Not Allowed
```

Le formulaire postait vers une URL relative (`/contact`) sur le domaine Vercel (site statique) au lieu de l'API NestJS hébergée sur Render.

### Cause racine

1. `environment.production.ts` a `apiBaseUrl: ''`.
2. `ContactService` (et `WebAuthService`, `DashboardPage`) construisaient leur endpoint directement depuis `environment.apiBaseUrl` **sans** consommer le `runtime-config.js` généré au build.
3. Le runtime déployé confirmait l'absence d'`apiBaseUrl` dans `__KRAAK_RUNTIME_CONFIG__` :
   ```js
   globalThis.__KRAAK_RUNTIME_CONFIG__ = Object.freeze({ "enableParticipantArea": false });
   ```

---

## Solution

### `runtime-config.ts` — nouveau helper `resolveApiBaseUrl`

Priorise `globalThis.__KRAAK_RUNTIME_CONFIG__.apiBaseUrl` (injecté au build depuis `CLIENT_API_BASE_URL`) puis retombe sur la valeur compilée. Nettoie les barres obliques finales.

```ts
export function resolveApiBaseUrl(fallback = ''): string {
  const runtimeApiBaseUrl = getRuntimeConfig().apiBaseUrl?.trim();
  if (runtimeApiBaseUrl) return runtimeApiBaseUrl.replace(/\/+$/u, '');
  return fallback.replace(/\/+$/u, '');
}
```

### Services mis à jour

| Fichier | Avant | Après |
|---|---|---|
| `contact.service.ts` | `environment.apiBaseUrl` | `resolveApiBaseUrl(environment.apiBaseUrl)` |
| `web-auth.service.ts` | `environment.apiBaseUrl` | `resolveApiBaseUrl(environment.apiBaseUrl)` |
| `dashboard.page.ts` | `environment.apiBaseUrl` | `resolveApiBaseUrl(environment.apiBaseUrl)` |

### Tests

`runtime-config.spec.ts` : 3 nouveaux scénarios `Given/When/Then` couvrant `resolveApiBaseUrl`.
- 7/7 tests verts, **100 % de couverture** sur `runtime-config.ts`.

---

## Action restante côté Vercel (hors code — obligatoire)

> Le fix code corrige la **lecture** du runtime config. La variable doit aussi être **fournie** au build.

Dans le projet Vercel `kraak-consulting`, ajouter en **Production** :

```
CLIENT_API_BASE_URL = https://kraak-api-prod.onrender.com
```

Puis redéployer pour régénérer `assets/runtime-config.js`.

Côté Render (`kraak-api-prod`), vérifier :
- `CORS_ALLOWED_ORIGINS` inclut `https://kraak-consulting.vercel.app`
- `RESEND_API_KEY`, `CONTACT_FROM_EMAIL`, `CONTACT_TO_EMAIL` sont renseignés

---

## Validation

- [x] `runtime-config.spec.ts` — 7/7 verts, 100 % couverture
- [x] `contact.page.spec.ts` — 10/10 verts
- [x] Aucune erreur TypeScript

Closes #305