### PR TITLE
fix(scripts): remove shell execution from setup-android-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:api:staging": "pnpm --filter @kraak/api run start:staging",
     "build:api": "pnpm --filter @kraak/api build",
     "check:observability": "node ./scripts/check-observability.mjs",
-    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs",
+    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/setup-android-env.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs",
     "test:api": "pnpm --filter @kraak/api test",
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
     "test:coverage": "pnpm --filter @kraak/api test:cov && pnpm --filter @kraak/client test:coverage && pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test:coverage",

--- a/scripts/setup-android-env.mjs
+++ b/scripts/setup-android-env.mjs
@@ -16,13 +16,11 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isWindows = os.platform() === 'win32';
-const isShell = process.argv.includes('--shell');
-const runCommand = process.argv[process.argv.indexOf('--run') + 1];
 
 // Configure paths
 const javaHome = isWindows
@@ -33,61 +31,169 @@ const androidHome = isWindows
   ? String.raw`C:\Users\USER\AppData\Local\Android\Sdk`
   : process.env.ANDROID_HOME || `${process.env.HOME}/Android/Sdk`;
 
-// Check if paths exist
-// We won't throw here, just set them anyway
-// The build system will fail with clear messaging if paths don't exist
+function splitCommandTokens(input) {
+  const tokens = [];
+  let current = '';
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let escaped = false;
 
-// Output shell-compatible export statements
-if (isShell || !runCommand) {
-  if (isWindows && !isShell) {
-    // PowerShell format
-    console.log(`$env:JAVA_HOME='${javaHome}'`);
-    console.log(`$env:ANDROID_HOME='${androidHome}'`);
-    console.log(`$env:ANDROID_SDK_ROOT='${androidHome}'`);
-  } else {
-    // Bash/Zsh format
-    console.log(`export JAVA_HOME='${javaHome}'`);
-    console.log(`export ANDROID_HOME='${androidHome}'`);
-    console.log(`export ANDROID_SDK_ROOT='${androidHome}'`);
-    if (!isWindows) {
-      console.log(`export PATH="$JAVA_HOME/bin:$PATH"`);
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
     }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (!inSingleQuote && !inDoubleQuote && /\s/u.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
   }
 
-  console.error('[android-env] Environment variables set:', {
+  if (escaped || inSingleQuote || inDoubleQuote) {
+    throw new Error(
+      '[android-env] Error: commande invalide. Vérifiez les guillemets et échappements.',
+    );
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+export function parseRunCommand(input) {
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    throw new Error(
+      '[android-env] Error: --run requires a non-empty command string.',
+    );
+  }
+
+  const [command, ...args] = splitCommandTokens(input.trim());
+
+  if (!command) {
+    throw new Error(
+      '[android-env] Error: --run requires a non-empty command string.',
+    );
+  }
+
+  return { args, command };
+}
+
+function runWithoutShell(command, args, env) {
+  let result = spawnSync(command, args, {
+    env,
+    shell: false,
+    stdio: 'inherit',
+  });
+
+  if (
+    isWindows &&
+    result.error?.code === 'ENOENT' &&
+    !path.extname(command)
+  ) {
+    result = spawnSync(`${command}.cmd`, args, {
+      env,
+      shell: false,
+      stdio: 'inherit',
+    });
+  }
+
+  return result;
+}
+
+export function runCommandWithAndroidEnv(
+  commandInput,
+  {
+    environmentSource = process.env,
+    exit = process.exit,
+    runProcess = runWithoutShell,
+  } = {},
+) {
+  const { args, command } = parseRunCommand(commandInput);
+  const env = {
+    ...environmentSource,
     JAVA_HOME: javaHome,
     ANDROID_HOME: androidHome,
     ANDROID_SDK_ROOT: androidHome,
-  });
-} else if (runCommand) {
-  // Validate that runCommand is a non-empty string before execution
-  if (typeof runCommand !== 'string' || runCommand.trim().length === 0) {
-    console.error(
-      '[android-env] Error: --run requires a non-empty command string.',
-    );
-    process.exit(1);
+  };
+
+  if (!isWindows) {
+    env.PATH = `${javaHome}/bin:${env.PATH}`;
   }
 
-  // Run the command with environment variables set
-  try {
-    const env = {
-      ...process.env,
+  console.error(`[android-env] Running: ${command} ${args.join(' ')}`.trim());
+
+  const result = runProcess(command, args, env);
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    exit(result.status ?? 1);
+  }
+}
+
+export function setupAndroidEnvFromCli(argv = process.argv.slice(2)) {
+  const isShell = argv.includes('--shell');
+  const runFlagIndex = argv.indexOf('--run');
+  const runCommand = runFlagIndex >= 0 ? argv[runFlagIndex + 1] : undefined;
+
+  if (isShell || !runCommand) {
+    if (isWindows && !isShell) {
+      // PowerShell format
+      console.log(`$env:JAVA_HOME='${javaHome}'`);
+      console.log(`$env:ANDROID_HOME='${androidHome}'`);
+      console.log(`$env:ANDROID_SDK_ROOT='${androidHome}'`);
+    } else {
+      // Bash/Zsh format
+      console.log(`export JAVA_HOME='${javaHome}'`);
+      console.log(`export ANDROID_HOME='${androidHome}'`);
+      console.log(`export ANDROID_SDK_ROOT='${androidHome}'`);
+      if (!isWindows) {
+        console.log(`export PATH="$JAVA_HOME/bin:$PATH"`);
+      }
+    }
+
+    console.error('[android-env] Environment variables set:', {
       JAVA_HOME: javaHome,
       ANDROID_HOME: androidHome,
       ANDROID_SDK_ROOT: androidHome,
-    };
-
-    if (!isWindows) {
-      env.PATH = `${javaHome}/bin:${env.PATH}`;
-    }
-
-    console.error(`[android-env] Running: ${runCommand}`);
-    execSync(runCommand, {
-      env,
-      stdio: 'inherit',
-      shell: true,
     });
+    return;
+  }
+
+  runCommandWithAndroidEnv(runCommand);
+}
+
+if (path.resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  try {
+    setupAndroidEnvFromCli();
   } catch (error) {
-    process.exit(error.status || 1);
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(error?.status || 1);
   }
 }

--- a/scripts/setup-android-env.test.mjs
+++ b/scripts/setup-android-env.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  parseRunCommand,
+  runCommandWithAndroidEnv,
+} from './setup-android-env.mjs';
+
+test('parseRunCommand extrait la commande et les arguments', () => {
+  assert.deepEqual(parseRunCommand('pnpm build:debug:android'), {
+    args: ['build:debug:android'],
+    command: 'pnpm',
+  });
+});
+
+test('parseRunCommand respecte les guillemets pour les arguments', () => {
+  assert.deepEqual(parseRunCommand('pnpm --filter "@kraak/client" test'), {
+    args: ['--filter', '@kraak/client', 'test'],
+    command: 'pnpm',
+  });
+});
+
+test('parseRunCommand rejette une commande vide', () => {
+  assert.throws(
+    () => parseRunCommand('   '),
+    /--run requires a non-empty command string/u,
+  );
+});
+
+test('parseRunCommand rejette les guillemets non fermés', () => {
+  assert.throws(
+    () => parseRunCommand('pnpm "build:debug:android'),
+    /commande invalide/u,
+  );
+});
+
+test('runCommandWithAndroidEnv exécute sans shell avec variables Android', () => {
+  const calls = [];
+
+  runCommandWithAndroidEnv('pnpm build:debug:android', {
+    environmentSource: { PATH: '/usr/bin', NODE_ENV: 'test' },
+    exit: () => {
+      throw new Error('exit should not be called');
+    },
+    runProcess: (command, args, env) => {
+      calls.push({ args, command, env });
+      return { status: 0 };
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'pnpm');
+  assert.deepEqual(calls[0].args, ['build:debug:android']);
+  assert.equal(typeof calls[0].env.JAVA_HOME, 'string');
+  assert.equal(typeof calls[0].env.ANDROID_HOME, 'string');
+  assert.equal(calls[0].env.ANDROID_SDK_ROOT, calls[0].env.ANDROID_HOME);
+});
+
+test('runCommandWithAndroidEnv demande une sortie non zéro en cas d échec commande', () => {
+  let exitCode = null;
+
+  runCommandWithAndroidEnv('pnpm build:debug:android', {
+    environmentSource: { PATH: '/usr/bin' },
+    exit: (code) => {
+      exitCode = code;
+    },
+    runProcess: () => ({ status: 2 }),
+  });
+
+  assert.equal(exitCode, 2);
+});


### PR DESCRIPTION
## Problème

Sonar signale un hotspot `javascript:S4721` dans [scripts/setup-android-env.mjs](scripts/setup-android-env.mjs) : exécution de commande via `execSync(..., { shell: true })`.

## Correctif

- Remplacement de `execSync` par `spawnSync` sans shell (`shell: false`).
- Ajout d'un parseur explicite `parseRunCommand` pour découper la commande `--run` sans passer par un interpréteur shell.
- Ajout d'une exécution robuste Windows (`.cmd`) uniquement en fallback `ENOENT`.
- Refactor du script pour supprimer les effets de bord à l'import:
  - nouvelle fonction `setupAndroidEnvFromCli(...)`
  - exécution CLI protégée par check d'entrypoint.

## Tests

- Nouveau fichier [scripts/setup-android-env.test.mjs](scripts/setup-android-env.test.mjs)
  - parsing commande simple
  - parsing avec guillemets
  - rejet commande vide
  - rejet guillemets non fermés
  - exécution sans shell avec env Android
  - propagation du code de sortie non-zéro
- `test:workspace` inclut désormais ce nouveau test.

Closes #307
