### PR TITLE
fix(infra): document non-empty CLIENT_API_BASE_URL requirement and ignore .env*.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ apps/client/projects/web/public/assets/runtime-config.js
 apps/client/android/
 
 .vercel
+.env*.local

--- a/docs/runbooks/ENVIRONMENT_VARIABLES.md
+++ b/docs/runbooks/ENVIRONMENT_VARIABLES.md
@@ -74,12 +74,12 @@ Alias utiles à la racine :
 
 Variables utilisées par le runtime-config et les scripts :
 
-| Variable                   | Description                                   | Exemple local            |
-| -------------------------- | --------------------------------------------- | ------------------------ |
-| `CLIENT_API_BASE_URL`      | URL publique de l'API consommée par le client | `http://localhost:3000`  |
-| `SUPABASE_URL`             | URL publique du projet Supabase côté client   | `http://127.0.0.1:54321` |
-| `SUPABASE_PUBLISHABLE_KEY` | Clé publique Supabase côté client             | —                        |
-| `KRAAK_WEB_PORT`           | Port du serveur Angular pour scripts / E2E    | `4200`                   |
+| Variable                   | Description                                                                                                                      | Exemple local            |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `CLIENT_API_BASE_URL`      | URL publique de l'API consommée par le client (doit être non vide en prod, sinon le client poste en same-origin et reçoit `405`) | `http://localhost:3000`  |
+| `SUPABASE_URL`             | URL publique du projet Supabase côté client                                                                                      | `http://127.0.0.1:54321` |
+| `SUPABASE_PUBLISHABLE_KEY` | Clé publique Supabase côté client                                                                                                | —                        |
+| `KRAAK_WEB_PORT`           | Port du serveur Angular pour scripts / E2E                                                                                       | `4200`                   |
 
 Les environnements Angular sont définis dans :
 


### PR DESCRIPTION
## Contexte

En production, la soumission du formulaire de contact retournait `HTTP 405 Method Not Allowed`.

### Root cause

La variable d'environnement Vercel **Production** `CLIENT_API_BASE_URL` existait mais était définie à une **chaîne vide** (`""`).
Le générateur de runtime-config (`scripts/generate-client-runtime-config.mjs`) **omet la clé `apiBaseUrl`** quand la valeur est vide. Côté client, `resolveApiBaseUrl()` retombait alors sur `environment.production.apiBaseUrl = ''`, faisant pointer le `POST` du `ContactService` vers `/contact` (same-origin → `kraak-consulting.vercel.app/contact`) au lieu de l'API Render.

Staging fonctionnait parce que `environment.staging.ts` hardcode l'URL de l'API staging.

### Résolution opérationnelle (déjà appliquée)

Via Vercel CLI :

```bash
vercel env rm CLIENT_API_BASE_URL production --yes
echo "https://kraak-api-prod.onrender.com" | vercel env add CLIENT_API_BASE_URL production
vercel deploy --prod --yes
```

Vérifié :
- `curl https://kraak-consulting.vercel.app/assets/runtime-config.js` → `{"apiBaseUrl":"https://kraak-api-prod.onrender.com",...}`
- `POST https://kraak-api-prod.onrender.com/contact` → `200 OK`, `{"success":true,...}`

## Changements de ce PR

- `docs/runbooks/ENVIRONMENT_VARIABLES.md` — note explicite que `CLIENT_API_BASE_URL` doit être **non vide** sur Vercel Production, sinon le client poste en same-origin et reçoit `405`.
- `.gitignore` — ignore les fichiers `.env*.local` générés par `vercel env pull` / `vercel link`.

Aucun changement de code applicatif. Le fix prod est purement infra.

## Tests

- ✅ `pnpm test` (libs + api + client unit + e2e Playwright) — passé via husky pre-push.
- ✅ Smoke prod manuel : runtime-config + endpoint `/contact` API.
