### PR TITLE
fix(web): remove CSP-blocked inline stylesheet handler

### DIFF
--- a/apps/client/angular.json
+++ b/apps/client/angular.json
@@ -24,6 +24,11 @@
             "index": "projects/web/src/index.html",
             "browser": "projects/web/src/main.ts",
             "polyfills": [],
+            "optimization": {
+              "styles": {
+                "inlineCritical": false
+              }
+            },
             "tsConfig": "projects/web/tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev:api:staging": "pnpm --filter @kraak/api run start:staging",
     "build:api": "pnpm --filter @kraak/api build",
     "check:observability": "node ./scripts/check-observability.mjs",
-    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/setup-android-env.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs",
+    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/setup-android-env.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs ./scripts/angular-web-build-config.test.mjs",
     "test:api": "pnpm --filter @kraak/api test",
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
     "test:coverage": "pnpm --filter @kraak/api test:cov && pnpm --filter @kraak/client test:coverage && pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test:coverage",

--- a/scripts/angular-web-build-config.test.mjs
+++ b/scripts/angular-web-build-config.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const angularWorkspace = JSON.parse(
+  readFileSync(new URL('../apps/client/angular.json', import.meta.url), 'utf8'),
+);
+
+const webBuildOptions =
+  angularWorkspace.projects?.web?.architect?.build?.options ?? {};
+
+test('Given the web production build, When CSP forbids inline event handlers, Then critical CSS inlining stays disabled', () => {
+  assert.equal(webBuildOptions.optimization?.styles?.inlineCritical, false);
+});


### PR DESCRIPTION
## Summary
- disable Angular critical CSS inlining for the web build so production HTML no longer emits onload="this.media='all'" on the main stylesheet
- add a workspace regression test that locks this CSP-safe build configuration in place
- keep the existing Vercel output assertion in the workspace config suite
## Root cause
Angular's critical CSS optimization was rewriting the generated stylesheet link to load asynchronously via an inline onload handler. Our CSP blocks inline event handlers, so the browser rejected it.
## Validation
- pnpm.cmd test:workspace
- pnpm.cmd build:web
- verified pps/client/dist/web/browser/index.html no longer contains onload= or 	his.media='all'
Closes #402