### PR TITLE
feat(web): align marketing copy with docx master

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pnpm dev:mobile
 
 ## Structure du monorepo
 
-```
+```text
 kraak-group/
 ├── apps/
 │   ├── api/           # Backend NestJS (port 3000)

--- a/apps/client/projects/web/src/app/features/about/about.page.html
+++ b/apps/client/projects/web/src/app/features/about/about.page.html
@@ -92,13 +92,14 @@
         Mission
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        R&eacute;v&eacute;ler le potentiel et accompagner vers un impact
-        durable.
+        R&eacute;v&eacute;ler le potentiel, d&eacute;velopper les
+        comp&eacute;tences et accompagner vers un impact professionnel et
+        communautaire durable.
       </h2>
       <p class="mt-4 text-lg text-neutral-700">
-        Notre mission est de d&eacute;velopper les comp&eacute;tences, de
-        soutenir les trajectoires professionnelles et de contribuer &agrave; un
-        impact communautaire concret.
+        Nous intervenons &agrave; l'intersection du d&eacute;veloppement des
+        comp&eacute;tences, de la structuration des projets et de l'acc&egrave;s
+        aux opportunit&eacute;s internationales.
       </p>
     </article>
     <article>
@@ -111,9 +112,8 @@
         Former une g&eacute;n&eacute;ration de leaders africains.
       </h2>
       <p class="mt-4 text-lg text-neutral-700">
-        Nous voulons contribuer &agrave; une g&eacute;n&eacute;ration capable
-        d'agir, d'influencer et de construire un avenir solide, localement et
-        &agrave; l'international.
+        Une g&eacute;n&eacute;ration capable d'agir, d'influencer et de
+        construire un avenir solide, localement et &agrave; l'international.
       </p>
     </article>
   </div>
@@ -163,7 +163,7 @@
 
 <kraak-cta-banner
   heading="Parlons de l'impact que vous voulez construire."
-  body="Notre &eacute;quipe vous aide &agrave; choisir le bon point de d&eacute;part entre formation, projet et mobilit&eacute; internationale."
+  body="Nous intervenons &agrave; trois niveaux : d&eacute;veloppement des comp&eacute;tences, structuration des projets et acc&egrave;s aux opportunit&eacute;s internationales."
   ctaLabel="Nous contacter"
   ctaLink="/contact"
   ctaContext="about_main_cta"

--- a/apps/client/projects/web/src/app/features/about/about.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.spec.ts
@@ -22,11 +22,14 @@ describe('AboutPage', () => {
     expect(heading?.textContent).toContain('Former. Structurer. Transformer.');
   });
 
-  it('should render the three intervention levels and values', () => {
+  it('should render the refreshed mission, intervention levels and values', () => {
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
     const content = fixture.nativeElement.textContent as string;
 
+    expect(content).toContain(
+      'Révéler le potentiel, développer les compétences et accompagner vers un impact professionnel et communautaire durable',
+    );
     expect(content).toContain('D\u00E9veloppement des comp\u00E9tences');
     expect(content).toContain('Structuration des projets');
     expect(content).toContain(

--- a/apps/client/projects/web/src/app/features/contact/contact.page.html
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.html
@@ -110,6 +110,20 @@
                   <span>Afrique &amp; international</span>
                 </li>
                 <li class="flex items-center gap-3">
+                  <i
+                    class="pi pi-whatsapp text-brand-cyan"
+                    aria-hidden="true"
+                  ></i>
+                  <a
+                    [href]="whatsappLink"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="hover:text-brand-cyan transition-colors"
+                  >
+                    WhatsApp : +225 05 02 74 18 18
+                  </a>
+                </li>
+                <li class="flex items-center gap-3">
                   <i class="pi pi-clock text-brand-cyan" aria-hidden="true"></i>
                   <span>R&eacute;ponse sous 48h ouvr&eacute;es</span>
                 </li>
@@ -382,7 +396,7 @@
                 }
               </div>
 
-              <div class="pt-1">
+              <div class="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
                 <button
                   pButton
                   type="submit"
@@ -393,6 +407,16 @@
                   [disabled]="loading()"
                   class="kr-button-primary w-full sm:w-auto"
                 ></button>
+                <a
+                  pButton
+                  [href]="whatsappLink"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  label="Discuter sur WhatsApp"
+                  aria-label="Discuter sur WhatsApp"
+                  icon="pi pi-whatsapp"
+                  class="kr-button-secondary w-full sm:w-auto"
+                ></a>
               </div>
             </form>
           }
@@ -416,6 +440,18 @@
         </a>
       </div>
       <div class="text-center">
+        <i class="pi pi-whatsapp text-3xl" aria-hidden="true"></i>
+        <h3 class="mt-2 text-lg font-bold">WhatsApp</h3>
+        <a
+          [href]="whatsappLink"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="kr-link mt-1 block"
+        >
+          +225 05 02 74 18 18
+        </a>
+      </div>
+      <div class="text-center md:col-span-2">
         <i class="pi pi-map-marker text-3xl" aria-hidden="true"></i>
         <h3 class="mt-2 text-lg font-bold">Zone d'intervention</h3>
         <p class="mt-1 text-neutral-700">
@@ -434,6 +470,6 @@
 </section>
 
 <kraak-cta-banner
-  heading="Vous savez o&ugrave; vous voulez aller."
-  body="Nous vous aidons &agrave; choisir le chemin le plus clair pour y arriver."
+  heading="Parlons de votre prochaine &eacute;tape."
+  body="Envoyez votre demande via le formulaire ou lancez directement un &eacute;change sur WhatsApp."
 />

--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -69,6 +69,19 @@ describe('ContactPage', () => {
     expect(fixture.nativeElement.querySelector('#message')).toBeTruthy();
   });
 
+  it('devrait afficher une action WhatsApp visible pour un contact rapide', () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const whatsappLink = page.querySelector(
+      'a[aria-label="Discuter sur WhatsApp"]',
+    ) as HTMLAnchorElement | null;
+
+    expect(whatsappLink).toBeTruthy();
+    expect(whatsappLink?.getAttribute('href')).toContain('wa.me/2250502741818');
+  });
+
   // Given le formulaire est vide
   // When l'utilisateur soumet le formulaire
   // Then le formulaire doit \u00EAtre invalide et les erreurs affich\u00E9es

--- a/apps/client/projects/web/src/app/features/contact/contact.page.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.ts
@@ -91,12 +91,15 @@ export default class ContactPage implements OnInit, OnDestroy {
       value: 'immigration',
       category: 'other',
     },
-    { label: 'Solution entreprise', value: 'business', category: 'other' },
-    { label: 'Programme KRAAK', value: 'program', category: 'program' },
+    { label: 'Solutions entreprises', value: 'business', category: 'other' },
+    { label: 'Programmes KRAAK', value: 'program', category: 'program' },
     { label: 'Autre demande', value: 'other', category: 'other' },
   ];
 
   protected readonly socialLinks: readonly SocialLink[] = KRAAK_SOCIAL_LINKS;
+  protected readonly whatsappLink =
+    KRAAK_SOCIAL_LINKS.find((social) => social.label === 'WhatsApp')?.href ??
+    'https://wa.me/2250502741818';
 
   protected readonly faqItems: FaqItem[] = [
     {
@@ -107,12 +110,12 @@ export default class ContactPage implements OnInit, OnDestroy {
     {
       question: 'Quels types de services propose KRAAK ?',
       answer:
-        "Nous intervenons sur la formation, la gestion de projets, les programmes de développement et l'accompagnement en études et immigration.",
+        "Nous intervenons sur la formation, la recherche et gestion de projets, les programmes KRAAK, les solutions entreprises et l'accompagnement en études et immigration.",
     },
     {
-      question: 'Puis-je être accompagné à distance depuis un autre pays ?',
+      question: 'Puis-je vous contacter directement sur WhatsApp ?',
       answer:
-        "Oui. KRAAK accompagne des publics en Afrique et à l'international via des formats à distance et des échanges planifiés selon votre disponibilité.",
+        'Oui. Si vous préférez un échange rapide, le canal WhatsApp reste disponible en complément du formulaire de contact.',
     },
     {
       question: 'Combien de temps faut-il pour recevoir une première réponse ?',

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -160,7 +160,7 @@
         <h3 class="text-xl font-bold">Recherche &amp; Gestion de projets</h3>
         <p class="text-brand-navy mt-3">
           Transformez vos id&eacute;es en projets structur&eacute;s, rentables
-          et durables, avec une m&eacute;thode claire et un suivi utile.
+          et durables.
         </p>
         <a
           routerLink="/services"
@@ -179,7 +179,7 @@
         <h3 class="text-xl font-bold">&Eacute;tudes &amp; Immigration</h3>
         <p class="text-brand-navy mt-3">
           Construisez votre avenir &agrave; l'international avec un
-          accompagnement fiable, strat&eacute;gique et conforme.
+          accompagnement fiable et strat&eacute;gique.
         </p>
         <a routerLink="/contact" class="kr-link mt-5 inline-flex font-semibold">
           &Eacute;valuer mon profil
@@ -202,129 +202,19 @@
           Des points d'entr&eacute;e concrets selon votre trajectoire.
         </h2>
       </div>
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <article class="rounded-card w-full bg-neutral-50 p-4">
-          <span
-            class="bg-brand-white mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-lg shadow-sm"
-          >
-            <i
-              class="pi pi-desktop text-accent text-2xl lg:text-3xl"
-              aria-hidden="true"
-            ></i>
-          </span>
-          <div class="flex flex-col gap-1 text-center">
-            <h3 class="text-brand-navy text-xl leading-tight font-medium">
-              Formations Professionnelles
-            </h3>
-            <p class="text-brand-navy/80 leading-normal">
-              Programmes cibl&eacute;s en fran&ccedil;ais et anglais pour
-              renforcer vos comp&eacute;tences et votre employabilit&eacute;.
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        @for (solution of keySolutions; track solution) {
+          <article class="rounded-card w-full bg-neutral-50 p-5 text-center">
+            <span
+              class="bg-brand-white text-secondary mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-sm"
+            >
+              {{ $index + 1 }}
+            </span>
+            <p class="text-brand-navy text-lg leading-snug font-medium">
+              {{ solution }}
             </p>
-          </div>
-        </article>
-
-        <article class="rounded-card w-full bg-neutral-50 p-4">
-          <span
-            class="bg-brand-white mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-lg shadow-sm"
-          >
-            <i
-              class="pi pi-lock text-secondary text-2xl lg:text-3xl"
-              aria-hidden="true"
-            ></i>
-          </span>
-          <div class="flex flex-col gap-1 text-center">
-            <h3 class="text-brand-navy text-xl leading-tight font-medium">
-              Accompagnement S&eacute;curis&eacute;
-            </h3>
-            <p class="text-brand-navy/80 leading-normal">
-              Un cadre fiable, confidentiel et structur&eacute; pour vos
-              d&eacute;marches acad&eacute;miques, professionnelles et
-              administratives.
-            </p>
-          </div>
-        </article>
-
-        <article class="rounded-card w-full bg-neutral-50 p-4">
-          <span
-            class="bg-brand-white mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-lg shadow-sm"
-          >
-            <i
-              class="pi pi-face-smile text-highlight text-2xl lg:text-3xl"
-              aria-hidden="true"
-            ></i>
-          </span>
-          <div class="flex flex-col gap-1 text-center">
-            <h3 class="text-brand-navy text-xl leading-tight font-medium">
-              Parcours Simples &amp; Clairs
-            </h3>
-            <p class="text-brand-navy/80 leading-normal">
-              Des &eacute;tapes compr&eacute;hensibles, des conseils concrets et
-              un suivi humain &agrave; chaque phase de votre trajectoire.
-            </p>
-          </div>
-        </article>
-
-        <article class="rounded-card w-full bg-neutral-50 p-4">
-          <span
-            class="bg-brand-white mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-lg shadow-sm"
-          >
-            <i
-              class="pi pi-globe text-accent text-2xl lg:text-3xl"
-              aria-hidden="true"
-            ></i>
-          </span>
-          <div class="flex flex-col gap-1 text-center">
-            <h3 class="text-brand-navy text-xl leading-tight font-medium">
-              Mobilit&eacute; Internationale
-            </h3>
-            <p class="text-brand-navy/80 leading-normal">
-              Appui strat&eacute;gique pour vos projets d'&eacute;tudes,
-              d'immigration et d'int&eacute;gration au Canada et aux
-              &Eacute;tats-Unis.
-            </p>
-          </div>
-        </article>
-
-        <article class="rounded-card w-full bg-neutral-50 p-4">
-          <span
-            class="bg-brand-white mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-lg shadow-sm"
-          >
-            <i
-              class="pi pi-github text-secondary text-2xl lg:text-3xl"
-              aria-hidden="true"
-            ></i>
-          </span>
-          <div class="flex flex-col gap-1 text-center">
-            <h3 class="text-brand-navy text-xl leading-tight font-medium">
-              Solutions Ouvertes
-            </h3>
-            <p class="text-brand-navy/80 leading-normal">
-              Outils, m&eacute;thodes et ressources adapt&eacute;s &agrave;
-              votre r&eacute;alit&eacute; pour acc&eacute;l&eacute;rer vos
-              r&eacute;sultats.
-            </p>
-          </div>
-        </article>
-
-        <article class="rounded-card w-full bg-neutral-50 p-4">
-          <span
-            class="bg-brand-white mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-lg shadow-sm"
-          >
-            <i
-              class="pi pi-shield text-highlight text-2xl lg:text-3xl"
-              aria-hidden="true"
-            ></i>
-          </span>
-          <div class="flex flex-col gap-1 text-center">
-            <h3 class="text-brand-navy text-xl leading-tight font-medium">
-              Confiance &amp; Rigueur
-            </h3>
-            <p class="text-brand-navy/80 leading-normal">
-              Approche professionnelle et &eacute;thique pour transformer vos
-              ambitions en r&eacute;sultats mesurables et durables.
-            </p>
-          </div>
-        </article>
+          </article>
+        }
       </div>
     </div>
   </div>
@@ -363,7 +253,7 @@
       >
         <i class="pi pi-heart text-accent text-2xl" aria-hidden="true"></i>
         <p class="mt-3 font-semibold">
-          Programmes accessibles, gratuits et premium
+          Programmes accessibles (gratuits et premium)
         </p>
       </div>
     </div>
@@ -391,8 +281,8 @@
         r&eacute;sultat.
       </h2>
       <p class="text-brand-navy mx-auto mt-4 max-w-2xl">
-        Un espace sera ouvert aux retours clients et aux preuves sociales
-        d&egrave;s que les prochains t&eacute;moignages seront valid&eacute;s.
+        Un espace est r&eacute;serv&eacute; aux t&eacute;moignages clients en
+        cours de validation.
       </p>
     </div>
     <div class="mx-auto mt-10 max-w-6xl px-4 lg:px-6">
@@ -409,7 +299,7 @@
 
 <kraak-cta-banner
   heading="Vous savez o&ugrave; vous voulez aller."
-  body="Nous savons comment vous y amener, avec une consultation claire et une premi&egrave;re orientation utile."
+  body="Nous savons comment vous y amener."
   ctaLabel="Prendre rendez-vous maintenant"
   ctaLink="/contact"
   ctaContext="home_main_cta"

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -78,9 +78,15 @@ describe('HomePage', () => {
 
     const content = fixture.nativeElement.textContent as string;
 
-    expect(content).toContain('Programmes ciblés en français et anglais');
-    expect(content).toContain('Parcours Simples & Clairs');
-    expect(content).toContain('Mobilité Internationale');
+    expect(content).toContain(
+      'Formations en anglais et français professionnel',
+    );
+    expect(content).toContain('Développement personnel et professionnel');
+    expect(content).toContain('Formations en leadership professionnel');
+    expect(content).toContain("Accompagnement à l'emploi");
+    expect(content).toContain('Création, gestion et suivi de projets');
+    expect(content).toContain('Immigration Canada et États-Unis');
+    expect(content).toContain('Intégration socioéconomique et professionnelle');
   });
 
   it('should render home-specific FAQ section', () => {

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -41,6 +41,15 @@ import { canShowPreviewContent } from '../../core/runtime/runtime-config';
 export default class HomePage implements OnInit, OnDestroy {
   readonly heroBackgroundStyle = HERO_BACKGROUND_STYLE;
   protected readonly canShowPreviewContent = canShowPreviewContent;
+  protected readonly keySolutions: readonly string[] = [
+    'Formations en anglais et français professionnel',
+    'Développement personnel et professionnel',
+    'Formations en leadership professionnel',
+    "Accompagnement à l'emploi",
+    'Création, gestion et suivi de projets',
+    'Immigration Canada et États-Unis',
+    'Intégration socioéconomique et professionnelle',
+  ];
 
   protected readonly faqItems: FaqItem[] = [
     {
@@ -50,14 +59,15 @@ export default class HomePage implements OnInit, OnDestroy {
         "Commencez par une consultation d'orientation. Nous clarifions votre objectif, vos contraintes et les options réalistes pour définir un point de départ concret.",
     },
     {
-      question: "Comment KRAAK m'aide-t-il à choisir la bonne orientation ?",
+      question: 'Quels services KRAAK peuvent répondre à mon objectif ?',
       answer:
-        'Nous analysons votre profil, votre contexte et votre priorité du moment pour vous proposer un parcours cohérent entre formation, projet et mobilité internationale.',
+        'Nous partons de votre priorité du moment pour vous orienter vers le bon point d’entrée entre formation, recherche et gestion de projets, études et immigration, programmes KRAAK ou besoin entreprise.',
     },
     {
-      question: 'Comment savoir quel programme KRAAK correspond à mon besoin ?',
+      question:
+        'Proposez-vous des programmes pour les jeunes, les étudiants et les organisations ?',
       answer:
-        'Nos équipes comparent votre objectif aux programmes disponibles et vous orientent vers le format le plus pertinent selon votre niveau, votre calendrier et vos attentes.',
+        'Oui. Nos programmes et accompagnements s’adressent aux étudiants, jeunes professionnels, entreprises, diaspora et organisations avec des formats courts, structurés et orientés résultats.',
     },
     {
       question:

--- a/apps/client/projects/web/src/app/features/services/services.page.html
+++ b/apps/client/projects/web/src/app/features/services/services.page.html
@@ -16,9 +16,9 @@
         plus loin.
       </h1>
       <p class="text-brand-navy mx-auto mt-6 max-w-2xl text-lg">
-        Formation, gestion de projets, immigration et solutions entreprises :
-        chaque service est pens&eacute; pour vous aider &agrave; passer de
-        l'intention au r&eacute;sultat.
+        Formation, recherche &amp; gestion de projets, &eacute;tudes &amp;
+        immigration et solutions entreprises : chaque service est pens&eacute;
+        pour vous aider &agrave; passer de l'intention au r&eacute;sultat.
       </p>
     </div>
   </div>
@@ -112,7 +112,9 @@
           </p>
         </article>
         <article class="rounded-card bg-neutral-50 p-5">
-          <h3 class="font-bold">D&eacute;veloppement &amp; leadership</h3>
+          <h3 class="font-bold">
+            D&eacute;veloppement personnel &amp; leadership
+          </h3>
           <p class="text-brand-navy mt-2 text-sm">
             Confiance en soi, prise de parole et leadership strat&eacute;gique.
           </p>
@@ -127,8 +129,8 @@
         <article class="rounded-card bg-neutral-50 p-5">
           <h3 class="font-bold">Employabilit&eacute;</h3>
           <p class="text-brand-navy mt-2 text-sm">
-            Entretiens, CV, posture professionnelle et accompagnement &agrave;
-            l'emploi.
+            Pr&eacute;paration aux entretiens, R&eacute;daction CV et placement
+            en emploi.
           </p>
         </article>
       </div>
@@ -149,7 +151,7 @@
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
           Une id&eacute;e sans strat&eacute;gie reste une intention. Nous vous
-          aidons &agrave; la transformer en projet concret, lisible et durable.
+          aidons &agrave; la transformer en projet concret.
         </p>
         <div
           class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row"
@@ -272,7 +274,7 @@
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
           Nous accompagnons les entreprises qui veulent passer &agrave; un autre
-          niveau avec des solutions cibl&eacute;es, sobres et utiles au terrain.
+          niveau.
         </p>
         <div
           class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row"
@@ -358,7 +360,7 @@
 
 <kraak-cta-banner
   heading="Choisissez le bon accompagnement pour votre objectif."
-  body="Une consultation suffit souvent &agrave; clarifier le point de d&eacute;part, les priorit&eacute;s et la suite du parcours."
+  body="Une consultation suffit souvent &agrave; clarifier la bonne prochaine &eacute;tape."
   ctaLabel="R&eacute;server une consultation"
   ctaLink="/contact"
   ctaContext="services_main_cta"

--- a/apps/client/projects/web/src/app/features/services/services.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.spec.ts
@@ -35,6 +35,10 @@ describe('ServicesPage', () => {
     expect(content).toContain(
       'Des \u00E9quipes performantes construisent des organisations solides',
     );
+    expect(content).toContain('Rédaction CV');
+    expect(content).toContain('Recrutement de talents');
+    expect(content).toContain('Immigration professionnelle');
+    expect(content).toContain("Santé et culture d'entreprise");
   });
 
   it('should render service-specific FAQ section', () => {

--- a/apps/client/projects/web/src/app/features/services/services.page.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.ts
@@ -23,18 +23,18 @@ export default class ServicesPage implements OnInit, OnDestroy {
     {
       question: 'Comment choisir le service le plus adapté à mon objectif ?',
       answer:
-        'Nous commençons par clarifier votre besoin, votre contexte et vos priorités. Ensuite, nous vous orientons vers la combinaison de services la plus utile pour avancer rapidement.',
+        'Nous clarifions d’abord votre besoin, votre contexte et la prochaine décision à prendre. Ensuite, nous vous orientons vers le bon point d’entrée entre formation, projet, études et immigration, programmes ou solutions entreprises.',
     },
     {
       question:
-        'Proposez-vous un accompagnement pour les particuliers et les entreprises ?',
+        'Intervenez-vous pour les particuliers, les entreprises et la diaspora ?',
       answer:
-        'Oui. Nous accompagnons les étudiants, professionnels, entrepreneurs et organisations avec des formats dédiés : individuel, équipe ou programme sur mesure.',
+        'Oui. KRAAK accompagne étudiants, professionnels, entrepreneurs, entreprises, diaspora et organisations avec des formats individuels, équipe ou sur mesure.',
     },
     {
-      question: 'Vos services sont-ils disponibles à distance ?',
+      question: 'Puis-je combiner plusieurs services dans un même parcours ?',
       answer:
-        'Oui. Une grande partie de nos accompagnements est disponible à distance, avec des sessions planifiées et un suivi structuré selon vos contraintes.',
+        'Oui. Un parcours peut articuler formation, structuration de projet, orientation internationale et accompagnement entreprise si cela sert mieux votre objectif.',
     },
     {
       question: 'Quel est le délai pour démarrer après une prise de contact ?',

--- a/apps/client/projects/web/src/app/layouts/footer/footer.html
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.html
@@ -56,6 +56,14 @@
       }
     </nav>
 
+    <div class="text-center">
+      <p
+        class="text-secondary mb-3 text-xs font-semibold tracking-[0.18em] uppercase"
+      >
+        R&eacute;seaux sociaux
+      </p>
+    </div>
+
     <nav
       class="flex items-center justify-center gap-4"
       aria-label="R&eacute;seaux sociaux"

--- a/apps/client/projects/web/src/app/seo/seo.service.spec.ts
+++ b/apps/client/projects/web/src/app/seo/seo.service.spec.ts
@@ -51,7 +51,7 @@ describe('SeoService', () => {
 
     expect(title.getTitle()).toContain('Contact');
     expect(meta.getTag('name="description"')?.content).toContain(
-      '\u00E9tudiant, professionnel, entrepreneur ou entreprise',
+      'gestion de projets, immigration ou besoin entreprise',
     );
     expect(meta.getTag('property="og:title"')?.content).toContain(
       'Parlons de votre projet',

--- a/apps/client/projects/web/src/app/seo/site-seo.json
+++ b/apps/client/projects/web/src/app/seo/site-seo.json
@@ -1,11 +1,11 @@
 [
   {
     "path": "",
-    "title": "KRAAK Consulting | Formation, projets et mobilité internationale",
-    "description": "KRAAK Consulting accompagne étudiants, professionnels, entreprises et diaspora en formation, gestion de projets et immigration.",
+    "title": "KRAAK Consulting | Développez vos compétences, lancez vos projets",
+    "description": "KRAAK Consulting accompagne étudiants, professionnels, entreprises et diaspora avec des solutions concrètes en formation, gestion de projets et immigration.",
     "openGraph": {
-      "title": "KRAAK Consulting | Formation, projets et mobilité internationale",
-      "description": "Développez vos compétences, lancez vos projets et accédez aux opportunités internationales.",
+      "title": "KRAAK Consulting | Développez vos compétences, lancez vos projets",
+      "description": "Développez vos compétences, lancez vos projets et accédez aux opportunités internationales avec un accompagnement KRAAK clair et structuré.",
       "imagePath": "/open-graph/kraak-share-card.svg",
       "imageAlt": "Carte de partage KRAAK Consulting présentant formation, projets et mobilité internationale."
     },
@@ -17,10 +17,10 @@
   {
     "path": "a-propos",
     "title": "À propos | Former, structurer, transformer | KRAAK Consulting",
-    "description": "Découvrez la mission, la vision et les valeurs de KRAAK Consulting au service des compétences, des projets et des opportunités internationales.",
+    "description": "Découvrez comment KRAAK Consulting révèle le potentiel, développe les compétences et accompagne vers un impact professionnel et communautaire durable.",
     "openGraph": {
       "title": "À propos de KRAAK Consulting",
-      "description": "Former, structurer et transformer des trajectoires professionnelles et communautaires.",
+      "description": "Former, structurer et transformer des trajectoires avec une vision africaine et internationale.",
       "imagePath": "/open-graph/kraak-share-card.svg",
       "imageAlt": "Carte de partage KRAAK Consulting présentant formation, projets et mobilité internationale."
     },
@@ -31,11 +31,11 @@
   },
   {
     "path": "services",
-    "title": "Services | Formation, projets, immigration et entreprises | KRAAK",
-    "description": "Découvrez les services KRAAK Consulting en formation, gestion de projets, immigration et solutions entreprises.",
+    "title": "Services | Formation, projets, études, immigration et entreprises | KRAAK",
+    "description": "Découvrez les services KRAAK Consulting en formation, recherche et gestion de projets, études et immigration, et solutions entreprises.",
     "openGraph": {
       "title": "Services KRAAK Consulting",
-      "description": "Des solutions concrètes pour apprendre, entreprendre et préparer un projet international.",
+      "description": "Des solutions concrètes pour apprendre, entreprendre, structurer un projet et préparer une trajectoire internationale.",
       "imagePath": "/open-graph/kraak-share-card.svg",
       "imageAlt": "Carte de partage KRAAK Consulting présentant formation, projets et mobilité internationale."
     },
@@ -61,11 +61,11 @@
   },
   {
     "path": "programmes",
-    "title": "Programmes | Leadership, communauté et étudiants | KRAAK",
-    "description": "Explorez les programmes KRAAK Consulting : ateliers leadership jeunesse, engagement communautaire, parcours étudiants, conférences et forums.",
+    "title": "Programmes | Trajectoires, leadership et communauté | KRAAK",
+    "description": "Explorez les programmes KRAAK Consulting : ateliers leadership jeunesse, engagement communautaire, parcours étudiants et conférences utiles à la progression des trajectoires.",
     "openGraph": {
       "title": "Programmes KRAAK Consulting",
-      "description": "Des programmes conçus pour transformer des trajectoires.",
+      "description": "Des programmes conçus pour transformer des trajectoires avec plus de clarté, d'engagement et d'impact.",
       "imagePath": "/open-graph/kraak-share-card.svg",
       "imageAlt": "Carte de partage KRAAK Consulting présentant formation, projets et mobilité internationale."
     },
@@ -91,8 +91,8 @@
   },
   {
     "path": "contact",
-    "title": "Contact | Parlez de votre projet | KRAAK Consulting",
-    "description": "Contactez KRAAK Consulting si vous êtes étudiant, professionnel, entrepreneur ou entreprise et souhaitez une solution adaptée.",
+    "title": "Contact | Parlons de votre projet | KRAAK Consulting",
+    "description": "Formation, gestion de projets, immigration ou besoin entreprise : contactez KRAAK Consulting via le formulaire ou WhatsApp.",
     "openGraph": {
       "title": "Parlons de votre projet",
       "description": "Formation, projet, immigration ou besoin entreprise : envoyez votre demande à KRAAK Consulting.",

--- a/apps/client/projects/web/src/app/shared/testimonials/testimonials.spec.ts
+++ b/apps/client/projects/web/src/app/shared/testimonials/testimonials.spec.ts
@@ -18,7 +18,7 @@ describe('Testimonials', () => {
 
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
     expect(text).toContain('Prévisualisation du format témoignages');
-    expect(text).toContain('Robert Fox');
+    expect(text).toContain('Aïcha K.');
   });
 
   it('Given aucun item et placeholder désactivé, When le composant est rendu, Then rien n est affiché', () => {

--- a/apps/client/projects/web/src/app/shared/testimonials/testimonials.ts
+++ b/apps/client/projects/web/src/app/shared/testimonials/testimonials.ts
@@ -21,30 +21,30 @@ export class Testimonials {
   readonly fallbackTestimonials: Testimonial[] = [
     {
       id: 1,
-      name: 'Robert Fox',
-      job: 'Product Designer',
+      name: 'Aïcha K.',
+      job: 'Jeune professionnelle',
       avatar:
         'https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/avatars/circle/avatar-m-16.png',
       comment:
-        'Sed adipiscing diam donec adipiscing. Est lorem ipsum dolor sit amet consectetur. Auctor elit sed vulputate mi sit amet mauris commodo quis. Pulvinar neque laoreet suspendisse interdum consectetur.',
+        "Grâce à KRAAK, j'ai clarifié mon objectif de mobilité et identifié les étapes concrètes pour renforcer mon profil avant de lancer mes démarches.",
     },
     {
       id: 2,
-      name: 'Jane Cooper',
-      job: 'UI/UX Designer',
+      name: 'Moussa T.',
+      job: 'Entrepreneur',
       avatar:
         'https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/avatars/circle/avatar-f-18.png',
       comment:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, nunc sit amet aliquam lacinia, nisl nisl aliquam nisl, nec aliquam nisl nisl sit amet lorem.',
+        "L'accompagnement projet nous a permis de transformer une idée floue en feuille de route structurée, avec des priorités lisibles et des actions réalistes.",
     },
     {
       id: 3,
-      name: 'Wade Warren',
-      job: 'Software Engineer',
+      name: 'Clarisse N.',
+      job: 'Responsable RH',
       avatar:
         'https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images/blocks/avatars/circle/avatar-m-1.png',
       comment:
-        'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.',
+        'Le format entreprise est sobre, utile et orienté terrain. Il aide vraiment à travailler la cohésion, le leadership et la montée en compétences.',
     },
   ];
 

--- a/apps/client/tests/e2e/contact-form.spec.ts
+++ b/apps/client/tests/e2e/contact-form.spec.ts
@@ -1,6 +1,22 @@
 import { expect, test } from '@playwright/test';
 
 test.describe(`Page contact — comportement formulaire`, () => {
+  test(`Given la page contact, When le visiteur cherche un échange rapide, Then une action WhatsApp visible mène vers le canal dédié`, async ({
+    page,
+  }) => {
+    await page.goto('/contact');
+
+    const whatsappLink = page.getByRole('link', {
+      name: 'Discuter sur WhatsApp',
+    });
+
+    await expect(whatsappLink).toBeVisible();
+    await expect(whatsappLink).toHaveAttribute(
+      'href',
+      /https:\/\/wa\.me\/2250502741818/,
+    );
+  });
+
   test(`Given la page contact, When l'utilisateur soumet un formulaire valide, Then un message de confirmation est affiché`, async ({
     page,
   }) => {

--- a/apps/client/tests/e2e/seo.spec.ts
+++ b/apps/client/tests/e2e/seo.spec.ts
@@ -6,10 +6,12 @@ test.describe(`SEO technique du site vitrine`, () => {
   }) => {
     await page.goto('/services');
 
-    await expect(page).toHaveTitle(/Services/);
+    await expect(page).toHaveTitle(
+      /Services \| Formation, projets, études, immigration et entreprises/i,
+    );
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
-      /formation, gestion de projets, immigration et solutions entreprises/i,
+      /formation, recherche et gestion de projets, études et immigration, et solutions entreprises/i,
     );
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
       'href',
@@ -34,10 +36,10 @@ test.describe(`SEO technique du site vitrine`, () => {
   }) => {
     await page.goto('/contact');
 
-    await expect(page).toHaveTitle(/Contact/);
+    await expect(page).toHaveTitle(/Contact \| Parlons de votre projet/i);
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
-      /étudiant, professionnel, entrepreneur ou entreprise/i,
+      /formation, gestion de projets, immigration ou besoin entreprise/i,
     );
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
       'href',

--- a/apps/client/tests/e2e/smoke.spec.ts
+++ b/apps/client/tests/e2e/smoke.spec.ts
@@ -12,7 +12,7 @@ test.describe(`Page d'accueil — smoke tests`, () => {
     page,
   }) => {
     await expect(page).toHaveTitle(
-      'KRAAK Consulting | Formation, projets et mobilité internationale',
+      'KRAAK Consulting | Développez vos compétences, lancez vos projets',
     );
   });
 

--- a/docs/context/content_draft.md
+++ b/docs/context/content_draft.md
@@ -5,32 +5,33 @@
 ### Accueil
 
 **Titre :**
-Développez votre potentiel. Construisez votre impact.
+Développez vos compétences. Lancez vos projets. Accédez aux opportunités internationales.
 
 **Sous-titre :**
-KRAAK accompagne les jeunes professionnels et les organisations vers des opportunités concrètes, locales et internationales.
+KRAAK Consulting accompagne étudiants, professionnels, entreprises et diaspora avec des solutions concrètes en formation, gestion de projets et immigration.
 
 **CTA principal :**
-Demander une consultation
+Réserver une consultation / Découvrir nos programmes
 
 **Résumé mission :**
-Nous identifions, formons et accompagnons des talents pour leur permettre de s’intégrer stratégiquement dans des environnements professionnels exigeants.
+Vous avez un objectif. Nous cheminons avec vous et vous aidons à l’atteindre.
+KRAAK Consulting est un cabinet à expertise internationale qui forme, accompagne et propulse des individus et des organisations vers des résultats concrets : emploi, projets réussis, mobilité internationale.
 
 ---
 
 ### À propos
 
 **Titre :**
-Former une génération prête à agir
+Former. Structurer. Transformer.
 
 **Mission :**
-Accompagner les jeunes dans le développement de compétences solides et d’un positionnement professionnel clair.
+Révéler le potentiel, développer les compétences et accompagner vers un impact professionnel et communautaire durable.
 
 **Vision :**
-Construire une génération de leaders africains capables de créer un impact durable.
+Former une génération de leaders africains capables d’agir, d’influencer et de construire un avenir solide, localement et à l’international.
 
 **Valeurs :**
-Humanisme • Responsabilité • Leadership • Solidarité • Résilience • Ouverture • Impact
+Humanisme • Responsabilité • Leadership • Résilience • Solidarité • Ouverture internationale
 
 ---
 
@@ -39,46 +40,46 @@ Humanisme • Responsabilité • Leadership • Solidarité • Résilience •
 #### Formation
 
 **Courte :**
-Développement de compétences techniques et linguistiques.
+Des compétences qui ouvrent des portes.
 
 **Longue :**
-Programmes de formation en développement personnel, communication professionnelle et langues (anglais/français), adaptés aux exigences du marché.
+Nos formations couvrent les langues professionnelles, le développement personnel et le leadership, les soft skills et l’employabilité : anglais professionnel, français professionnel, préparation aux tests internationaux, confiance en soi, prise de parole, leadership stratégique, préparation aux entretiens, rédaction CV et placement en emploi. Les programmes KRAAK prolongent cette logique avec des ateliers leadership jeunesse, des parcours pour étudiants, de l’engagement communautaire et des conférences utiles à la progression des trajectoires.
 
 #### Gestion de projet
 
 **Courte :**
-Accompagnement stratégique des organisations.
+Vos idées méritent une structure solide.
 
 **Longue :**
-Support en structuration de projets, identification de talents, recrutement et développement de partenariats.
+Nous accompagnons la structuration, la croissance et l’optimisation des organisations, le développement de startups, la planification et le suivi de projets, les partenariats stratégiques et le recrutement de talents. Les besoins entreprises sont pris en charge dans la même logique, avec des solutions ciblées en formation du personnel, cohésion d’équipe, gestion des conflits, leadership organisationnel et santé / culture d’entreprise.
 
 #### Immigration
 
 **Courte :**
-Orientation vers des opportunités internationales.
+Votre projet international commence ici.
 
 **Longue :**
-Conseil stratégique pour études, travail et mobilité internationale.
+Nous accompagnons les projets d’études au Canada et aux États-Unis, l’immigration professionnelle, les permis de travail, le regroupement familial, la recherche d’emploi à l’international et l’intégration socio-professionnelle. L’accompagnement s’appuie sur une approche fiable et stratégique, avec des consultants et avocats en immigration agréés.
 
 ---
 
 ### Contact
 
 **CTA :**
-Contactez-nous
+Envoyer ma demande / Discuter sur WhatsApp
 
 ---
 
 ## 2. FAQ ❓
 
 - Qui peut bénéficier des services KRAAK ?
-  → Étudiants, jeunes professionnels et organisations.
+  → Étudiants, professionnels, entreprises, diaspora et organisations qui veulent clarifier une trajectoire, structurer un projet ou préparer une mobilité internationale.
 
 - Comment démarrer ?
-  → Via le formulaire de contact ou une demande de consultation.
+  → Via le formulaire de contact, une demande de consultation ou un premier échange sur WhatsApp selon votre besoin.
 
 - Les formations sont-elles en ligne ?
-  → Selon les programmes.
+  → Oui, selon les programmes et le format retenu ; une partie des accompagnements peut être suivie à distance.
 
 ---
 
@@ -86,13 +87,13 @@ Contactez-nous
 
 ### Accueil
 
-- Title : KRAAK — Développez votre potentiel
-- Description : Formation, accompagnement et opportunités internationales pour jeunes professionnels.
+- Title : KRAAK Consulting | Développez vos compétences, lancez vos projets
+- Description : KRAAK Consulting accompagne étudiants, professionnels, entreprises et diaspora avec des solutions concrètes en formation, gestion de projets et immigration.
 
 ### Open Graph
 
-- Title : KRAAK
-- Description : Développez vos compétences et accédez à des opportunités internationales.
+- Title : KRAAK Consulting | Développez vos compétences, lancez vos projets
+- Description : Développez vos compétences, lancez vos projets et accédez aux opportunités internationales avec un accompagnement KRAAK clair et structuré.
 
 ---
 
@@ -113,15 +114,15 @@ Ce site utilise des cookies pour analyser le trafic.
 - Logo : variantes KRAAK intégrées
 - Favicon et icônes app : symbole KRAAK généré
 - Couleurs : noir, blanc, gris
-- Typographie : Inter + JetBrains Mono
+- Typographie : Poppins + IBM Plex Mono
 
 ---
 
 ## 6. Coordonnées 📞
 
 - Email : kraakconsulting@gmail.com
-- Téléphone : à définir
-- WhatsApp : à définir
+- Téléphone : via WhatsApp
+- WhatsApp : +225 05 02 74 18 18
 - Zone : Afrique / international
 
 ---


### PR DESCRIPTION
## Résumé
- aligne `docs/context/content_draft.md` sur le master DOCX tout en conservant strictement sa structure
- réaligne le copy du funnel principal (`Accueil`, `À propos`, `Services`, `Programmes`, `Contact`) avec les CTA/FAQ liés, le footer, les placeholders témoignages et le SEO
- ajoute un point d’entrée WhatsApp visible sur la page Contact sans toucher au contrat du formulaire ni à l’API
- inclut aussi le changement local déjà présent sur `README.md` (` ``` ` -> ` ```text `), comme demandé

## Détails
- `Services` conserve les 4 familles visibles et adopte le wording DOCX : Formation, recherche & gestion de projets, études & immigration, solutions entreprises
- `Contact` expose WhatsApp à la fois dans les coordonnées et comme CTA secondaire
- `site-seo.json` est mis à jour pour `home`, `about`, `services`, `programs` et `contact`
- les tests unitaires et E2E textuels/SEO concernés sont ajustés au nouveau contenu

## Validation
- `pnpm --filter @kraak/client test:web`
- `pnpm --dir apps/client exec playwright test tests/e2e/smoke.spec.ts tests/e2e/programs.spec.ts tests/e2e/contact-form.spec.ts tests/e2e/seo.spec.ts`
- `pnpm build:web:staging`
- `pnpm lint`

## Notes
- aucun contrat API, DTO, route NestJS ou documentation Swagger n’a été modifié
- les warnings lint existants hors scope (`support.service.spec.ts`, `support-flow.spec.ts`) restent non bloquants