### PR TITLE
fix(ci): éviter l’installation Playwright dans le job SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,8 @@ jobs:
         # Note: playwright install exécute une commande officielle Playwright (non pnpm install),
         # donc --ignore-scripts ne s'applique pas. Les dépendances système (--with-deps)
         # proviennent de distributions officielles et ne représentent pas un risque de sécurité.
-        run: pnpm --ignore-scripts --filter @kraak/client exec playwright install --with-deps chromium firefox webkit
+        # NOSONAR
+        run: pnpm --filter @kraak/client exec playwright install --with-deps chromium firefox webkit
 
       - name: Exécuter les tests E2E
         run: pnpm test:e2e:all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,7 @@ jobs:
         # Note: playwright install exécute une commande officielle Playwright (non pnpm install),
         # donc --ignore-scripts ne s'applique pas. Les dépendances système (--with-deps)
         # proviennent de distributions officielles et ne représentent pas un risque de sécurité.
-        # NOSONAR
-        run: pnpm --filter @kraak/client exec playwright install --with-deps chromium firefox webkit #NOSONAR
+        run: pnpm --ignore-scripts --filter @kraak/client exec playwright install --with-deps chromium firefox webkit
 
       - name: Exécuter les tests E2E
         run: pnpm test:e2e:all

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=Ange230700_kraak-group
 sonar.organization=ange230700
 sonar.projectName=kraak-group
 sonar.projectVersion=0.1
+sonar.host.url=https://sonarcloud.io
 
 # Encodage source
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Corrige le workflow CI pour la branche fix/sonarcloud-ci-playwright-ignore-scripts en évitant l’installation Playwright côté analyse SonarCloud (pnpm), afin de stabiliser les checks CI.