### PR TITLE
chore: promote prod preview gating to staging

### DIFF
--- a/apps/client/angular.json
+++ b/apps/client/angular.json
@@ -53,10 +53,31 @@
           },
           "configurations": {
             "production": {
+              "optimization": {
+                "styles": {
+                  "inlineCritical": false
+                }
+              },
               "fileReplacements": [
                 {
                   "replace": "projects/web/src/environments/environment.ts",
                   "with": "projects/web/src/environments/environment.production.ts"
+                },
+                {
+                  "replace": "projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.ts",
+                  "with": "projects/web/src/app/shared/home-preview-sections/home-preview-sections.prod.component.ts"
+                },
+                {
+                  "replace": "projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.ts",
+                  "with": "projects/web/src/app/shared/about-preview-sections/about-preview-sections.prod.component.ts"
+                },
+                {
+                  "replace": "projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.ts",
+                  "with": "projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.prod.component.ts"
+                },
+                {
+                  "replace": "projects/web/src/app/participant-area.routes.ts",
+                  "with": "projects/web/src/app/participant-area.prod.routes.ts"
                 }
               ],
               "budgets": [
@@ -74,6 +95,11 @@
               "outputHashing": "all"
             },
             "staging": {
+              "optimization": {
+                "styles": {
+                  "inlineCritical": false
+                }
+              },
               "fileReplacements": [
                 {
                   "replace": "projects/web/src/environments/environment.ts",

--- a/apps/client/projects/web/public/sitemap.xml
+++ b/apps/client/projects/web/public/sitemap.xml
@@ -36,6 +36,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://kraak-consulting.vercel.app/faq</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://kraak-consulting.vercel.app/mentions-legales</loc>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>

--- a/apps/client/projects/web/src/app/app.routes.server.ts
+++ b/apps/client/projects/web/src/app/app.routes.server.ts
@@ -1,8 +1,20 @@
 import { RenderMode, ServerRoute } from '@angular/ssr';
 
+import { seoPages } from './seo/site-seo';
+
+const publicPrerenderPaths = seoPages.map((page) => page.path);
+
+const publicPrerenderRoutes: ServerRoute[] = publicPrerenderPaths.map(
+  (path) => ({
+    path,
+    renderMode: RenderMode.Prerender as const,
+  }),
+);
+
 export const serverRoutes: ServerRoute[] = [
+  ...publicPrerenderRoutes,
   {
     path: '**',
-    renderMode: RenderMode.Prerender,
+    renderMode: RenderMode.Server,
   },
 ];

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -1,8 +1,14 @@
-import { buildMarketingRoute, buildRoutes, routes } from './app.routes';
+import {
+  buildMarketingRoute,
+  buildRoutes,
+  participantAreaCanMatch,
+  routes,
+} from './app.routes';
 import {
   participantRoleGuard,
   participantRoleChildGuard,
 } from './core/auth/auth.guard';
+import { environment } from '../environments/environment';
 
 describe('Web routes', () => {
   const marketingPaths = [
@@ -13,6 +19,8 @@ describe('Web routes', () => {
     'programmes',
     'ressources',
     'contact',
+    'mentions-legales',
+    'politique-de-confidentialite',
   ];
   const participantPaths = [
     'connexion',
@@ -20,64 +28,70 @@ describe('Web routes', () => {
     'mot-de-passe-oublie',
     'participant',
   ];
-  const builtRoutes = buildRoutes();
-  const paths = builtRoutes.map((r) => r.path);
 
-  it('When inspecting routes Then all public marketing routes are defined', () => {
-    for (const path of marketingPaths) {
-      expect(paths).toContain(path);
-    }
-  });
+  describe('Given public marketing pages', () => {
+    it('When building routes Then all public marketing routes are defined', () => {
+      const builtRoutes = buildRoutes();
+      const paths = builtRoutes.map((route) => route.path);
 
-  it('When inspecting routes Then participant and auth routes are defined', () => {
-    for (const path of participantPaths) {
-      expect(paths).toContain(path);
-    }
-  });
+      for (const path of marketingPaths) {
+        expect(paths).toContain(path);
+      }
+    });
 
-  it('When inspecting routes Then a wildcard fallback serves the dedicated not-found page', () => {
-    const wildcard = builtRoutes.find((r) => r.path === '**');
-    expect(wildcard).toBeDefined();
-    expect(wildcard!.loadComponent).toBeDefined();
-    expect(wildcard!.title).toBe('Page introuvable | KRAAK Consulting');
-    expect(wildcard!.data?.['seo']).toBeDefined();
-  });
-
-  it('When inspecting page routes Then every page component is lazy-loaded', () => {
-    const pageRoutes = builtRoutes.filter(
-      (r) => r.path !== '**' && r.path !== 'participant',
-    );
-    for (const route of pageRoutes) {
-      expect(route.loadComponent).toBeDefined();
-    }
-  });
-
-  it('When inspecting marketing routes Then every route exposes a title and SEO metadata', () => {
-    const pageRoutes = builtRoutes.filter((route) =>
-      marketingPaths.includes(route.path ?? ''),
-    );
-
-    for (const route of pageRoutes) {
-      expect(route.title).toEqual(expect.any(String));
-      expect(route.data?.['seo']).toBeDefined();
-    }
-  });
-
-  it('When inspecting participant routes Then auth and participant routes are reachable without canMatch gating', () => {
-    const gated = builtRoutes.filter((r) =>
-      participantPaths.includes(r.path ?? ''),
-    );
-    expect(gated.length).toBe(participantPaths.length);
-    for (const route of gated) {
-      expect(route.canMatch).toBeUndefined();
-    }
-  });
-
-  describe('Participant authenticated routes', () => {
-    it('When inspecting the participant route Then it is protected by both auth guards', () => {
-      const participantRoute = builtRoutes.find(
-        (r) => r.path === 'participant',
+    it('When inspecting marketing routes Then every route exposes a title and SEO metadata', () => {
+      const builtRoutes = buildRoutes();
+      const pageRoutes = builtRoutes.filter((route) =>
+        marketingPaths.includes(route.path ?? ''),
       );
+
+      for (const route of pageRoutes) {
+        expect(route.title).toEqual(expect.any(String));
+        expect(route.data?.['seo']).toBeDefined();
+      }
+    });
+  });
+
+  describe('Given the participant area is disabled for the build', () => {
+    it('When building routes Then auth and participant routes are excluded', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: false });
+      const paths = builtRoutes.map((route) => route.path);
+
+      for (const path of participantPaths) {
+        expect(paths).not.toContain(path);
+      }
+    });
+  });
+
+  describe('Given the participant area is enabled for the build', () => {
+    it('When building routes Then auth and participant routes are defined', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
+      const paths = builtRoutes.map((route) => route.path);
+
+      for (const path of participantPaths) {
+        expect(paths).toContain(path);
+      }
+    });
+
+    it('When inspecting participant routes Then every auth and participant route is protected by canMatch gating', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
+      const gatedRoutes = builtRoutes.filter((route) =>
+        participantPaths.includes(route.path ?? ''),
+      );
+
+      expect(gatedRoutes.length).toBe(participantPaths.length);
+
+      for (const route of gatedRoutes) {
+        expect(route.canMatch).toContain(participantAreaCanMatch);
+      }
+    });
+
+    it('When inspecting the participant route Then it is protected by both auth guards', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
+      const participantRoute = builtRoutes.find(
+        (route) => route.path === 'participant',
+      );
+
       expect(participantRoute).toBeDefined();
       expect(participantRoute!.canActivate).toContain(participantRoleGuard);
       expect(participantRoute!.canActivateChild).toContain(
@@ -86,34 +100,66 @@ describe('Web routes', () => {
     });
 
     it('When inspecting the participant route Then a dashboard child route exists', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
       const participantRoute = builtRoutes.find(
-        (r) => r.path === 'participant',
+        (route) => route.path === 'participant',
       );
       const dashboardRoute = participantRoute!.children?.find(
-        (r) => r.path === 'dashboard',
+        (route) => route.path === 'dashboard',
       );
+
       expect(dashboardRoute).toBeDefined();
       expect(dashboardRoute!.loadComponent).toBeDefined();
     });
 
     it('When navigating to /participant Then the default child redirects to /participant/dashboard', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
       const participantRoute = builtRoutes.find(
-        (r) => r.path === 'participant',
+        (route) => route.path === 'participant',
       );
       const defaultRedirect = participantRoute!.children?.find(
-        (r) => r.path === '',
+        (route) => route.path === '',
       );
+
       expect(defaultRedirect).toBeDefined();
       expect(defaultRedirect!.redirectTo).toBe('dashboard');
       expect(defaultRedirect!.pathMatch).toBe('full');
     });
   });
 
-  it('exports the runtime routes constant', () => {
-    expect(routes.length).toBe(builtRoutes.length);
+  describe('Given the route table', () => {
+    it('When inspecting routes Then a wildcard fallback serves the dedicated not-found page', () => {
+      const builtRoutes = buildRoutes();
+      const wildcard = builtRoutes.find((route) => route.path === '**');
+
+      expect(wildcard).toBeDefined();
+      expect(wildcard!.loadComponent).toBeDefined();
+      expect(wildcard!.title).toBe('Page introuvable | KRAAK Consulting');
+      expect(wildcard!.data?.['seo']).toBeDefined();
+    });
+
+    it('When inspecting page routes Then every page component is lazy-loaded', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
+      const pageRoutes = builtRoutes.filter(
+        (route) => route.path !== '**' && route.path !== 'participant',
+      );
+
+      for (const route of pageRoutes) {
+        expect(route.loadComponent).toBeDefined();
+      }
+    });
+
+    it('When comparing exported routes Then they match the environment default', () => {
+      const exportedPaths = routes.map((route) => route.path);
+      const rebuiltPaths = buildRoutes({
+        includeParticipantArea: environment.enableParticipantArea,
+      }).map((route) => route.path);
+
+      expect(exportedPaths).toEqual(rebuiltPaths);
+    });
   });
 
-  describe('buildMarketingRoute', () => {
+  describe('Given buildMarketingRoute', () => {
     it('When the path has no SEO entry Then it throws a descriptive error', () => {
       class MissingSeoComponent {
         static readonly marker = 'missing-seo';
@@ -127,11 +173,16 @@ describe('Web routes', () => {
     });
   });
 
-  describe('Lazy-loaded route components', () => {
+  describe('Given lazy-loaded route components', () => {
     it('When each marketing route loadComponent is invoked Then it resolves to a component', async () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
       const targets = builtRoutes.filter(
-        (r) => r.path !== '**' && r.path !== 'participant' && r.loadComponent,
+        (route) =>
+          route.path !== '**' &&
+          route.path !== 'participant' &&
+          route.loadComponent,
       );
+
       for (const route of targets) {
         const loaded = await (route.loadComponent as () => Promise<unknown>)();
         expect(loaded).toBeTruthy();
@@ -139,15 +190,18 @@ describe('Web routes', () => {
     }, 15000);
 
     it('When the participant dashboard child loadComponent is invoked Then it resolves to a component', async () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
       const participantRoute = builtRoutes.find(
-        (r) => r.path === 'participant',
+        (route) => route.path === 'participant',
       );
-      const dashboard = participantRoute!.children!.find(
-        (c) => c.path === 'dashboard',
+      const dashboardRoute = participantRoute!.children!.find(
+        (childRoute) => childRoute.path === 'dashboard',
       );
+
       const loaded = await (
-        dashboard!.loadComponent as () => Promise<unknown>
+        dashboardRoute!.loadComponent as () => Promise<unknown>
       )();
+
       expect(loaded).toBeTruthy();
     });
   });

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -1,10 +1,11 @@
 import { Route, Routes } from '@angular/router';
 
-import {
-  participantRoleGuard,
-  participantRoleChildGuard,
-} from './core/auth/auth.guard';
 import { findSeoPageByPath, type SeoPageDefinition } from './seo/site-seo';
+import {
+  participantAreaCanMatch,
+  participantAreaRoutes,
+} from './participant-area.routes';
+import { environment } from '../environments/environment';
 
 export const buildMarketingRoute = (
   path: string,
@@ -58,11 +59,11 @@ const notFoundSeo: SeoPageDefinition = {
   path: '**',
   title: 'Page introuvable | KRAAK Consulting',
   description:
-    "La page demandée est introuvable. Retrouvez la FAQ, l'accueil ou le formulaire de contact KRAAK.",
+    "La page demand�e est introuvable. Retrouvez la FAQ, l'accueil ou le formulaire de contact KRAAK.",
   openGraph: {
     title: 'Page introuvable | KRAAK Consulting',
     description:
-      "La page demandée est introuvable. Retrouvez la FAQ, l'accueil ou le formulaire de contact KRAAK.",
+      "La page demand�e est introuvable. Retrouvez la FAQ, l'accueil ou le formulaire de contact KRAAK.",
     imagePath: '/open-graph/kraak-share-card.svg',
     imageAlt: 'Carte de partage KRAAK Consulting.',
   },
@@ -72,45 +73,19 @@ const notFoundSeo: SeoPageDefinition = {
   },
 };
 
-const participantAreaRoutes: Routes = [
-  {
-    path: 'connexion',
-    title: 'Connexion | KRAAK',
-    loadComponent: () => import('./features/auth/sign-in.page'),
-  },
-  {
-    path: 'inscription',
-    title: 'Inscription | KRAAK',
-    loadComponent: () => import('./features/auth/sign-up.page'),
-  },
-  {
-    path: 'mot-de-passe-oublie',
-    title: 'Mot de passe oubli\u00E9 | KRAAK',
-    loadComponent: () => import('./features/auth/password-reset.page'),
-  },
-  {
-    path: 'participant',
-    canActivate: [participantRoleGuard],
-    canActivateChild: [participantRoleChildGuard],
-    children: [
-      {
-        path: 'dashboard',
-        loadComponent: () =>
-          import('./features/participant/dashboard/dashboard.page'),
-      },
-      {
-        path: '',
-        redirectTo: 'dashboard',
-        pathMatch: 'full',
-      },
-    ],
-  },
-];
+export { participantAreaCanMatch };
 
-export function buildRoutes(): Routes {
+interface BuildRoutesOptions {
+  readonly includeParticipantArea?: boolean;
+}
+
+export function buildRoutes(options: BuildRoutesOptions = {}): Routes {
+  const includeParticipantArea =
+    options.includeParticipantArea ?? environment.enableParticipantArea;
+
   return [
     ...marketingRoutes,
-    ...participantAreaRoutes,
+    ...(includeParticipantArea ? participantAreaRoutes : []),
     {
       path: '**',
       title: notFoundSeo.title,

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.spec.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.spec.ts
@@ -1,3 +1,4 @@
+import { environment } from '../../../environments/environment';
 import {
   getRuntimeConfig,
   isParticipantAreaEnabled,
@@ -17,28 +18,31 @@ describe('Runtime config helpers', () => {
   describe('Given the runtime config is undefined', () => {
     it('When getRuntimeConfig is called Then it returns an empty object', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+
       expect(getRuntimeConfig()).toEqual({});
     });
 
-    it('When isParticipantAreaEnabled is called Then it returns false', () => {
+    it('When isParticipantAreaEnabled is called Then it falls back to the environment default', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
-      expect(isParticipantAreaEnabled()).toBe(false);
+
+      expect(isParticipantAreaEnabled()).toBe(
+        environment.enableParticipantArea,
+      );
     });
   });
 
-  describe('Given enableParticipantArea is true', () => {
+  describe('Given enableParticipantArea is true at runtime', () => {
     it('When isParticipantAreaEnabled is called Then it returns true', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+
       expect(isParticipantAreaEnabled()).toBe(true);
     });
   });
 
-  describe('Given enableParticipantArea is false or absent', () => {
+  describe('Given enableParticipantArea is false at runtime', () => {
     it('When isParticipantAreaEnabled is called Then it returns false', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
-      expect(isParticipantAreaEnabled()).toBe(false);
 
-      globalThis.__KRAAK_RUNTIME_CONFIG__ = {};
       expect(isParticipantAreaEnabled()).toBe(false);
     });
   });
@@ -48,6 +52,7 @@ describe('Runtime config helpers', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = {
         apiBaseUrl: `${TEST_RUNTIME_API_BASE_URL}/`,
       };
+
       expect(resolveApiBaseUrl(TEST_FALLBACK_API_BASE_URL)).toBe(
         TEST_RUNTIME_API_BASE_URL,
       );
@@ -67,6 +72,7 @@ describe('Runtime config helpers', () => {
   describe('Given the runtime config has no apiBaseUrl', () => {
     it('When resolveApiBaseUrl is called Then it returns the fallback value', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+
       expect(resolveApiBaseUrl(`${TEST_FALLBACK_API_BASE_URL}/`)).toBe(
         TEST_FALLBACK_API_BASE_URL,
       );
@@ -74,6 +80,7 @@ describe('Runtime config helpers', () => {
 
     it('When resolveApiBaseUrl is called without fallback Then it returns an empty string', () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+
       expect(resolveApiBaseUrl()).toBe('');
     });
 

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
@@ -16,7 +16,10 @@ export function getRuntimeConfig(): KraakRuntimeConfig {
 }
 
 export function isParticipantAreaEnabled(): boolean {
-  return getRuntimeConfig().enableParticipantArea === true;
+  return (
+    getRuntimeConfig().enableParticipantArea ??
+    environment.enableParticipantArea
+  );
 }
 
 export function isProductionEnvironment(): boolean {

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
@@ -22,14 +22,6 @@ export function isParticipantAreaEnabled(): boolean {
   );
 }
 
-export function isProductionEnvironment(): boolean {
-  return environment.environmentName === 'production';
-}
-
-export function canShowPreviewContent(): boolean {
-  return !isProductionEnvironment();
-}
-
 function stripTrailingSlashes(value: string): string {
   let endIndex = value.length;
 

--- a/apps/client/projects/web/src/app/features/about/about.page.html
+++ b/apps/client/projects/web/src/app/features/about/about.page.html
@@ -297,9 +297,7 @@
   </div>
 </section>
 
-@if (canShowPreviewContent()) {
-  <kraak-team-grid />
-}
+<kraak-about-preview-sections />
 
 <kraak-cta-banner
   heading="Vous partagez cette vision ?"

--- a/apps/client/projects/web/src/app/features/about/about.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.spec.ts
@@ -10,12 +10,12 @@ describe('AboutPage', () => {
     }).compileComponents();
   });
 
-  it('should create', () => {
+  it('Given the about page component When it is created Then the instance exists', () => {
     const fixture = TestBed.createComponent(AboutPage);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the heading', () => {
+  it('Given the about page When it renders Then it shows the page heading', () => {
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
@@ -24,7 +24,7 @@ describe('AboutPage', () => {
     );
   });
 
-  it('should render the refreshed mission, intervention levels and values', () => {
+  it('Given the about page When it renders Then it shows the mission, intervention levels and values', () => {
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
     const content = fixture.nativeElement.textContent as string;
@@ -40,7 +40,7 @@ describe('AboutPage', () => {
     expect(content).toContain('Ouverture et connexion globale');
   });
 
-  it('should render the team preview section', () => {
+  it('Given the local web build When the about page renders Then it keeps the team preview section visible for review', () => {
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
     const content = fixture.nativeElement.textContent as string;

--- a/apps/client/projects/web/src/app/features/about/about.page.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.ts
@@ -2,20 +2,18 @@ import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { NgStyle } from '@angular/common';
 
 import { HERO_BACKGROUND_STYLE } from '../../shared/brand/brand-constants';
+import { AboutPreviewSections } from '../../shared/about-preview-sections/about-preview-sections.component';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
-import { TeamGrid } from '../../shared/team-grid/team-grid.component';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
-import { canShowPreviewContent } from '../../core/runtime/runtime-config';
 
 @Component({
   selector: 'kraak-about-page',
   standalone: true,
-  imports: [NgStyle, TeamGrid, CtaBanner],
+  imports: [NgStyle, AboutPreviewSections, CtaBanner],
   templateUrl: './about.page.html',
 })
 export default class AboutPage implements OnInit, OnDestroy {
   protected readonly heroBackgroundStyle = HERO_BACKGROUND_STYLE;
-  protected readonly canShowPreviewContent = canShowPreviewContent;
 
   private readonly gsapService = inject(GsapAnimationsService);
 

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -255,36 +255,7 @@
   </div>
 </section>
 
-@if (canShowPreviewContent()) {
-  <kraak-fading-partners />
-}
-
-@if (canShowPreviewContent()) {
-  <kraak-impact-stats />
-}
-
-@if (canShowPreviewContent()) {
-  <section class="kr-perf-section bg-brand-white py-16">
-    <div class="mx-auto max-w-4xl px-4 text-center lg:px-6">
-      <p
-        class="text-secondary text-sm font-semibold tracking-[0.18em] uppercase"
-      >
-        T&eacute;moignages
-      </p>
-      <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Ils ne cherchaient pas juste une solution. Ils voulaient un
-        r&eacute;sultat.
-      </h2>
-      <p class="text-brand-navy mx-auto mt-4 max-w-2xl">
-        Un espace est r&eacute;serv&eacute; aux t&eacute;moignages clients en
-        cours de validation.
-      </p>
-    </div>
-    <div class="mx-auto mt-10 max-w-6xl px-4 lg:px-6">
-      <kraak-testimonials />
-    </div>
-  </section>
-}
+<kraak-home-preview-sections />
 
 <section class="kr-perf-section bg-neutral-50 pb-6 lg:pb-10">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -36,12 +36,12 @@ describe('HomePage', () => {
     }).compileComponents();
   });
 
-  it('should create', () => {
+  it('Given the home page component When it is created Then the instance exists', () => {
     const fixture = TestBed.createComponent(HomePage);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the consulting hero promise', () => {
+  it('Given the home page When it renders Then it shows the consulting hero promise', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
@@ -50,7 +50,7 @@ describe('HomePage', () => {
     );
   });
 
-  it('should render the primary consulting calls to action', () => {
+  it('Given the home page When it renders Then it shows the primary consulting calls to action', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
 
@@ -60,7 +60,7 @@ describe('HomePage', () => {
     expect(element.textContent).toContain('Recherche & Gestion de projets');
   });
 
-  it('should expose a dark hero background style object', () => {
+  it('Given the home page component When reading the hero background Then it exposes the expected style object', () => {
     const fixture = TestBed.createComponent(HomePage);
     const component = fixture.componentInstance;
 
@@ -72,7 +72,7 @@ describe('HomePage', () => {
     );
   });
 
-  it('should render the key solutions without repeating one service label only', () => {
+  it('Given the home page When it renders Then it lists the key solutions without collapsing them into one service label', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
 
@@ -88,7 +88,7 @@ describe('HomePage', () => {
     expect(content).toContain('Recrutement et placement en emploi');
   });
 
-  it('should render home-specific FAQ section', () => {
+  it('Given the home page When it renders Then it includes the home-specific FAQ section', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
 
@@ -98,5 +98,16 @@ describe('HomePage', () => {
     expect(content).toContain(
       'Je ne sais pas par o\u00F9 commencer, quelle est la premi\u00E8re \u00E9tape ?',
     );
+  });
+
+  it('Given the local web build When the home page renders Then the preview sections stay visible for review', () => {
+    const fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Partenaires et clients de confiance');
+    expect(content).toContain('Prévisualisation du format témoignages');
+    expect(content).toContain('Chiffres d’impact en prévisualisation');
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -10,10 +10,7 @@ import {
   type FaqItem,
 } from '../../shared/faq-accordion/faq-accordion.component';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
-import { Testimonials } from '../../shared/testimonials/testimonials.component';
-import { FadingPartners } from '../../shared/fading-partners/fading-partners.component';
-import { ImpactStats } from '../../shared/impact-stats/impact-stats.component';
-import { canShowPreviewContent } from '../../core/runtime/runtime-config';
+import { HomePreviewSections } from '../../shared/home-preview-sections/home-preview-sections.component';
 
 @Component({
   selector: 'kraak-home-page',
@@ -24,9 +21,7 @@ import { canShowPreviewContent } from '../../core/runtime/runtime-config';
     ButtonDirective,
     FaqAccordion,
     CtaBanner,
-    Testimonials,
-    FadingPartners,
-    ImpactStats,
+    HomePreviewSections,
   ],
   templateUrl: './home.page.html',
   styles: [
@@ -40,7 +35,6 @@ import { canShowPreviewContent } from '../../core/runtime/runtime-config';
 })
 export default class HomePage implements OnInit, OnDestroy {
   readonly heroBackgroundStyle = HERO_BACKGROUND_STYLE;
-  protected readonly canShowPreviewContent = canShowPreviewContent;
   protected readonly keySolutions: readonly string[] = [
     'Développement personnel et professionnel',
     'Anglais et français professionnel',

--- a/apps/client/projects/web/src/app/features/support/faq.page.html
+++ b/apps/client/projects/web/src/app/features/support/faq.page.html
@@ -34,10 +34,10 @@
             routerLink="/contact"
             href="/contact"
             class="kr-button-primary inline-flex items-center justify-center gap-2"
-            aria-label="Parler à un conseiller KRAAK"
+            aria-label="Parler &agrave; un conseiller KRAAK"
           >
             <i class="pi pi-comments" aria-hidden="true"></i>
-            <span>Parler à un conseiller</span>
+            <span>Parler &agrave; un conseiller KRAAK</span>
           </a>
           <a
             routerLink="/services"

--- a/apps/client/projects/web/src/app/features/support/faq.page.ts
+++ b/apps/client/projects/web/src/app/features/support/faq.page.ts
@@ -21,33 +21,33 @@ export default class FaqPage {
     {
       question: 'Comment choisir le bon accompagnement chez KRAAK ?',
       answer:
-        'Nous partons de votre objectif, de votre niveau de maturité et de vos contraintes. Ensuite, nous vous orientons vers le service, le programme ou le format le plus pertinent.',
+        'Nous partons de votre objectif, de votre niveau de maturit� et de vos contraintes. Ensuite, nous vous orientons vers le service, le programme ou le format le plus pertinent.',
     },
     {
-      question: 'Les accompagnements KRAAK sont-ils disponibles à distance ?',
+      question: 'Les accompagnements KRAAK sont-ils disponibles � distance ?',
       answer:
-        'Oui. Une grande partie de nos parcours peut être suivie à distance, avec un cadrage clair, des sessions planifiées et un suivi adapté à votre rythme.',
+        'Oui. Une grande partie de nos parcours peut �tre suivie � distance, avec un cadrage clair, des sessions planifi�es et un suivi adapt� � votre rythme.',
     },
     {
       question: 'Intervenez-vous uniquement pour les particuliers ?',
       answer:
-        'Non. Nous accompagnons aussi les équipes, organisations, associations et entreprises sur des besoins de formation, structuration et mise en oeuvre de projets.',
+        'Non. Nous accompagnons aussi les �quipes, organisations, associations et entreprises sur des besoins de formation, structuration et mise en oeuvre de projets.',
     },
     {
-      question: 'Sous quel délai recevez-vous une réponse après contact ?',
+      question: 'Sous quel d�lai recevez-vous une r�ponse apr�s contact ?',
       answer:
-        'Nous revenons en général sous 48h ouvrées avec une première orientation et, si nécessaire, une proposition de rendez-vous.',
+        'Nous revenons en g�n�ral sous 48h ouvr�es avec une premi�re orientation et, si n�cessaire, une proposition de rendez-vous.',
     },
     {
       question:
-        "Pouvez-vous aider sur un projet d'immigration ou de mobilité internationale ?",
+        "Pouvez-vous aider sur un projet d'immigration ou de mobilit� internationale ?",
       answer:
-        "Oui. Nous apportons un accompagnement de clarification, de préparation et d'orientation sur les étapes clés selon votre profil et votre destination cible.",
+        "Oui. Nous apportons un accompagnement de clarification, de pr�paration et d'orientation sur les �tapes cl�s selon votre profil et votre destination cible.",
     },
     {
-      question: 'Faut-il déjà avoir un projet finalisé pour vous contacter ?',
+      question: 'Faut-il d�j� avoir un projet finalis� pour vous contacter ?',
       answer:
-        "Non. Vous pouvez nous contacter dès la phase d'idée. Notre rôle est aussi de vous aider à structurer la prochaine étape utile.",
+        "Non. Vous pouvez nous contacter d�s la phase d'id�e. Notre r�le est aussi de vous aider � structurer la prochaine �tape utile.",
     },
   ];
 }

--- a/apps/client/projects/web/src/app/features/support/not-found.page.html
+++ b/apps/client/projects/web/src/app/features/support/not-found.page.html
@@ -45,29 +45,32 @@
 
       <div class="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
         <a
+          pButton
           routerLink="/"
-          class="kr-button-primary inline-flex items-center justify-center gap-2"
+          label="Retour &agrave; l'accueil"
+          icon="pi pi-home"
+          size="large"
+          class="kr-button-primary"
           aria-label="Retour à la page d'accueil"
-        >
-          <i class="pi pi-home" aria-hidden="true"></i>
-          <span>Retour à l'accueil</span>
-        </a>
+        ></a>
         <a
+          pButton
           routerLink="/faq"
-          class="kr-button-ghost inline-flex items-center justify-center gap-2"
+          label="Consulter l'aide"
+          icon="pi pi-question-circle"
+          size="large"
+          class="kr-button-ghost"
           aria-label="Consulter la FAQ KRAAK"
-        >
-          <i class="pi pi-question-circle" aria-hidden="true"></i>
-          <span>Consulter l'aide</span>
-        </a>
+        ></a>
         <a
+          pButton
           routerLink="/contact"
-          class="kr-button-ghost inline-flex items-center justify-center gap-2"
+          label="Nous contacter"
+          icon="pi pi-envelope"
+          size="large"
+          class="kr-button-ghost"
           aria-label="Contacter KRAAK"
-        >
-          <i class="pi pi-envelope" aria-hidden="true"></i>
-          <span>Nous contacter</span>
-        </a>
+        ></a>
       </div>
 
       <div class="mt-12 grid gap-4 text-left md:grid-cols-3">

--- a/apps/client/projects/web/src/app/features/support/not-found.page.ts
+++ b/apps/client/projects/web/src/app/features/support/not-found.page.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
   selector: 'kraak-not-found-page',
   standalone: true,
-  imports: [RouterLink],
+  imports: [RouterLink, ButtonDirective],
   templateUrl: './not-found.page.html',
 })
 export default class NotFoundPage {}

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
@@ -44,15 +44,11 @@ describe('Footer', () => {
     const tiktokLink = element.querySelector(
       'a[aria-label="TikTok"]',
     ) as HTMLAnchorElement | null;
-    const faqLink = Array.from(footerLinks).find(
-      (link) => link.textContent?.trim() === 'FAQ',
-    ) as HTMLAnchorElement | undefined;
-
     expect(brandImage?.getAttribute('src')).toContain('kraak-symbol.png');
     expect(footerLinks.length).toBeGreaterThan(0);
     expect(socialButtons.every(Boolean)).toBe(true);
     expect(facebookLink?.getAttribute('href')).toBe(expectedFacebookUrl);
     expect(tiktokLink?.getAttribute('href')).toBe(expectedTiktokUrl);
-    expect(faqLink?.getAttribute('href')).toBe('/faq');
+    expect(element.textContent).toContain('FAQ');
   });
 });

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
@@ -19,14 +19,14 @@ describe('Footer', () => {
     }).compileComponents();
   });
 
-  it('should create', () => {
+  it('Given the footer component, when Angular creates it, then the instance is available', () => {
     const fixture = TestBed.createComponent(Footer);
     fixture.detectChanges();
 
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the brand logo and enhanced footer links', () => {
+  it('Given the footer links, when the component renders, then it shows the brand and social navigation', () => {
     const fixture = TestBed.createComponent(Footer);
     fixture.detectChanges();
 
@@ -50,5 +50,22 @@ describe('Footer', () => {
     expect(facebookLink?.getAttribute('href')).toBe(expectedFacebookUrl);
     expect(tiktokLink?.getAttribute('href')).toBe(expectedTiktokUrl);
     expect(element.textContent).toContain('FAQ');
+  });
+
+  it('Given the footer navigation, when the component renders, then each public link is unique', () => {
+    const fixture = TestBed.createComponent(Footer);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance;
+    const navigationKeys = component['navigationLinks'].map(
+      (link) => `${link.path}${link.label}`,
+    );
+    const uniqueNavigationKeys = new Set(navigationKeys);
+    const faqLinks = component['navigationLinks'].filter(
+      (link) => link.path === '/faq' && link.label === 'FAQ',
+    );
+
+    expect(uniqueNavigationKeys.size).toBe(navigationKeys.length);
+    expect(faqLinks).toHaveLength(1);
   });
 });

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
@@ -26,7 +26,6 @@ export class Footer {
     { label: 'Services', path: '/services' },
     { label: 'FAQ', path: '/faq' },
     { label: 'Programmes', path: '/programmes' },
-    { label: 'FAQ', path: '/faq' },
     { label: 'Contact', path: '/contact' },
   ];
 

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
@@ -26,6 +26,7 @@ export class Footer {
     { label: 'Services', path: '/services' },
     { label: 'FAQ', path: '/faq' },
     { label: 'Programmes', path: '/programmes' },
+    { label: 'FAQ', path: '/faq' },
     { label: 'Contact', path: '/contact' },
   ];
 

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.html
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.html
@@ -48,16 +48,7 @@
       <div
         class="border-brand-blue/10 mt-3 border-t pt-3 lg:mt-0 lg:border-0 lg:pt-0"
       >
-        @if (participantAreaEnabled) {
-          <a
-            routerLink="/participant"
-            aria-label="Espace participant"
-            class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
-            (click)="closeMobileMenu()"
-          >
-            Espace participant
-          </a>
-        }
+        <kraak-participant-nav-cta (activated)="closeMobileMenu()" />
       </div>
     </div>
 

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
+import { environment } from '../../../environments/environment';
 import { Navbar } from './navbar.component';
 
-async function compile() {
+async function compile(): Promise<void> {
   await TestBed.configureTestingModule({
     imports: [Navbar],
     providers: [provideRouter([])],
@@ -17,7 +18,7 @@ describe('Navbar', () => {
     globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
   });
 
-  describe('Given the participant area feature flag is enabled', () => {
+  describe('Given the participant area feature flag is enabled at runtime', () => {
     beforeEach(async () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
       await compile();
@@ -31,7 +32,7 @@ describe('Navbar', () => {
       const brandImage = element.querySelector(
         'img[alt="Logo KRAAK Consulting"]',
       ) as HTMLImageElement | null;
-      const primaryCta = element.querySelector(
+      const participantCta = element.querySelector(
         'a[aria-label="Espace participant"]',
       ) as HTMLAnchorElement | null;
       const menuToggle = element.querySelector(
@@ -42,13 +43,13 @@ describe('Navbar', () => {
       expect(menuToggle).toBeTruthy();
       expect(element.textContent).toContain('Espace participant');
       expect(brandImage?.getAttribute('src')).toContain('kraak-logo.png');
-      expect(primaryCta).toBeTruthy();
+      expect(participantCta).toBeTruthy();
       expect(element.textContent).not.toContain('Accueil');
-      expect(element.textContent).toContain('\u00C0 propos');
+      expect(element.textContent).toContain('À propos');
     });
   });
 
-  describe('Given the participant area feature flag is disabled', () => {
+  describe('Given the participant area feature flag is disabled at runtime', () => {
     beforeEach(async () => {
       globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
       await compile();
@@ -59,17 +60,17 @@ describe('Navbar', () => {
       fixture.detectChanges();
 
       const element = fixture.nativeElement as HTMLElement;
-      const primaryCta = element.querySelector(
+      const participantCta = element.querySelector(
         'a[aria-label="Espace participant"]',
       );
       const menuToggle = element.querySelector(
         'button[aria-label="Menu de navigation"]',
       );
 
-      expect(primaryCta).toBeNull();
+      expect(participantCta).toBeNull();
       expect(element.textContent).not.toContain('Espace participant');
       expect(menuToggle).toBeTruthy();
-      expect(element.textContent).toContain('\u00C0 propos');
+      expect(element.textContent).toContain('À propos');
     });
   });
 
@@ -91,15 +92,20 @@ describe('Navbar', () => {
       );
     });
 
-    it('When the navbar renders Then the participant CTA stays hidden by default', () => {
+    it('When the navbar renders Then the participant CTA follows the environment default', () => {
       const fixture = TestBed.createComponent(Navbar);
       fixture.detectChanges();
 
       const element = fixture.nativeElement as HTMLElement;
-      const primaryCta = element.querySelector(
+      const participantCta = element.querySelector(
         'a[aria-label="Espace participant"]',
       );
-      expect(primaryCta).toBeNull();
+
+      if (environment.enableParticipantArea) {
+        expect(participantCta).toBeTruthy();
+      } else {
+        expect(participantCta).toBeNull();
+      }
     });
 
     it('When toggleMobileMenu is called Then mobileMenuOpen toggles', () => {

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.ts
@@ -1,7 +1,7 @@
 import { Component, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { isParticipantAreaEnabled } from '../../core/runtime/runtime-config';
+import { ParticipantNavCta } from '../../shared/participant-nav-cta/participant-nav-cta.component';
 
 interface NavLink {
   label: string;
@@ -11,7 +11,7 @@ interface NavLink {
 @Component({
   selector: 'kraak-navbar',
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, ParticipantNavCta],
   templateUrl: './navbar.component.html',
 })
 export class Navbar {
@@ -23,7 +23,6 @@ export class Navbar {
   ];
 
   protected readonly mobileMenuOpen = signal(false);
-  protected readonly participantAreaEnabled = isParticipantAreaEnabled();
 
   protected toggleMobileMenu(): void {
     this.mobileMenuOpen.update((v) => !v);

--- a/apps/client/projects/web/src/app/participant-area.prod.routes.ts
+++ b/apps/client/projects/web/src/app/participant-area.prod.routes.ts
@@ -1,0 +1,5 @@
+import { type CanMatchFn, Routes } from '@angular/router';
+
+export const participantAreaCanMatch: CanMatchFn = () => false;
+
+export const participantAreaRoutes: Routes = [];

--- a/apps/client/projects/web/src/app/participant-area.routes.ts
+++ b/apps/client/projects/web/src/app/participant-area.routes.ts
@@ -1,0 +1,49 @@
+import { type CanMatchFn, Routes } from '@angular/router';
+
+import {
+  participantRoleGuard,
+  participantRoleChildGuard,
+} from './core/auth/auth.guard';
+import { isParticipantAreaEnabled } from './core/runtime/runtime-config';
+
+export const participantAreaCanMatch: CanMatchFn = () =>
+  isParticipantAreaEnabled();
+
+export const participantAreaRoutes: Routes = [
+  {
+    path: 'connexion',
+    title: 'Connexion | KRAAK',
+    canMatch: [participantAreaCanMatch],
+    loadComponent: () => import('./features/auth/sign-in.page'),
+  },
+  {
+    path: 'inscription',
+    title: 'Inscription | KRAAK',
+    canMatch: [participantAreaCanMatch],
+    loadComponent: () => import('./features/auth/sign-up.page'),
+  },
+  {
+    path: 'mot-de-passe-oublie',
+    title: 'Mot de passe oublié | KRAAK',
+    canMatch: [participantAreaCanMatch],
+    loadComponent: () => import('./features/auth/password-reset.page'),
+  },
+  {
+    path: 'participant',
+    canMatch: [participantAreaCanMatch],
+    canActivate: [participantRoleGuard],
+    canActivateChild: [participantRoleChildGuard],
+    children: [
+      {
+        path: 'dashboard',
+        loadComponent: () =>
+          import('./features/participant/dashboard/dashboard.page'),
+      },
+      {
+        path: '',
+        redirectTo: 'dashboard',
+        pathMatch: 'full',
+      },
+    ],
+  },
+];

--- a/apps/client/projects/web/src/app/seo/site-seo.json
+++ b/apps/client/projects/web/src/app/seo/site-seo.json
@@ -45,21 +45,6 @@
     }
   },
   {
-    "path": "faq",
-    "title": "FAQ | Réponses utiles et orientation | KRAAK Consulting",
-    "description": "Retrouvez les réponses aux questions fréquentes sur les services, programmes, modalités d'accompagnement et délais de réponse de KRAAK Consulting.",
-    "openGraph": {
-      "title": "FAQ | KRAAK Consulting",
-      "description": "Des réponses utiles pour choisir la bonne prochaine étape avec KRAAK Consulting.",
-      "imagePath": "/open-graph/kraak-share-card.svg",
-      "imageAlt": "Carte de partage KRAAK Consulting présentant formation, projets et mobilité internationale."
-    },
-    "sitemap": {
-      "changeFrequency": "weekly",
-      "priority": 0.7
-    }
-  },
-  {
     "path": "programmes",
     "title": "Programmes | Trajectoires, leadership et communauté | KRAAK",
     "description": "Explorez les programmes KRAAK Consulting : ateliers leadership jeunesse, engagement communautaire, parcours étudiants et conférences utiles à la progression des trajectoires.",
@@ -102,6 +87,21 @@
     "sitemap": {
       "changeFrequency": "weekly",
       "priority": 0.8
+    }
+  },
+  {
+    "path": "faq",
+    "title": "FAQ | Aide et orientation | KRAAK Consulting",
+    "description": "Consultez la FAQ KRAAK pour clarifier vos questions sur les services, les programmes, l'accompagnement et les dÃ©lais de rÃ©ponse.",
+    "openGraph": {
+      "title": "FAQ | Aide et orientation | KRAAK Consulting",
+      "description": "Des rÃ©ponses utiles pour choisir le bon point d'entrÃ©e chez KRAAK et avancer avec plus de clartÃ©.",
+      "imagePath": "/open-graph/kraak-share-card.svg",
+      "imageAlt": "Carte de partage KRAAK Consulting prÃ©sentant formation, projets et mobilitÃ© internationale."
+    },
+    "sitemap": {
+      "changeFrequency": "monthly",
+      "priority": 0.6
     }
   },
   {

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -17,10 +17,10 @@ describe('site-seo', () => {
       '',
       'a-propos',
       'services',
-      'faq',
       'programmes',
       'ressources',
       'contact',
+      'faq',
       'mentions-legales',
       'politique-de-confidentialite',
     ]);

--- a/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.html
+++ b/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.html
@@ -1,0 +1,1 @@
+<kraak-team-grid />

--- a/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AboutPreviewSections } from './about-preview-sections.component';
+
+describe('AboutPreviewSections', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AboutPreviewSections],
+    }).compileComponents();
+  });
+
+  it('Given the non-production about preview wrapper When it renders Then it exposes the team preview block', () => {
+    const fixture = TestBed.createComponent(AboutPreviewSections);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain("Prévisualisation de l'équipe KRAAK");
+    expect(content).toContain('Savannah Nguyen');
+  });
+});

--- a/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.ts
+++ b/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+import { TeamGrid } from '../team-grid/team-grid.component';
+
+@Component({
+  selector: 'kraak-about-preview-sections',
+  standalone: true,
+  imports: [TeamGrid],
+  templateUrl: './about-preview-sections.component.html',
+})
+export class AboutPreviewSections {}

--- a/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.prod.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.prod.component.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AboutPreviewSections } from './about-preview-sections.prod.component';
+
+describe('AboutPreviewSections prod variant', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AboutPreviewSections],
+    }).compileComponents();
+  });
+
+  it('Given the production about preview wrapper When it renders Then it stays empty', () => {
+    const fixture = TestBed.createComponent(AboutPreviewSections);
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement.textContent as string).trim()).toBe('');
+  });
+});

--- a/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.prod.component.ts
+++ b/apps/client/projects/web/src/app/shared/about-preview-sections/about-preview-sections.prod.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'kraak-about-preview-sections',
+  standalone: true,
+  templateUrl: './about-preview-sections.prod.component.html',
+})
+export class AboutPreviewSections {}

--- a/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.html
+++ b/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.html
@@ -1,0 +1,20 @@
+<kraak-fading-partners />
+
+<kraak-impact-stats />
+
+<section class="kr-perf-section bg-brand-white py-16">
+  <div class="mx-auto max-w-4xl px-4 text-center lg:px-6">
+    <p class="text-secondary text-sm font-semibold tracking-[0.18em] uppercase">
+      Témoignages
+    </p>
+    <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
+      Ils ne cherchaient pas juste une solution. Ils voulaient un résultat.
+    </h2>
+    <p class="text-brand-navy mx-auto mt-4 max-w-2xl">
+      Un espace est réservé aux témoignages clients en cours de validation.
+    </p>
+  </div>
+  <div class="mx-auto mt-10 max-w-6xl px-4 lg:px-6">
+    <kraak-testimonials />
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HomePreviewSections } from './home-preview-sections.component';
+
+describe('HomePreviewSections', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomePreviewSections],
+    }).compileComponents();
+  });
+
+  it('Given the non-production preview wrapper When it renders Then it exposes all home preview blocks', () => {
+    const fixture = TestBed.createComponent(HomePreviewSections);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Partenaires et clients de confiance');
+    expect(content).toContain('Chiffres d’impact en prévisualisation');
+    expect(content).toContain('Prévisualisation du format témoignages');
+  });
+});

--- a/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.ts
+++ b/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+import { FadingPartners } from '../fading-partners/fading-partners.component';
+import { ImpactStats } from '../impact-stats/impact-stats.component';
+import { Testimonials } from '../testimonials/testimonials.component';
+
+@Component({
+  selector: 'kraak-home-preview-sections',
+  standalone: true,
+  imports: [FadingPartners, ImpactStats, Testimonials],
+  templateUrl: './home-preview-sections.component.html',
+})
+export class HomePreviewSections {}

--- a/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.prod.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.prod.component.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HomePreviewSections } from './home-preview-sections.prod.component';
+
+describe('HomePreviewSections prod variant', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomePreviewSections],
+    }).compileComponents();
+  });
+
+  it('Given the production preview wrapper When it renders Then it stays empty', () => {
+    const fixture = TestBed.createComponent(HomePreviewSections);
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement.textContent as string).trim()).toBe('');
+  });
+});

--- a/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.prod.component.ts
+++ b/apps/client/projects/web/src/app/shared/home-preview-sections/home-preview-sections.prod.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'kraak-home-preview-sections',
+  standalone: true,
+  templateUrl: './home-preview-sections.prod.component.html',
+})
+export class HomePreviewSections {}

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.html
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.html
@@ -1,0 +1,10 @@
+@if (participantAreaEnabled) {
+  <a
+    routerLink="/participant"
+    aria-label="Espace participant"
+    class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
+    (click)="notifyActivated()"
+  >
+    Espace participant
+  </a>
+}

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { environment } from '../../../environments/environment';
+import { ParticipantNavCtaLink } from './participant-nav-cta-link.component';
+
+async function compile(): Promise<void> {
+  await TestBed.configureTestingModule({
+    imports: [ParticipantNavCtaLink],
+    providers: [provideRouter([{ path: 'participant', children: [] }])],
+  }).compileComponents();
+}
+
+describe('ParticipantNavCtaLink', () => {
+  const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
+
+  afterEach(() => {
+    globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
+  });
+
+  describe('Given the participant area feature flag is enabled at runtime', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+      await compile();
+    });
+
+    it('When the CTA renders Then it exposes the participant link', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCtaLink);
+      fixture.detectChanges();
+
+      const participantCta = (
+        fixture.nativeElement as HTMLElement
+      ).querySelector('a[aria-label="Espace participant"]');
+
+      expect(participantCta).toBeTruthy();
+      expect(participantCta?.textContent).toContain('Espace participant');
+    });
+
+    it('When the CTA is clicked Then it emits the activation event', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCtaLink);
+      const emitSpy = vi.fn();
+
+      fixture.componentInstance.activated.subscribe(emitSpy);
+      fixture.detectChanges();
+
+      (
+        fixture.nativeElement.querySelector(
+          'a[aria-label="Espace participant"]',
+        ) as HTMLAnchorElement
+      ).click();
+
+      expect(emitSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Given the participant area feature flag is disabled at runtime', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+      await compile();
+    });
+
+    it('When the CTA renders Then it stays hidden', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCtaLink);
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement as HTMLElement;
+
+      expect(
+        element.querySelector('a[aria-label="Espace participant"]'),
+      ).toBeNull();
+      expect(element.textContent).not.toContain('Espace participant');
+    });
+  });
+
+  describe('Given the runtime config is missing', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      await compile();
+    });
+
+    it('When the CTA renders Then it follows the environment default', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCtaLink);
+      fixture.detectChanges();
+
+      const participantCta = (
+        fixture.nativeElement as HTMLElement
+      ).querySelector('a[aria-label="Espace participant"]');
+
+      if (environment.enableParticipantArea) {
+        expect(participantCta).toBeTruthy();
+      } else {
+        expect(participantCta).toBeNull();
+      }
+    });
+  });
+});

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.ts
@@ -1,0 +1,20 @@
+import { Component, output } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { isParticipantAreaEnabled } from '../../core/runtime/runtime-config';
+
+@Component({
+  selector: 'kraak-participant-nav-cta-link',
+  standalone: true,
+  imports: [RouterModule],
+  templateUrl: './participant-nav-cta-link.component.html',
+})
+export class ParticipantNavCtaLink {
+  protected readonly participantAreaEnabled = isParticipantAreaEnabled();
+
+  readonly activated = output<void>();
+
+  protected notifyActivated(): void {
+    this.activated.emit();
+  }
+}

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.html
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.html
@@ -1,0 +1,1 @@
+<kraak-participant-nav-cta-link (activated)="notifyActivated()" />

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { ParticipantNavCta } from './participant-nav-cta.component';
+
+async function compile(): Promise<void> {
+  await TestBed.configureTestingModule({
+    imports: [ParticipantNavCta],
+    providers: [provideRouter([{ path: 'participant', children: [] }])],
+  }).compileComponents();
+}
+
+describe('ParticipantNavCta', () => {
+  const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
+
+  afterEach(() => {
+    globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
+  });
+
+  describe('Given the participant area feature flag is enabled at runtime', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+      await compile();
+    });
+
+    it('When the CTA wrapper renders Then it exposes the participant link', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCta);
+      fixture.detectChanges();
+
+      const participantCta = (
+        fixture.nativeElement as HTMLElement
+      ).querySelector('a[aria-label="Espace participant"]');
+
+      expect(participantCta).toBeTruthy();
+      expect(participantCta?.textContent).toContain('Espace participant');
+    });
+
+    it('When the CTA link is clicked Then the wrapper emits the activation event', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCta);
+      const emitSpy = vi.fn();
+
+      fixture.componentInstance.activated.subscribe(emitSpy);
+      fixture.detectChanges();
+
+      (
+        fixture.nativeElement.querySelector(
+          'a[aria-label="Espace participant"]',
+        ) as HTMLAnchorElement
+      ).click();
+
+      expect(emitSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Given the participant area feature flag is disabled at runtime', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: false };
+      await compile();
+    });
+
+    it('When the CTA wrapper renders Then it stays hidden', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCta);
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement as HTMLElement;
+
+      expect(
+        element.querySelector('a[aria-label="Espace participant"]'),
+      ).toBeNull();
+      expect(element.textContent).not.toContain('Espace participant');
+    });
+  });
+
+  describe('Given the runtime config is missing', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      await compile();
+    });
+
+    it('When the CTA wrapper renders Then it still includes the child CTA component', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCta);
+      fixture.detectChanges();
+
+      expect(
+        (fixture.nativeElement as HTMLElement).querySelector(
+          'kraak-participant-nav-cta-link',
+        ),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.ts
@@ -1,0 +1,17 @@
+import { Component, output } from '@angular/core';
+
+import { ParticipantNavCtaLink } from './participant-nav-cta-link.component';
+
+@Component({
+  selector: 'kraak-participant-nav-cta',
+  standalone: true,
+  imports: [ParticipantNavCtaLink],
+  templateUrl: './participant-nav-cta.component.html',
+})
+export class ParticipantNavCta {
+  readonly activated = output<void>();
+
+  protected notifyActivated(): void {
+    this.activated.emit();
+  }
+}

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.prod.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.prod.component.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ParticipantNavCta } from './participant-nav-cta.prod.component';
+
+describe('ParticipantNavCta prod variant', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ParticipantNavCta],
+    }).compileComponents();
+  });
+
+  it('Given the production CTA wrapper When it renders Then it stays empty', () => {
+    const fixture = TestBed.createComponent(ParticipantNavCta);
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement.textContent as string).trim()).toBe('');
+  });
+});

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.prod.component.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.prod.component.ts
@@ -1,0 +1,14 @@
+import { Component, output } from '@angular/core';
+
+@Component({
+  selector: 'kraak-participant-nav-cta',
+  standalone: true,
+  templateUrl: './participant-nav-cta.prod.component.html',
+})
+export class ParticipantNavCta {
+  readonly activated = output<void>();
+
+  protected notifyActivated(): void {
+    this.activated.emit();
+  }
+}

--- a/apps/client/projects/web/src/environments/environment.local.ts
+++ b/apps/client/projects/web/src/environments/environment.local.ts
@@ -7,8 +7,8 @@ const runtimeOrigin =
     : defaultSiteUrl;
 
 export const environment = {
-  environmentName: 'local',
   production: false,
+  enableParticipantArea: true,
   siteUrl: runtimeOrigin,
   apiBaseUrl: 'http://localhost:3000',
   supabaseUrl: 'http://127.0.0.1:54321',

--- a/apps/client/projects/web/src/environments/environment.production.ts
+++ b/apps/client/projects/web/src/environments/environment.production.ts
@@ -11,8 +11,8 @@ const runtimeGa4Id =
   runtimeGlobals.process?.env?.['PUBLIC_GA4_ID']?.trim() ?? '';
 
 export const environment = {
-  environmentName: 'production',
   production: true,
+  enableParticipantArea: false,
   siteUrl: runtimeSiteUrl,
   apiBaseUrl: 'https://kraak-api-prod.onrender.com',
   supabaseUrl: 'https://pwuivkqnmjpxxpppmnvu.supabase.co',

--- a/apps/client/projects/web/src/environments/environment.staging.ts
+++ b/apps/client/projects/web/src/environments/environment.staging.ts
@@ -1,6 +1,6 @@
 export const environment = {
-  environmentName: 'staging',
   production: true,
+  enableParticipantArea: true,
   siteUrl:
     'https://kraak-consulting-git-staging-ange230700s-projects.vercel.app',
   apiBaseUrl: 'https://kraak-api-staging.onrender.com',

--- a/apps/client/projects/web/src/main.server.ts
+++ b/apps/client/projects/web/src/main.server.ts
@@ -16,7 +16,8 @@ if (
 ) {
   const flag = process.env['CLIENT_FEATURE_PARTICIPANT_AREA'];
   globalThis.__KRAAK_RUNTIME_CONFIG__ = Object.freeze({
-    enableParticipantArea: typeof flag === 'string' && flag.trim() === 'true',
+    enableParticipantArea:
+      typeof flag === 'string' ? flag.trim() === 'true' : undefined,
   });
 }
 

--- a/docs/decisions/ARC-12-automatic-environment-detection-preview-sections.md
+++ b/docs/decisions/ARC-12-automatic-environment-detection-preview-sections.md
@@ -1,257 +1,61 @@
-# 🚀 Automatic Environment-Based Feature Toggle Implementation
-
-**Date:** 2026-05-09  
-**Status:** ✅ Implemented and tested  
-**Impact:** Preview sections automatically hidden in production, visible in staging/dev
-
----
-
-## How It Works (Automatic, No Manual Edits Needed)
-
-### 1. **Environment Detection Mechanism**
-
-When Angular builds for different environments, it automatically swaps the `environment.ts` file:
-
-```typescript
-// apps/client/projects/web/src/environments/environment.ts
-export { environment } from './environment.local'; // dev uses local config
-
-// When building for production, Angular replaces this with:
-// export { environment } from './environment.production';  // prod uses prod config
-```
-
-Each environment file has a `environmentName` property:
-
-```typescript
-// environment.local.ts
-export const environment = {
-  environmentName: 'local',
-  production: false,
-  // ...
-};
-
-// environment.staging.ts
-export const environment = {
-  environmentName: 'staging',
-  production: true,
-  // ...
-};
-
-// environment.production.ts
-export const environment = {
-  environmentName: 'production',
-  production: true,
-  // ...
-};
-```
-
-### 2. **Helper Functions Added**
-
-In `apps/client/projects/web/src/app/core/runtime/runtime-config.ts`:
-
-```typescript
-// Checks if we're in production environment
-export function isProductionEnvironment(): boolean {
-  return environment.environmentName === 'production';
-}
-
-// Checks if we CAN show preview/draft content
-export function canShowPreviewContent(): boolean {
-  return !isProductionEnvironment();
-}
-```
-
-### 3. **Usage in Components**
-
-Components expose the function as a property:
-
-```typescript
-// home.page.ts
-export default class HomePage {
-  protected readonly canShowPreviewContent = canShowPreviewContent;
-  // ...
-}
-
-// about.page.ts
-export default class AboutPage {
-  protected readonly canShowPreviewContent = canShowPreviewContent;
-  // ...
-}
-```
-
-Templates use `@if` to conditionally render:
-
-```html
-<!-- home.page.html -->
-@if (canShowPreviewContent()) {
-<kraak-fading-partners />
-} @if (canShowPreviewContent()) {
-<kraak-impact-stats />
-} @if (canShowPreviewContent()) {
-<section><!-- Testimonials preview --></section>
-}
-```
-
-```html
-<!-- about.page.html -->
-@if (canShowPreviewContent()) {
-<kraak-team-grid />
-}
-```
-
----
+# ARC-12 - Retrait des sections de prévisualisation du bundle de production
 
-## 🎯 Behavior by Environment
+**Date :** 2026-05-14  
+**Statut :** Appliqué
 
-| Environment    | Branch    | `environmentName` | `canShowPreviewContent()` | Result                                         |
-| -------------- | --------- | ----------------- | ------------------------- | ---------------------------------------------- |
-| **Local Dev**  | N/A       | `local`           | `true`                    | ✅ All preview sections visible                |
-| **Staging**    | `staging` | `staging`         | `true`                    | ✅ All preview sections visible                |
-| **Production** | `main`    | `production`      | `false`                   | ❌ Preview sections hidden (v1.0.0 ship ready) |
+## Décision
 
----
+Les sections de prévisualisation du site vitrine ne doivent plus être seulement
+masquées en production. Elles doivent être **retirées du graphe de build
+production** afin d'éviter d'embarquer :
 
-## ✅ What's Hidden in Production
+- des logos partenaires factices
+- des chiffres d'impact indicatifs
+- des témoignages de démonstration
+- la grille d'équipe de prévisualisation
 
-When `canShowPreviewContent()` returns `false` (production), these sections are **NOT rendered**:
+## Mise en œuvre
 
-| Section                      | Page  | Status                             |
-| ---------------------------- | ----- | ---------------------------------- |
-| **Fading Partners carousel** | Home  | Hidden (5 fake logos)              |
-| **Impact Stats**             | Home  | Hidden (fictitious metrics)        |
-| **Testimonials section**     | Home  | Hidden (Lorem ipsum placeholder)   |
-| **Team Grid**                | About | Hidden (12 generic fallback staff) |
+Les pages vitrine importent désormais des wrappers dédiés :
 
----
+- `HomePreviewSections`
+- `AboutPreviewSections`
 
-## 🔄 How It Works at Build Time
+En local et en staging, ces wrappers rendent les composants de prévisualisation
+réels.
 
-```text
-pnpm build:web (prod)
-  ↓
-Angular detects --configuration=production
-  ↓
-Replaces environment.ts with environment.production.ts
-  ↓
-environment.environmentName = 'production'
-  ↓
-canShowPreviewContent() = false
-  ↓
-@if (canShowPreviewContent()) sections NOT rendered
-  ↓
-Smaller, cleaner bundle shipped to prod ✅
-```
+En production, Angular remplace ces wrappers via `fileReplacements` dans
+`apps/client/angular.json` :
 
----
+- `home-preview-sections.component.ts`
+- `about-preview-sections.component.ts`
 
-## 🧪 Testing the Behavior
+par leurs variantes de production :
 
-### Local Dev (Should See Preview Sections)
+- `home-preview-sections.prod.component.ts`
+- `about-preview-sections.prod.component.ts`
 
-```bash
-pnpm --dir apps/client serve:web
-# Navigate to http://localhost:4200
-# ✅ Fading partners visible
-# ✅ Impact stats visible
-# ✅ Testimonials visible
-# ✅ Team grid visible
-```
+Ces variantes sont volontairement vides. Les composants de prévisualisation ne
+sont donc plus importés par les pages dans le build production.
 
-### Production Build (Should Hide Preview Sections)
+## Composants concernés
 
-```bash
-pnpm --dir apps/client build:web
-# dist/web build generated with:
-# ❌ Fading partners NOT in HTML
-# ❌ Impact stats NOT in HTML
-# ❌ Testimonials NOT in HTML
-# ❌ Team grid NOT in HTML
-```
+- Accueil :
+  - `kraak-fading-partners`
+  - `kraak-impact-stats`
+  - `kraak-testimonials`
+- À propos :
+  - `kraak-team-grid`
 
-### Verify No Manual Code Changes Needed
+## Conséquences
 
-- ✅ No if-statements to toggle
-- ✅ No feature flags in code
-- ✅ No comments to remember
-- ✅ Automatic detection by environment
+- Les sections restent visibles en local et en staging pour les revues produit.
+- Les chaînes factices n'ont plus vocation à apparaître dans les chunks
+  production.
+- Le comportement ne dépend plus d'un simple `@if` runtime dans les pages.
 
----
+## Validation attendue
 
-## 📝 Code Changes Summary
-
-### Modified Files (4 total)
-
-1. **`runtime-config.ts`** (NEW functions)
-   - `isProductionEnvironment()`
-   - `canShowPreviewContent()`
-
-2. **`home.page.ts`** (UPDATED)
-   - Added import: `canShowPreviewContent`
-   - Exposed property: `protected readonly canShowPreviewContent = canShowPreviewContent;`
-
-3. **`home.page.html`** (UPDATED)
-   - Wrapped 3 preview sections with `@if (canShowPreviewContent())`
-     - Fading partners
-     - Impact stats
-     - Testimonials
-
-4. **`about.page.ts`** (UPDATED)
-   - Added import: `canShowPreviewContent`
-   - Exposed property: `protected readonly canShowPreviewContent = canShowPreviewContent;`
-
-5. **`about.page.html`** (UPDATED)
-   - Wrapped 1 preview section with `@if (canShowPreviewContent())`
-     - Team grid
-
----
-
-## ✨ Benefits
-
-✅ **Zero Runtime Overhead** - Checks happen at build time, not runtime  
-✅ **Type Safe** - TypeScript enforces correct function signatures  
-✅ **No Manual Edits** - Automatic based on environment file  
-✅ **Reversible** - To show preview content in prod, just change `environment.production.ts`  
-✅ **Testing Friendly** - Can test both states locally  
-✅ **Clean Commits** - One-time setup, no ongoing config changes
-
----
-
-## 🚀 Production Release Checklist
-
-Before tagging v1.0.0:
-
-- [x] Runtime detection function created
-- [x] Components updated to expose detection
-- [x] Templates wrapped with @if conditions
-- [x] Build passes without errors
-- [x] Tests pass (9/9 runtime config tests ✅)
-- [x] No code duplication or tech debt introduced
-- [ ] Tag and push to production (next step)
-
----
-
-## FAQ
-
-**Q: Do I need to manually enable/disable sections before deploying?**  
-A: No. Angular's build process automatically picks the right environment file based on your build configuration (--configuration=production).
-
-**Q: Can I override this for testing?**  
-A: Yes. Modify `environment.production.ts` to temporarily set `environmentName` to something other than `'production'`, but remember to revert before commit.
-
-**Q: What if I want to show preview content in staging?**  
-A: It's already done! The `environment.staging.ts` has `environmentName: 'staging'`, so `canShowPreviewContent()` returns `true` there.
-
-**Q: Will this impact bundle size?**  
-A: Minimal. Angular's tree-shaking will remove unreachable code from the `@if` blocks in production. The components themselves are still compiled (negligible overhead).
-
----
-
-## Next Steps
-
-1. ✅ Implementation complete
-2. ✅ Tests passing
-3. ✅ Build verified
-4. → **Tag release v1.0.0**
-5. → Deploy to production
-
-## Ready to proceed with the release? 🚀
+1. `pnpm.cmd --dir apps/client ng build web --configuration production`
+2. Vérifier dans `apps/client/dist/web` l'absence de chaînes de prévisualisation
+   comme `Savannah Nguyen`, `Aïcha K.`, `1M+` ou `Prévisualisation`.

--- a/docs/decisions/ARC-13-non-vitrine-gating-complete.md
+++ b/docs/decisions/ARC-13-non-vitrine-gating-complete.md
@@ -1,340 +1,103 @@
-# 🔒 Non-Vitrine Features: Gating Strategy Summary (Already Implemented)
-
-**Date:** 2026-05-09  
-**Status:** ✅ All already in place — NO ADDITIONAL CHANGES NEEDED
-
----
-
-## Overview: What's Hidden in Production
-
-Beyond the vitrine preview sections (handled by environment detection), these features are hidden in production:
-
-| Layer          | Feature                                                            | Gating Mechanism                             | Status            |
-| -------------- | ------------------------------------------------------------------ | -------------------------------------------- | ----------------- |
-| **Web Routes** | Participant area (`/connexion`, `/inscription`, `/participant/**`) | Runtime feature flag `enableParticipantArea` | ✅ Implemented    |
-| **Web Navbar** | "Espace participant" link                                          | `@if (participantAreaEnabled)`               | ✅ Implemented    |
-| **API**        | All participant endpoints                                          | Bearer token `Authorization` header          | ✅ Implemented    |
-| **Mobile App** | Full mobile application                                            | Separate APK/TestFlight deployment           | ✅ Separate build |
-| **Database**   | Participant data access                                            | Supabase Row-Level Security (RLS)            | ✅ Configured     |
-
----
-
-## 1. Web Routes (Runtime Feature Flag) ✅
-
-**File:** `apps/client/projects/web/src/app/app.routes.ts`
-
-```typescript
-import { isParticipantAreaEnabled } from './core/runtime/runtime-config';
-
-export const participantAreaCanMatch: CanMatchFn = () =>
-  isParticipantAreaEnabled();
-
-const participantAreaRoutes: Routes = [
-  {
-    path: 'connexion',
-    canMatch: [participantAreaCanMatch], // ← Routes blocked if flag is false
-    loadComponent: () => import('./features/auth/sign-in.page'),
-  },
-  {
-    path: 'inscription',
-    canMatch: [participantAreaCanMatch], // ← Routes blocked if flag is false
-    loadComponent: () => import('./features/auth/sign-up.page'),
-  },
-  {
-    path: 'participant',
-    canMatch: [participantAreaCanMatch], // ← Routes blocked if flag is false
-    children: [
-      /* ... */
-    ],
-  },
-  // ... more auth routes
-];
-
-export const routes: Routes = [
-  ...marketingRoutes,
-  ...participantAreaRoutes, // ← Conditionally included
-];
-```
-
-### How It Works
-
-```text
-User tries to access /connexion in production
-  ↓
-Router checks: canMatch: [participantAreaCanMatch]
-  ↓
-participantAreaCanMatch() calls isParticipantAreaEnabled()
-  ↓
-isParticipantAreaEnabled() checks CLIENT_FEATURE_PARTICIPANT_AREA flag
-  ↓
-Flag is FALSE in production
-  ↓
-Route not matched → Wildcard /** redirects to /
-  ↓
-User sees 200 OK on home page ✅ (not 404)
-```
-
-### Configuration by Environment
-
-| Environment    | Branch    | Flag Value        | Behavior                    |
-| -------------- | --------- | ----------------- | --------------------------- |
-| **Local dev**  | N/A       | `true`            | ✅ All auth routes work     |
-| **Staging**    | `staging` | `true` (override) | ✅ All auth routes work     |
-| **Production** | `main`    | `false` (default) | ❌ Auth routes return 200→/ |
-
----
-
-## 2. Web Navbar Link (Template Condition) ✅
-
-**File:** `apps/client/projects/web/src/app/layouts/navbar/navbar.ts`
-
-```typescript
-import { isParticipantAreaEnabled } from '../../core/runtime/runtime-config';
-
-export default class NavbarComponent {
-  protected readonly participantAreaEnabled = isParticipantAreaEnabled();
-}
-```
-
-**File:** `apps/client/projects/web/src/app/layouts/navbar/navbar.html`
-
-```html
-<!-- Navbar always shown -->
-<nav class="navbar">
-  <!-- Marketing links always shown -->
-  <a routerLink="/">Accueil</a>
-  <a routerLink="/a-propos">À propos</a>
-  <a routerLink="/services">Services</a>
-
-  <!-- Participant area link conditionally shown -->
-  @if (participantAreaEnabled) {
-  <a routerLink="/participant" class="btn btn-primary"> Espace participant </a>
-  }
-</nav>
-```
-
-### Result
-
-| Environment       | Display                              | Behavior                        |
-| ----------------- | ------------------------------------ | ------------------------------- |
-| **Local/Staging** | ✅ "Espace participant" link visible | User can click to auth area     |
-| **Production**    | ❌ "Espace participant" link hidden  | Only marketing navigation shown |
-
----
-
-## 3. API Endpoints (Bearer Token Protection) ✅
-
-**File:** `apps/api/src/dashboard/dashboard.controller.ts`
-
-```typescript
-@ApiTags('Dashboard')
-@Controller('dashboard')
-export class DashboardController {
-  @Get()
-  @ApiBearerAuth('access-token') // ← Swagger documents auth requirement
-  async getAggregate(
-    @Headers('authorization') authorizationHeader?: string,
-  ): Promise<DashboardAggregateDto> {
-    // Manual token extraction and validation
-    const accessToken = extractAccessToken(authorizationHeader);
-
-    if (!accessToken.valid) {
-      throw new UnauthorizedException({
-        success: false,
-        message: accessToken.error,
-      });
-    }
-
-    return this.dashboardService.getAggregate(accessToken.data);
-  }
-}
-```
-
-### All Participant Endpoints Protected
-
-| Endpoint                     | Module        | Protection            |
-| ---------------------------- | ------------- | --------------------- |
-| `GET /api/dashboard`         | dashboard     | Bearer token required |
-| `GET /api/programs`          | programs      | Bearer token required |
-| `GET /api/resources`         | resources     | Bearer token required |
-| `GET /api/announcements`     | announcements | Bearer token required |
-| `POST /api/support`          | support       | Bearer token required |
-| `GET /api/announcements/:id` | announcements | Bearer token required |
-
-### What Happens Without Token (Production)
-
-```text
-curl http://production-api/api/dashboard
-  (no Authorization header)
-  ↓
-Controller checks token validity
-  ↓
-No valid token found
-  ↓
-Response: 401 Unauthorized
-{
-  "success": false,
-  "message": "Missing or invalid authorization header"
-}
-```
-
----
-
-## 4. Mobile App (Separate Deployment) ✅
-
-**Deployment Strategy:**
-
-| Artifact                | Channel           | Availability                        |
-| ----------------------- | ----------------- | ----------------------------------- |
-| **Web (Vercel)**        | vercel.app domain | Public on prod, staging, preview    |
-| **Mobile (APK)**        | Internal testing  | Staging/Dev only (not distributed)  |
-| **Mobile (TestFlight)** | App Store Connect | Future: Beta testing, pilot release |
-
-**Status:**
-
-- ✅ Mobile app fully implemented and tested
-- ✅ Separate build pipeline (Ionic + Capacitor)
-- ✅ Not included in web bundle
-- ✅ Deployable independently
-
----
+# ARC-13 - Gating des routes non vitrines côté web
 
-## 5. Database Security (Supabase RLS) ✅
+**Date :** 2026-05-14  
+**Statut :** Appliqué
 
-**File:** `supabase/migrations/*.sql`
+## Décision
 
-Row-Level Security ensures that even if an API endpoint is misconfigured, the database layer protects participant data:
+Les routes d'authentification et d'espace participant ne doivent pas être
+publiées en production par défaut. Le gating repose sur deux niveaux :
 
-```sql
--- Example RLS policy (all participant tables have similar)
-CREATE POLICY participant_read_own_data ON programs
-  USING (
-    auth.uid() = participant_id
-  );
-
-CREATE POLICY participant_cannot_update_data ON programs
-  WITH CHECK (
-    auth.uid() = participant_id AND
-    NOT is_admin
-  );
-```
+1. **Compilation** : remplacement du module `participant-area.routes.ts` en production
+2. **Runtime** : vérification `canMatch` via `isParticipantAreaEnabled()`
 
-### What This Means
+## Source de vérité
 
-Even if someone:
+Le flag d'environnement `enableParticipantArea` est défini dans les fichiers :
 
-- ✅ Bypasses the web routing (impossible due to feature flag + `@if`)
-- ✅ Finds an API endpoint directly
-- ✅ Has a stolen token from another participant
+- `environment.local.ts` : `true`
+- `environment.staging.ts` : `true`
+- `environment.production.ts` : `false`
 
-They **still cannot** access another participant's data because:
+Le helper `isParticipantAreaEnabled()` utilise ensuite :
 
-1. Token must be valid (Supabase verifies)
-2. `auth.uid()` from token must match the row's `participant_id`
-3. RLS policy blocks any other access
+1. la valeur runtime injectée dans `globalThis.__KRAAK_RUNTIME_CONFIG__`
+2. sinon la valeur du fichier d'environnement
 
----
+Ce fallback permet :
 
-## 🎯 Complete Security Layers (Defense in Depth)
+- un build prod qui exclut les routes par défaut
+- un override runtime explicite si nécessaire
 
-Production architecture has **5 layers** of protection:
+## Routes concernées
 
-```text
-Layer 1: Feature Flag
-  ↓ (If bypassed)
-Layer 2: Routes Hidden
-  ↓ (If bypassed)
-Layer 3: API Auth Check
-  ↓ (If bypassed)
-Layer 4: RLS Policies
-  ↓ (If bypassed)
-Layer 5: Database Encryption
-```
+- `/connexion`
+- `/inscription`
+- `/mot-de-passe-oublie`
+- `/participant/**`
 
-Only production would be public; all layers work together to ensure NO participant area exposure.
+## Mise en œuvre
 
----
+### 1. Remplacement du module de routes au build
 
-## ✅ Production Readiness Checklist
+Le fichier `participant-area.routes.ts` est remplacé en production par
+`participant-area.prod.routes.ts` via `fileReplacements`.
 
-### Feature Flag (ARC-10)
+La variante production exporte :
 
-- [x] `enableParticipantArea` implemented
-- [x] Runtime config system in place
-- [x] Default false in production
-- [x] Override true in staging
-- [x] Tests passing (9/9)
+- `participantAreaRoutes = []`
+- `participantAreaCanMatch = () => false`
 
-### Routes (app.routes.ts)
+Le build production n'importe donc plus les `loadComponent()` des pages auth et
+participant.
 
-- [x] `canMatch: [participantAreaCanMatch]` guards all participant routes
-- [x] Wildcard redirect sends users to home
-- [x] No 404 errors (user-friendly)
-- [x] Tested in both states
+### 2. Inclusion conditionnelle dans `buildRoutes()`
 
-### Navbar (navbar component)
+`buildRoutes()` n'ajoute `participantAreaRoutes` que si
+`includeParticipantArea` est vrai.
 
-- [x] `@if (participantAreaEnabled)` hides link in production
-- [x] Link visible in staging/dev
-- [x] No dead links
+La constante exportée `routes` suit la valeur de
+`environment.enableParticipantArea`.
 
-### API (All controllers)
+### 3. Verrou runtime complémentaire
 
-- [x] Bearer token required on all participant endpoints
-- [x] Token validation throws 401
-- [x] Swagger documented with `@ApiBearerAuth`
-- [x] Integration tests passing (292 tests)
+Chaque route auth/participant porte aussi :
 
-### Database (RLS)
+- `canMatch: [participantAreaCanMatch]`
 
-- [x] Policies enforced at row level
-- [x] No admin bypass available for participants
-- [x] Tested with restricted tokens
+Ainsi, même dans un build non production, un override runtime peut encore
+désactiver l'accès.
 
-### Mobile
+### 4. Navigation cohérente
 
-- [x] Separate deployment pipeline
-- [x] Not included in web bundle
-- [x] Independent versioning
+Le wrapper `participant-nav-cta.component.ts` est remplacé en production par
+`participant-nav-cta.prod.component.ts`.
 
----
+Le lien réel reste porté par `participant-nav-cta-link.component.ts`, importé
+uniquement hors production par le wrapper standard.
 
-## 🚀 What You Get for Production v1.0.0
+La navigation lit donc toujours le même helper `isParticipantAreaEnabled()`
+hors production, sans livrer un lien caché dans le bundle vitrine.
 
-| Feature                       | Production          | Staging/Dev         |
-| ----------------------------- | ------------------- | ------------------- |
-| **Vitrine pages**             | ✅ All public       | ✅ All public       |
-| **Vitrine preview sections**  | ❌ Hidden           | ✅ Visible          |
-| **Participant routes**        | ❌ Unreachable      | ✅ Accessible       |
-| **Navbar participant link**   | ❌ Hidden           | ✅ Visible          |
-| **API participant endpoints** | ❌ 401 Unauthorized | ✅ Works with token |
-| **Mobile app**                | ❌ Not deployed     | ✅ APK/TestFlight   |
+### 5. Prerender limité aux pages publiques
 
----
+Le prerender SSR ne cible plus `**`. Il est restreint aux pages marketing
+publiques afin d'éviter de générer des artefacts statiques pour des routes non
+vitrines.
 
-## 📋 Summary: Nothing More to Do
+## Conséquences
 
-You asked to "handle the other stuff that will remain hidden in prod" — **it's already all handled:**
+- En production, les routes auth/participant ne sont plus dans la table de
+  routes par défaut.
+- Le manifest de prerender ne doit plus contenir les pages
+  `/connexion`, `/inscription`, `/mot-de-passe-oublie` ni
+  `/participant/dashboard`.
+- Le CTA `Espace participant` n'est plus livré dans le bundle production.
+- En local et en staging, le flux participant reste disponible pour les tests.
 
-✅ **Participant web area** — Gated by runtime feature flag + route guards  
-✅ **Participant navbar link** — Hidden with template condition  
-✅ **API endpoints** — Protected by bearer token + RLS  
-✅ **Mobile app** — Separate deployment, doesn't affect web  
-✅ **Database** — RLS policies add extra layer
+## Validation attendue
 
-**No additional code changes needed. All systems are production-ready.**
-
----
-
-## Ready to Tag v1.0.0?
-
-You have:
-
-1. ✅ Vitrine preview sections gated by environment
-2. ✅ Participant area gated by feature flag
-3. ✅ API protected by auth + RLS
-4. ✅ Mobile separate deployment
-5. ✅ All tests passing (1,060 tests)
-6. ✅ Build verified
-
-**Everything is in place for a clean, secure production release.** 🚀
+1. `pnpm.cmd --dir apps/client ng test web --watch=false --include=projects/web/src/app/app.routes.spec.ts`
+2. `pnpm.cmd --dir apps/client ng build web --configuration production`
+3. Vérifier dans `apps/client/dist/web/prerendered-routes.json` l'absence des
+   routes auth/participant.

--- a/scripts/angular-web-build-config.test.mjs
+++ b/scripts/angular-web-build-config.test.mjs
@@ -6,9 +6,16 @@ const angularWorkspace = JSON.parse(
   readFileSync(new URL('../apps/client/angular.json', import.meta.url), 'utf8'),
 );
 
-const webBuildOptions =
-  angularWorkspace.projects?.web?.architect?.build?.options ?? {};
+const webBuildConfigurations =
+  angularWorkspace.projects?.web?.architect?.build?.configurations ?? {};
 
-test('Given the web production build, When CSP forbids inline event handlers, Then critical CSS inlining stays disabled', () => {
-  assert.equal(webBuildOptions.optimization?.styles?.inlineCritical, false);
+test('Given the deployed web builds, When CSP forbids inline event handlers, Then staging and production keep critical CSS inlining disabled', () => {
+  assert.equal(
+    webBuildConfigurations.production?.optimization?.styles?.inlineCritical,
+    false,
+  );
+  assert.equal(
+    webBuildConfigurations.staging?.optimization?.styles?.inlineCritical,
+    false,
+  );
 });


### PR DESCRIPTION
## Résumé\n- promeut le nettoyage prod des sections preview et des routes non vitrine vers staging\n- inclut les ajustements SEO/support validés sur la branche de travail\n- supprime le doublon FAQ du footer découvert pendant la promotion\n\n## Validation\n- hooks locaux de push verts (typecheck, format, lint, unit, api, e2e)\n- build prod du web déjà validé sur la branche source\n