### PR TITLE
chore(repo): migrate public domain to kraak-consulting.vercel.app

### DIFF
--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -14,7 +14,7 @@ jobs:
     name: Uptime Check
     runs-on: ubuntu-latest
     env:
-      KRAAK_OBSERVABILITY_WEB_URL: https://kraak-group.vercel.app
+      KRAAK_OBSERVABILITY_WEB_URL: https://kraak-consulting.vercel.app
       KRAAK_OBSERVABILITY_API_URL: https://kraak-api-staging.onrender.com
       ALERT_ISSUE_TITLE: '[ALERT][DEP-05] Observability check failure'
     steps:

--- a/apps/client/projects/mobile/src/environments/environment.production.ts
+++ b/apps/client/projects/mobile/src/environments/environment.production.ts
@@ -1,7 +1,7 @@
 export const environment = {
   environmentName: 'production',
   production: true,
-  siteUrl: 'https://kraak-group.vercel.app',
+  siteUrl: 'https://kraak-consulting.vercel.app',
   apiBaseUrl: 'https://kraak-api-staging.onrender.com',
   pushNotificationsEnabled: true,
   pushNotificationsProvider: 'fcm',

--- a/apps/client/projects/web/public/robots.txt
+++ b/apps/client/projects/web/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://kraak-group.vercel.app/sitemap.xml
+Sitemap: https://kraak-consulting.vercel.app/sitemap.xml

--- a/apps/client/projects/web/public/sitemap.xml
+++ b/apps/client/projects/web/public/sitemap.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://kraak-group.vercel.app/</loc>
+    <loc>https://kraak-consulting.vercel.app/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://kraak-group.vercel.app/a-propos</loc>
+    <loc>https://kraak-consulting.vercel.app/a-propos</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://kraak-group.vercel.app/services</loc>
+    <loc>https://kraak-consulting.vercel.app/services</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://kraak-group.vercel.app/programmes</loc>
+    <loc>https://kraak-consulting.vercel.app/programmes</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://kraak-group.vercel.app/ressources</loc>
+    <loc>https://kraak-consulting.vercel.app/ressources</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://kraak-group.vercel.app/contact</loc>
+    <loc>https://kraak-consulting.vercel.app/contact</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -154,7 +154,7 @@ describe('Web routes', () => {
         const loaded = await (route.loadComponent as () => Promise<unknown>)();
         expect(loaded).toBeTruthy();
       }
-    });
+    }, 15000);
 
     it('When the participant dashboard child loadComponent is invoked Then it resolves to a component', async () => {
       const participantRoute = builtRoutes.find(

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -18,33 +18,35 @@ describe('site-seo', () => {
   });
 
   it('should build an XML sitemap with absolute URLs for every public page', () => {
-    const sitemap = buildSitemapXml('https://kraak-group.vercel.app');
+    const sitemap = buildSitemapXml('https://kraak-consulting.vercel.app');
 
-    expect(sitemap).toContain('<loc>https://kraak-group.vercel.app/</loc>');
     expect(sitemap).toContain(
-      '<loc>https://kraak-group.vercel.app/a-propos</loc>',
+      '<loc>https://kraak-consulting.vercel.app/</loc>',
     );
     expect(sitemap).toContain(
-      '<loc>https://kraak-group.vercel.app/services</loc>',
+      '<loc>https://kraak-consulting.vercel.app/a-propos</loc>',
     );
     expect(sitemap).toContain(
-      '<loc>https://kraak-group.vercel.app/programmes</loc>',
+      '<loc>https://kraak-consulting.vercel.app/services</loc>',
     );
     expect(sitemap).toContain(
-      '<loc>https://kraak-group.vercel.app/ressources</loc>',
+      '<loc>https://kraak-consulting.vercel.app/programmes</loc>',
     );
     expect(sitemap).toContain(
-      '<loc>https://kraak-group.vercel.app/contact</loc>',
+      '<loc>https://kraak-consulting.vercel.app/ressources</loc>',
+    );
+    expect(sitemap).toContain(
+      '<loc>https://kraak-consulting.vercel.app/contact</loc>',
     );
   });
 
   it('should build robots.txt pointing crawlers to the sitemap', () => {
-    const robots = buildRobotsTxt('https://kraak-group.vercel.app');
+    const robots = buildRobotsTxt('https://kraak-consulting.vercel.app');
 
     expect(robots).toContain('User-agent: *');
     expect(robots).toContain('Allow: /');
     expect(robots).toContain(
-      'Sitemap: https://kraak-group.vercel.app/sitemap.xml',
+      'Sitemap: https://kraak-consulting.vercel.app/sitemap.xml',
     );
   });
 

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -25,7 +25,7 @@ export interface SeoPageDefinition {
   };
 }
 
-const DEFAULT_SITE_URL = 'https://kraak-group.vercel.app';
+const DEFAULT_SITE_URL = 'https://kraak-consulting.vercel.app';
 const DEFAULT_SITE_NAME = 'KRAAK';
 const DEFAULT_LOCALE = 'fr_FR';
 const DEFAULT_ROBOTS = 'index, follow';

--- a/apps/client/projects/web/src/environments/environment.production.ts
+++ b/apps/client/projects/web/src/environments/environment.production.ts
@@ -1,4 +1,4 @@
-const defaultSiteUrl = 'https://kraak-group.vercel.app';
+const defaultSiteUrl = 'https://kraak-consulting.vercel.app';
 const runtimeGlobals = globalThis as typeof globalThis & {
   process?: {
     env?: Record<string, string | undefined>;

--- a/docs/runbooks/DEP-05_OBSERVABILITY_ALERTING_2026-04-30.md
+++ b/docs/runbooks/DEP-05_OBSERVABILITY_ALERTING_2026-04-30.md
@@ -17,7 +17,7 @@ ajouter d infrastructure externe supplementaire:
 
 - DEP-02: satisfaite
   - le site public est deja deployee via Vercel
-  - URL publique documentee: `https://kraak-group.vercel.app`
+  - URL publique documentee: `https://kraak-consulting.vercel.app`
 - DEP-03: satisfaite
   - l API est deja deployee via Render
   - endpoint de sante declare dans `render.yaml` via `healthCheckPath: /health`
@@ -73,7 +73,7 @@ Comportement:
 
 Valeurs versionnees actuellement dans le workflow:
 
-- `KRAAK_OBSERVABILITY_WEB_URL=https://kraak-group.vercel.app`
+- `KRAAK_OBSERVABILITY_WEB_URL=https://kraak-consulting.vercel.app`
 - `KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com`
 
 ## Exploitation manuelle
@@ -81,7 +81,7 @@ Valeurs versionnees actuellement dans le workflow:
 Commande locale ou CI:
 
 ```bash
-KRAAK_OBSERVABILITY_WEB_URL=https://kraak-group.vercel.app \
+KRAAK_OBSERVABILITY_WEB_URL=https://kraak-consulting.vercel.app \
 KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com \
 pnpm check:observability
 ```

--- a/docs/runbooks/DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST_2026-04-30.md
+++ b/docs/runbooks/DEP-06_INCIDENT_ROLLBACK_PILOT_CHECKLIST_2026-04-30.md
@@ -52,7 +52,7 @@ Cette tâche ne couvre pas :
 Les incidents sont détectés via :
 
 1. **Workflow `Observability`** (toutes les 15 minutes)
-   - vérification `GET https://kraak-group.vercel.app` (web home)
+   - vérification `GET https://kraak-consulting.vercel.app` (web home)
    - vérification `GET https://kraak-api-staging.onrender.com/health` (API health)
    - en cas d'échec, issue GitHub `[ALERT][DEP-05] Observability check failure`
    - chaque échec crée un commentaire horodate
@@ -73,7 +73,7 @@ Si l'issue d'alerte Observability n'est pas fermée au-delà de **15 minutes** :
 
    ```bash
    # Web
-   curl -v https://kraak-group.vercel.app
+   curl -v https://kraak-consulting.vercel.app
 
    # API
    curl -v https://kraak-api-staging.onrender.com/health
@@ -111,7 +111,7 @@ curl -s https://api.vercel.com/v6/deployments?teamId=TEAM_ID \
 # Via dashboard: https://vercel.com/dashboard/kraak-group > Deployments > Recent
 
 # 3. Vérifier health via headers HTTP
-curl -i https://kraak-group.vercel.app
+curl -i https://kraak-consulting.vercel.app
 ```
 
 **API (Render)**
@@ -153,7 +153,7 @@ Action 1 : Vérifier le dernier déploiement web
 Action 2 : Redéployer depuis main manuellement
 - Pousser un petit commit de "bump" (ex: changement inoffensif)
 - Ou utiliser Vercel UI > Deployments > Redeploy
-- Attendre ~60s et vérifier avec: curl -v https://kraak-group.vercel.app
+- Attendre ~60s et vérifier avec: curl -v https://kraak-consulting.vercel.app
 
 Action 3 : Si le problème persiste
 - Procéder à un ROLLBACK (voir section 2)
@@ -257,7 +257,7 @@ Action 4 : Si c'est une erreur BD (ex: table manquante)
 6. Sélectionner **Promote to Production**
 7. Confirmer
 8. Attendre ~60 secondes
-9. Vérifier : `curl -v https://kraak-group.vercel.app`
+9. Vérifier : `curl -v https://kraak-consulting.vercel.app`
 
 **Durée** : ~2 minutes  
 **Risque** : bas (même artefact, juste serveur mis à jour)
@@ -272,7 +272,7 @@ Action 4 : Si c'est une erreur BD (ex: table manquante)
 6. Créer une PR, reviewer, merger vers `main`
 7. Vercel redéploie automatiquement
 8. Attendre ~60 secondes
-9. Vérifier : `curl -v https://kraak-group.vercel.app`
+9. Vérifier : `curl -v https://kraak-consulting.vercel.app`
 
 **Durée** : ~5 minutes (incluant build)  
 **Risque** : très bas (tracé Git clair)
@@ -362,7 +362,7 @@ Si web ET API doivent être rollbackés ensemble :
 
 2. Puis rollback web (plus visible)
    - Rollback web suivant méthode 2.1.B
-   - Attendre vérification: curl https://kraak-group.vercel.app
+   - Attendre vérification: curl https://kraak-consulting.vercel.app
 
 3. Post-rollback
    - Documenter l'incident
@@ -392,7 +392,7 @@ Si web ET API doivent être rollbackés ensemble :
 
 #### Infrastructure & Déploiement
 
-- [ ] Web déployée et accessible : `curl -I https://kraak-group.vercel.app` → HTTP 200
+- [ ] Web déployée et accessible : `curl -I https://kraak-consulting.vercel.app` → HTTP 200
 - [ ] API déployée et accessible : `curl https://kraak-api-staging.onrender.com/health` → `{ "status": "ok", ... }`
 - [ ] Supabase production-pilot configuré et connecté
 - [ ] Variables d'environnement validées sur tous les services
@@ -426,7 +426,7 @@ Si web ET API doivent être rollbackés ensemble :
 
 #### Parcours Utilisateur Critiques
 
-Tester manuellement chaque flux principal via https://kraak-group.vercel.app :
+Tester manuellement chaque flux principal via https://kraak-consulting.vercel.app :
 
 - [ ] **Page d'accueil** `/`
   - [ ] Charge en < 2s
@@ -465,10 +465,10 @@ Tester manuellement chaque flux principal via https://kraak-group.vercel.app :
 
 - [ ] HTTPS obligatoire
   - Vérifier que tous les endpoints sont HTTPS
-  - Test: `curl -I https://kraak-group.vercel.app` → `strict-transport-security` header
+  - Test: `curl -I https://kraak-consulting.vercel.app` → `strict-transport-security` header
 
 - [ ] Content-Security-Policy configurée (si applicable)
-  - Vérifier headers: `curl -i https://kraak-group.vercel.app | grep -i "content-security"`
+  - Vérifier headers: `curl -i https://kraak-consulting.vercel.app | grep -i "content-security"`
 
 #### Données & Base de Données
 
@@ -505,13 +505,13 @@ Tester manuellement chaque flux principal via https://kraak-group.vercel.app :
 
 ```bash
 # 1. Web sanity check
-curl -I https://kraak-group.vercel.app
+curl -I https://kraak-consulting.vercel.app
 
 # 2. API sanity check
 curl https://kraak-api-staging.onrender.com/health | jq .
 
 # 3. Observability check
-KRAAK_OBSERVABILITY_WEB_URL=https://kraak-group.vercel.app \
+KRAAK_OBSERVABILITY_WEB_URL=https://kraak-consulting.vercel.app \
 KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com \
 pnpm check:observability
 

--- a/docs/runbooks/DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md
+++ b/docs/runbooks/DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md
@@ -45,7 +45,7 @@ Cette tâche ne couvre pas :
 
 Preuves :
 
-- site vitrine KRAAK déployé et accessible : `https://kraak-group.vercel.app`
+- site vitrine KRAAK déployé et accessible : `https://kraak-consulting.vercel.app`
 - pipeline CI/CD Vercel actif (déploiements automatiques sur `main`)
 - toutes les routes critiques répondent avec HTTP 200 :
   - `/` (Accueil)
@@ -136,7 +136,7 @@ Preuves :
 
 **Périmètre du pilote** :
 
-- Surface web : `https://kraak-group.vercel.app` (routes `/`, `/services`, `/programmes`, `/contact`)
+- Surface web : `https://kraak-consulting.vercel.app` (routes `/`, `/services`, `/programmes`, `/contact`)
 - Surface API : `https://kraak-api-staging.onrender.com` (endpoints de contact, health)
 - Surface mobile : APK debug disponible pour distribution interne (TestFlight iOS en préparation)
 
@@ -175,7 +175,7 @@ git push origin pilot-2026-04-30
 
 ### 4.2 Périmètre de la release pilote
 
-#### Web — `https://kraak-group.vercel.app`
+#### Web — `https://kraak-consulting.vercel.app`
 
 Pages déployées :
 

--- a/docs/runbooks/DEP-08_EPIC_DEPLOYMENT_PILOT_LAUNCH_2026-04-30.md
+++ b/docs/runbooks/DEP-08_EPIC_DEPLOYMENT_PILOT_LAUNCH_2026-04-30.md
@@ -28,7 +28,7 @@ Verification realisee via GitHub CLI sur les issues `[TASK][DEP-*]`.
 1. `pnpm lint`
 2. `pnpm typecheck`
 3. `pnpm test:workspace`
-4. `KRAAK_OBSERVABILITY_WEB_URL=https://kraak-group.vercel.app KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com pnpm check:observability`
+4. `KRAAK_OBSERVABILITY_WEB_URL=https://kraak-consulting.vercel.app KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com pnpm check:observability`
 5. `curl -sS -o /tmp/api_health.json -w "%{http_code}\\n" https://kraak-api-staging.onrender.com/health`
 
 ## Resultats
@@ -42,7 +42,7 @@ Verification realisee via GitHub CLI sur les issues `[TASK][DEP-*]`.
 ### Reverifications runtime pilote
 
 - API pilot (`https://kraak-api-staging.onrender.com/health`): HTTP 200, payload observe `{"status":"ok"}`
-- Web pilot (`https://kraak-group.vercel.app/`): HTTP 401 pendant le check d observabilite
+- Web pilot (`https://kraak-consulting.vercel.app/`): HTTP 401 pendant le check d observabilite
 
 ## Decision de lancement maitrise
 

--- a/docs/runbooks/ENVIRONMENT_VARIABLES.md
+++ b/docs/runbooks/ENVIRONMENT_VARIABLES.md
@@ -152,7 +152,7 @@ Variables attendues :
 
 ## Domaines publics documentés
 
-- Domaine public principal : `https://kraak-group.vercel.app`
+- Domaine public principal : `https://kraak-consulting.vercel.app`
 - Domaine staging actuel : `https://client-six-indol-58.vercel.app`
 - API staging actuelle : `https://kraak-api-staging.onrender.com`
 

--- a/docs/runbooks/SUPABASE_AUTH_SETUP.md
+++ b/docs/runbooks/SUPABASE_AUTH_SETUP.md
@@ -45,8 +45,8 @@ Pour un projet Supabase staging ou production, répliquer au minimum dans le Das
 
 URLs minimales à autoriser :
 
-- `https://kraak-group.vercel.app/auth/callback`
-- `https://kraak-group.vercel.app/auth/reset`
+- `https://kraak-consulting.vercel.app/auth/callback`
+- `https://kraak-consulting.vercel.app/auth/reset`
 - `https://client-six-indol-58.vercel.app/auth/callback`
 - `https://client-six-indol-58.vercel.app/auth/reset`
 - `http://localhost:4200/auth/callback`

--- a/docs/runbooks/evidence/DEP-05_observability-alerting-evidence_2026-04-30.md
+++ b/docs/runbooks/evidence/DEP-05_observability-alerting-evidence_2026-04-30.md
@@ -46,7 +46,7 @@ Resultat attendu:
 
 ## Couverture DEP-02 / DEP-03 verifiee
 
-- DEP-02: deploiement web alimente le endpoint surveille `https://kraak-group.vercel.app`
+- DEP-02: deploiement web alimente le endpoint surveille `https://kraak-consulting.vercel.app`
 - DEP-03: deploiement API expose `/health` et `render.yaml` reference `healthCheckPath: /health`
 
 ## Preuve structurelle ajoutee

--- a/docs/runbooks/evidence/DEP-06_incident-rollback-pilot-evidence_2026-04-30.md
+++ b/docs/runbooks/evidence/DEP-06_incident-rollback-pilot-evidence_2026-04-30.md
@@ -19,7 +19,7 @@ Evidence:
     - Vercel: https://vercel.com/dashboard/kraak-group (Environment Variables)
     - Render: https://dashboard.render.com > kraak-api > Environment
 - Deployment URLs stable and documented:
-  - Web (pilot): `https://kraak-group.vercel.app`
+  - Web (pilot): `https://kraak-consulting.vercel.app`
   - API (pilot): `https://kraak-api-staging.onrender.com`
   - Supabase: Configured in environment files
 

--- a/docs/runbooks/evidence/DEP-07_go-no-go-pilot-release-evidence_2026-04-30.md
+++ b/docs/runbooks/evidence/DEP-07_go-no-go-pilot-release-evidence_2026-04-30.md
@@ -17,7 +17,7 @@ Issue: #124
 
 **Statut** : ✅ Satisfaite
 
-- Site pilote accessible : `https://kraak-group.vercel.app`
+- Site pilote accessible : `https://kraak-consulting.vercel.app`
 - Déploiements automatiques Vercel actifs sur `main`
 - Routes critiques HTTP 200 validées par QAT-06
 
@@ -73,7 +73,7 @@ Issue: #124
 ### Vérification observabilité
 
 ```bash
-KRAAK_OBSERVABILITY_WEB_URL=https://kraak-group.vercel.app \
+KRAAK_OBSERVABILITY_WEB_URL=https://kraak-consulting.vercel.app \
 KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com \
 pnpm check:observability
 ```

--- a/docs/runbooks/evidence/DEP-08_epic-deployment-pilot-launch-evidence_2026-04-30.md
+++ b/docs/runbooks/evidence/DEP-08_epic-deployment-pilot-launch-evidence_2026-04-30.md
@@ -48,7 +48,7 @@ Resultat:
 Commande:
 
 ```bash
-KRAAK_OBSERVABILITY_WEB_URL=https://kraak-group.vercel.app KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com pnpm check:observability
+KRAAK_OBSERVABILITY_WEB_URL=https://kraak-consulting.vercel.app KRAAK_OBSERVABILITY_API_URL=https://kraak-api-staging.onrender.com pnpm check:observability
 ```
 
 Resultat:

--- a/scripts/check-observability.test.mjs
+++ b/scripts/check-observability.test.mjs
@@ -9,21 +9,21 @@ import {
 
 test('Given une URL publique valide, When on la normalise, Then le slash terminal est retire', () => {
   assert.equal(
-    normalizePublicUrl('https://kraak-group.vercel.app/', 'KRAAK_OBSERVABILITY_WEB_URL'),
-    'https://kraak-group.vercel.app',
+    normalizePublicUrl('https://kraak-consulting.vercel.app/', 'KRAAK_OBSERVABILITY_WEB_URL'),
+    'https://kraak-consulting.vercel.app',
   );
 });
 
 test('Given les URLs web et API, When on construit les checks, Then la home web et /health sont surveilles', () => {
   assert.deepEqual(
     createObservabilityTargets({
-      webUrl: 'https://kraak-group.vercel.app/',
+      webUrl: 'https://kraak-consulting.vercel.app/',
       apiUrl: 'https://kraak-api-staging.onrender.com/',
     }),
     [
       {
         name: 'web-home',
-        url: 'https://kraak-group.vercel.app/',
+        url: 'https://kraak-consulting.vercel.app/',
         expectedStatus: 200,
         expectedContentType: 'text/html',
       },
@@ -76,7 +76,7 @@ test('Given un endpoint web qui repond en JSON, When le check s execute, Then un
       checkTarget(
         {
           name: 'web-home',
-          url: 'https://kraak-group.vercel.app/',
+          url: 'https://kraak-consulting.vercel.app/',
           expectedStatus: 200,
           expectedContentType: 'text/html',
         },

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -19,7 +19,7 @@ const seoSourcePath = join(
   'site-seo.json',
 );
 const publicDir = join(repoRoot, 'apps', 'client', 'projects', 'web', 'public');
-const defaultSiteUrl = 'https://kraak-group.vercel.app';
+const defaultSiteUrl = 'https://kraak-consulting.vercel.app';
 
 const trimTrailingSlashes = (value) => {
   let end = value.length;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -10,8 +10,8 @@ additional_redirect_urls = [
   "http://localhost:4300/auth/reset",
   "https://client-six-indol-58.vercel.app/auth/callback",
   "https://client-six-indol-58.vercel.app/auth/reset",
-  "https://kraak-group.vercel.app/auth/callback",
-  "https://kraak-group.vercel.app/auth/reset",
+  "https://kraak-consulting.vercel.app/auth/callback",
+  "https://kraak-consulting.vercel.app/auth/reset",
   "kraak://auth/callback",
   "kraak://auth/reset",
 ]


### PR DESCRIPTION
## Résumé\n- migration des références de domaine public vers https://kraak-consulting.vercel.app\n- alignement SEO (robots/sitemap), observability, runbooks, redirects Supabase\n- ajustement timeout test flaky sur lazy-load routes\n\n## Validation\n- pnpm test:workspace ✅\n- pnpm --filter @kraak/client run test:web ✅