### PR TITLE
feat(web): harmonize PrimeNG messages and toasts

### DIFF
--- a/apps/client/projects/web/src/app/app.html
+++ b/apps/client/projects/web/src/app/app.html
@@ -4,4 +4,4 @@
   <router-outlet />
 </main>
 <kraak-footer />
-<p-toast />
+<p-toast key="app-feedback" position="top-right" />

--- a/apps/client/projects/web/src/app/features/auth/password-reset.page.html
+++ b/apps/client/projects/web/src/app/features/auth/password-reset.page.html
@@ -43,6 +43,15 @@
           }
         </div>
 
+        @if (successMessage()) {
+          <p-message
+            severity="success"
+            [text]="successMessage()!"
+            [closable]="false"
+            styleClass="w-full"
+          />
+        }
+
         @if (errorMessage()) {
           <p-message
             severity="error"

--- a/apps/client/projects/web/src/app/features/auth/password-reset.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/password-reset.page.spec.ts
@@ -11,6 +11,8 @@ describe('Web PasswordResetPage', () => {
   const authService = {
     requestPasswordReset: vi.fn(),
   };
+  let messageService: MessageService;
+  let messageServiceAddSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     authService.requestPasswordReset.mockReset();
@@ -28,6 +30,9 @@ describe('Web PasswordResetPage', () => {
         MessageService,
       ],
     }).compileComponents();
+
+    messageService = TestBed.inject(MessageService);
+    messageServiceAddSpy = vi.spyOn(messageService, 'add');
   });
 
   it('should create', () => {
@@ -51,5 +56,12 @@ describe('Web PasswordResetPage', () => {
       ),
     });
     expect(fixture.componentInstance.successMessage()).toContain('email');
+    expect(messageServiceAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'app-feedback',
+        severity: 'success',
+        summary: 'R\u00E9initialisation',
+      }),
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/auth/password-reset.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/password-reset.page.ts
@@ -68,6 +68,7 @@ export default class PasswordResetPage {
 
       this.successMessage.set(response.message);
       this.messageService.add({
+        key: 'app-feedback',
         severity: 'success',
         summary: 'R\u00E9initialisation',
         detail: response.message,

--- a/apps/client/projects/web/src/app/features/auth/sign-in.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-in.page.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
+import { MessageService } from 'primeng/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WebAuthService } from '../../core/auth/web-auth.service';
 import SignInPage from './sign-in.page';
@@ -11,6 +12,8 @@ describe('Web SignInPage', () => {
 
   let router: Router;
   let navigateByUrlSpy: ReturnType<typeof vi.spyOn>;
+  let messageService: MessageService;
+  let messageServiceAddSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     authService.signIn.mockReset();
@@ -21,13 +24,16 @@ describe('Web SignInPage', () => {
       providers: [
         provideRouter([]),
         { provide: WebAuthService, useValue: authService },
+        MessageService,
       ],
     }).compileComponents();
 
     router = TestBed.inject(Router);
+    messageService = TestBed.inject(MessageService);
     navigateByUrlSpy = vi
       .spyOn(router, 'navigateByUrl')
       .mockResolvedValue(true);
+    messageServiceAddSpy = vi.spyOn(messageService, 'add');
   });
 
   it('should create', () => {
@@ -59,6 +65,13 @@ describe('Web SignInPage', () => {
       email: 'alice@example.com',
       password: 'motdepasse-securise',
     });
+    expect(messageServiceAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'app-feedback',
+        severity: 'success',
+        summary: 'Connexion',
+      }),
+    );
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/participant/dashboard');
   });
 

--- a/apps/client/projects/web/src/app/features/auth/sign-in.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-in.page.ts
@@ -6,6 +6,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
+import { MessageService } from 'primeng/api';
 import { ButtonDirective } from 'primeng/button';
 import { Message } from 'primeng/message';
 import {
@@ -27,6 +28,7 @@ interface SignInFormModel {
 })
 export default class SignInPage {
   private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
   private readonly router = inject(Router);
 
   readonly form = new FormGroup<SignInFormModel>({
@@ -61,6 +63,13 @@ export default class SignInPage {
         password,
       });
 
+      this.messageService.add({
+        key: 'app-feedback',
+        severity: 'success',
+        summary: 'Connexion',
+        detail: 'Connexion reussie. Redirection vers votre dashboard.',
+        life: 4500,
+      });
       await this.router.navigateByUrl('/participant/dashboard');
     } catch (error) {
       this.errorMessage.set(

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.html
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.html
@@ -193,6 +193,15 @@
               }
             </div>
 
+            @if (successMessage()) {
+              <p-message
+                severity="success"
+                [text]="successMessage()!"
+                [closable]="false"
+                styleClass="w-full"
+              />
+            }
+
             @if (errorMessage()) {
               <p-message
                 severity="error"

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.spec.ts
@@ -14,6 +14,8 @@ describe('Web SignUpPage', () => {
 
   let router: Router;
   let navigateByUrlSpy: ReturnType<typeof vi.spyOn>;
+  let messageService: MessageService;
+  let messageServiceAddSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     authService.signUp.mockReset();
@@ -34,9 +36,11 @@ describe('Web SignUpPage', () => {
     }).compileComponents();
 
     router = TestBed.inject(Router);
+    messageService = TestBed.inject(MessageService);
     navigateByUrlSpy = vi
       .spyOn(router, 'navigateByUrl')
       .mockResolvedValue(true);
+    messageServiceAddSpy = vi.spyOn(messageService, 'add');
   });
 
   it('should create', () => {
@@ -65,6 +69,13 @@ describe('Web SignUpPage', () => {
     expect(navigateByUrlSpy).not.toHaveBeenCalled();
     expect(fixture.componentInstance.successMessage()).toBe(
       'Votre compte a ete cree.',
+    );
+    expect(messageServiceAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'app-feedback',
+        severity: 'success',
+        summary: 'Inscription',
+      }),
     );
   });
 

--- a/apps/client/projects/web/src/app/features/auth/sign-up.page.ts
+++ b/apps/client/projects/web/src/app/features/auth/sign-up.page.ts
@@ -92,6 +92,7 @@ export default class SignUpPage {
 
       this.successMessage.set(response.message);
       this.messageService.add({
+        key: 'app-feedback',
         severity: 'success',
         summary: 'Inscription',
         detail: response.message,

--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -5,11 +5,15 @@ import {
 } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
+import { MessageService } from 'primeng/api';
+import { vi } from 'vitest';
 
 import ContactPage from './contact.page';
 
 describe('ContactPage', () => {
   let httpTestingController: HttpTestingController;
+  let messageService: MessageService;
+  let messageServiceAddSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -18,10 +22,13 @@ describe('ContactPage', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         provideRouter([]),
+        MessageService,
       ],
     }).compileComponents();
 
     httpTestingController = TestBed.inject(HttpTestingController);
+    messageService = TestBed.inject(MessageService);
+    messageServiceAddSpy = vi.spyOn(messageService, 'add');
   });
 
   afterEach(() => {
@@ -155,6 +162,13 @@ describe('ContactPage', () => {
     expect(component.success()).toBe(true);
     expect(component.apiErrors()).toEqual([]);
     expect(component.loading()).toBe(false);
+    expect(messageServiceAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'app-feedback',
+        severity: 'success',
+        summary: 'Contact',
+      }),
+    );
   });
 
   // Given un succ\u00E8s pr\u00E9c\u00E9dent
@@ -271,5 +285,12 @@ describe('ContactPage', () => {
     expect(component.apiErrors()).toEqual([
       'Une erreur est survenue. Veuillez réessayer plus tard.',
     ]);
+    expect(messageServiceAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'app-feedback',
+        severity: 'error',
+        summary: 'Contact',
+      }),
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/contact/contact.page.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.ts
@@ -8,6 +8,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import { MessageService } from 'primeng/api';
 import { ButtonDirective } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { Message } from 'primeng/message';
@@ -31,6 +32,9 @@ interface ServiceOption {
   category: ContactFormDto['category'];
 }
 
+const GENERIC_CONTACT_ERROR_MESSAGE =
+  'Une erreur est survenue. Veuillez r\u00E9essayer plus tard.';
+
 @Component({
   selector: 'kraak-contact-page',
   standalone: true,
@@ -47,6 +51,7 @@ interface ServiceOption {
 })
 export default class ContactPage {
   private readonly contactService = inject(ContactService);
+  private readonly messageService = inject(MessageService);
 
   protected readonly serviceOptions: ServiceOption[] = [
     { label: 'Formation', value: 'formation', category: 'program' },
@@ -124,12 +129,34 @@ export default class ContactPage {
       next: () => {
         this.loading.set(false);
         this.success.set(true);
+        this.messageService.add({
+          key: 'app-feedback',
+          severity: 'success',
+          summary: 'Contact',
+          detail:
+            'Votre message a bien ete envoye. Notre equipe revient vers vous rapidement.',
+          life: 6000,
+        });
         this.form.reset();
         this.submitted.set(false);
       },
       error: (errorResponse: HttpErrorResponse) => {
         this.loading.set(false);
-        this.apiErrors.set(this.extractApiErrors(errorResponse));
+        const extractedErrors = this.extractApiErrors(errorResponse);
+        this.apiErrors.set(extractedErrors);
+
+        if (
+          extractedErrors.length === 1 &&
+          extractedErrors[0] === GENERIC_CONTACT_ERROR_MESSAGE
+        ) {
+          this.messageService.add({
+            key: 'app-feedback',
+            severity: 'error',
+            summary: 'Contact',
+            detail: GENERIC_CONTACT_ERROR_MESSAGE,
+            life: 7000,
+          });
+        }
       },
     });
   }
@@ -145,7 +172,7 @@ export default class ContactPage {
       return rawErrors;
     }
 
-    return ['Une erreur est survenue. Veuillez r\u00E9essayer plus tard.'];
+    return [GENERIC_CONTACT_ERROR_MESSAGE];
   }
 
   private buildPayload(): ContactFormDto {

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
@@ -77,10 +77,12 @@
           informations.
         </p>
       } @else if (errorMessage()) {
-        <p class="mt-4 text-sm leading-6 text-red-700">
-          La synth&egrave;se n'a pas pu &ecirc;tre charg&eacute;e pour le
-          moment.
-        </p>
+        <p-message
+          severity="warn"
+          text="La synthese n'a pas pu etre chargee pour le moment."
+          [closable]="false"
+          styleClass="mt-4 w-full"
+        />
       } @else {
         <div class="mt-5 grid gap-4 lg:grid-cols-[1.65fr_minmax(16rem,1fr)]">
           <div class="grid gap-3 sm:grid-cols-3">
@@ -157,13 +159,13 @@
       </div>
 
       @if (errorMessage()) {
-        <div
-          class="mt-6 space-y-3 rounded-[1.25rem] border border-red-200 bg-red-50 p-4"
-          role="alert"
-        >
-          <p class="text-sm leading-6 text-red-700">
-            {{ errorMessage() }}
-          </p>
+        <div class="mt-6 space-y-3">
+          <p-message
+            severity="error"
+            [text]="errorMessage()!"
+            [closable]="false"
+            styleClass="w-full"
+          />
           <button
             type="button"
             class="btn btn-primary"

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { ApiError } from '@kraak/api-client';
 import type { DashboardAggregateDto } from '@kraak/contracts';
+import { MessageService } from 'primeng/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DashboardPage from './dashboard.page';
@@ -109,7 +110,7 @@ describe('Web Participant Dashboard Page', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DashboardPage],
-      providers: [WebAuthService, provideRouter([])],
+      providers: [WebAuthService, provideRouter([]), MessageService],
     }).compileComponents();
   });
 

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
@@ -4,6 +4,8 @@ import { RouterLink } from '@angular/router';
 import { createApiClient, type ApiClient } from '@kraak/api-client';
 import type { DashboardAggregateDto } from '@kraak/contracts';
 import { loadDashboardAggregate } from '@kraak/domain';
+import { MessageService } from 'primeng/api';
+import { Message } from 'primeng/message';
 
 import { environment } from '../../../../environments/environment';
 import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
@@ -39,11 +41,12 @@ const QUICK_LINKS: readonly DashboardQuickLink[] = [
 @Component({
   selector: 'kraak-web-participant-dashboard',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, RouterLink, Message],
   templateUrl: './dashboard.page.html',
 })
 export default class DashboardPage implements OnInit {
   private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
   protected dashboardClient: Pick<ApiClient['dashboard'], 'getAggregate'> =
     createApiClient({
       baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
@@ -59,6 +62,7 @@ export default class DashboardPage implements OnInit {
   );
   protected readonly loading = signal(true);
   protected readonly errorMessage = signal<string | null>(null);
+  private readonly hasRecoveredFromError = signal(false);
 
   private selectFromAggregate<K extends keyof DashboardAggregateDto>(key: K) {
     return computed(
@@ -136,6 +140,30 @@ export default class DashboardPage implements OnInit {
       setData: (value) => this.dashboardState.set(value),
       setError: (value) => this.errorMessage.set(value),
     });
+
+    const currentError = this.errorMessage();
+    if (currentError) {
+      this.messageService.add({
+        key: 'app-feedback',
+        severity: 'error',
+        summary: 'Dashboard',
+        detail: currentError,
+        life: 7000,
+      });
+      this.hasRecoveredFromError.set(true);
+      return;
+    }
+
+    if (this.hasRecoveredFromError()) {
+      this.messageService.add({
+        key: 'app-feedback',
+        severity: 'success',
+        summary: 'Dashboard',
+        detail: 'Les donnees ont ete rechargees avec succes.',
+        life: 4500,
+      });
+      this.hasRecoveredFromError.set(false);
+    }
   }
 
   private formatDate(rawDate: string): string {

--- a/docs/specs/MESSAGES_TOASTS_RULE_WEB.md
+++ b/docs/specs/MESSAGES_TOASTS_RULE_WEB.md
@@ -1,0 +1,38 @@
+# Règle d'usage PrimeNG Messages et Toasts (Web)
+
+Cette règle s'applique à tout le site web dans apps/client/projects/web.
+
+## Principe
+
+- Utiliser `p-message` pour un retour **contextuel et persistant** lié à une zone précise de la page.
+- Utiliser `p-toast` pour une notification **globale et transitoire** après une action utilisateur.
+
+## Quand utiliser `p-message`
+
+- Erreur de validation ou de saisie à corriger dans un formulaire.
+- Erreur bloquante d'une section (ex: dashboard impossible à charger) avec action locale de correction (ex: bouton Réessayer).
+- Confirmation qui doit rester visible dans la zone de travail courante (ex: message d'état sous un formulaire).
+
+## Quand utiliser `p-toast`
+
+- Confirmation de fin d'action asynchrone (ex: connexion, inscription, demande envoyée, rechargement réussi).
+- Alerte globale non bloquante.
+- Retour rapide qui n'a pas besoin d'occuper durablement l'espace principal de la page.
+
+## Convention technique
+
+- Canal de toast unique: `key="app-feedback"`.
+- Le composant global est déclaré dans `app.html` avec `p-toast`.
+- Les messages contextuels restent rendus dans les templates des pages concernées.
+
+## Application sur le MVP web
+
+- Auth (`connexion`, `inscription`, `mot-de-passe-oublie`):
+  - `p-message` pour erreurs et confirmations locales.
+  - toast global pour confirmer la fin d'action.
+- Contact:
+  - `p-message` pour erreurs API contextualisées.
+  - toast global pour succès d'envoi et erreur générique.
+- Dashboard participant:
+  - `p-message` pour erreurs de chargement de section.
+  - toast global pour échec de chargement et succès après reprise.


### PR DESCRIPTION
## Summary
Implement a unified user-feedback pattern across the web app using PrimeNG Messages and Toasts.

## Rule Established
- Use p-message for contextual, persistent feedback inside the current page/section.
- Use p-toast for global, transient action confirmations/alerts.
- Shared toast channel: key="app-feedback".

## Changes
- Added shared global toast key in app shell.
- Updated auth pages (sign-in, sign-up, password-reset) to consistently combine inline messages + global toasts.
- Updated contact page to keep contextual API errors inline and emit global toasts for success and generic failures.
- Updated participant dashboard to use PrimeNG p-message for section-level errors and toast notifications for failure/recovery events.
- Added web documentation rule: docs/specs/MESSAGES_TOASTS_RULE_WEB.md.
- Updated related unit tests for new feedback behavior.

## Validation
- pnpm --filter @kraak/client run test:web
- pnpm typecheck:web
- pnpm --filter @kraak/client lint
- pre-push suite executed successfully after releasing local port 4200 conflict.
