### PR TITLE
fix(api): restore participant endpoints under staging schema drift

### DIFF
--- a/apps/api/src/announcements/announcements.service.spec.ts
+++ b/apps/api/src/announcements/announcements.service.spec.ts
@@ -267,6 +267,96 @@ describe('AnnouncementsService', () => {
       expect(result.data).toHaveLength(2);
       expect(result.data[0].id).toBe('ann-001');
     });
+
+    it('Given: missing priority column on announcement, When: listAnnouncements called, Then: fallback query returns announcements with normal priority', async () => {
+      const accessToken = 'valid-token';
+      const participantId = 'participant-001';
+      const userId = 'user-001';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: userId },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: participantId },
+        error: null,
+      });
+
+      const announcementsQueryWithMissingPriority = createAsyncQuery(
+        {
+          data: null,
+          error: {
+            code: '42703',
+            message: 'column announcement.priority does not exist',
+          },
+        },
+        { withOrder: true },
+      );
+
+      const announcementsFallbackQuery = createAsyncQuery(
+        {
+          data: [
+            {
+              id: 'ann-001',
+              title: 'Fallback Announcement',
+              body: 'Body',
+              audience_type: 'all_participants',
+              program_id: null,
+              cohort_id: null,
+              status: 'published',
+              published_at: '2026-04-20T10:00:00Z',
+              created_by_user_id: 'user-001',
+              created_at: '2026-04-19T10:00:00Z',
+              updated_at: '2026-04-20T10:00:00Z',
+            },
+          ],
+          error: null,
+        },
+        { withOrder: true },
+      );
+
+      const enrollmentsQuery = createAsyncQuery(
+        {
+          data: [],
+          error: null,
+        },
+        { withIn: true },
+      );
+
+      let announcementCalls = 0;
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+
+          if (table === 'announcement') {
+            announcementCalls += 1;
+            return announcementCalls === 1
+              ? announcementsQueryWithMissingPriority
+              : announcementsFallbackQuery;
+          }
+
+          if (table === 'enrollment') {
+            return enrollmentsQuery;
+          }
+
+          return undefined;
+        }),
+      });
+
+      const result = await service.listAnnouncements(accessToken, 1, 20);
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: 'ann-001',
+        priority: 'normal',
+      });
+    });
   });
 
   describe('getAnnouncementById', () => {
@@ -420,6 +510,76 @@ describe('AnnouncementsService', () => {
       await expect(
         service.getAnnouncementById(announcementId, accessToken),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('Given: missing priority column on announcement, When: getAnnouncementById called, Then: fallback query returns the announcement with normal priority', async () => {
+      const accessToken = 'valid-token';
+      const announcementId = 'ann-001';
+
+      mockAuthClient.auth.getUser.mockResolvedValue({
+        data: {
+          user: { id: 'user-001' },
+        },
+        error: null,
+      });
+
+      const participantQuery = createAsyncQuery({
+        data: { id: 'participant-001' },
+        error: null,
+      });
+
+      const announcementQueryWithMissingPriority = createAsyncQuery({
+        data: null,
+        error: {
+          code: '42703',
+          message: 'column announcement.priority does not exist',
+        },
+      });
+
+      const announcementFallbackQuery = createAsyncQuery({
+        data: {
+          id: announcementId,
+          title: 'Fallback Announcement',
+          body: 'Body',
+          audience_type: 'all_participants',
+          program_id: null,
+          cohort_id: null,
+          status: 'published',
+          published_at: '2026-04-20T10:00:00Z',
+          created_by_user_id: 'user-001',
+          created_at: '2026-04-19T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+        error: null,
+      });
+
+      let announcementCalls = 0;
+      mockSupabaseService.getClient.mockReturnValue({
+        from: jest.fn((table: string) => {
+          if (table === 'participant') {
+            return participantQuery;
+          }
+
+          if (table === 'announcement') {
+            announcementCalls += 1;
+            return announcementCalls === 1
+              ? announcementQueryWithMissingPriority
+              : announcementFallbackQuery;
+          }
+
+          return undefined;
+        }),
+      });
+
+      const result = await service.getAnnouncementById(
+        announcementId,
+        accessToken,
+      );
+
+      expect(result).toMatchObject({
+        id: announcementId,
+        priority: 'normal',
+      });
     });
   });
 

--- a/apps/api/src/announcements/announcements.service.ts
+++ b/apps/api/src/announcements/announcements.service.ts
@@ -17,12 +17,14 @@ import { SupabaseService } from '../supabase/supabase.service';
 
 const ANNOUNCEMENT_SELECT_FIELDS =
   'id, title, body, priority, audience_type, program_id, cohort_id, status, published_at, created_by_user_id, created_at, updated_at';
+const ANNOUNCEMENT_SELECT_FIELDS_WITHOUT_PRIORITY =
+  'id, title, body, audience_type, program_id, cohort_id, status, published_at, created_by_user_id, created_at, updated_at';
 
 type AnnouncementRow = {
   id: string;
   title: string;
   body: string;
-  priority: AnnouncementPriorityValue;
+  priority?: AnnouncementPriorityValue | null;
   audience_type: AudienceTypeValue;
   program_id: string | null;
   cohort_id: string | null;
@@ -37,6 +39,36 @@ type EnrollmentRow = {
   program_id: string;
   cohort_id: string | null;
 };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readErrorCode(error: unknown): string | null {
+  if (!isObject(error) || typeof error['code'] !== 'string') {
+    return null;
+  }
+
+  return error['code'];
+}
+
+function readErrorMessage(error: unknown): string | null {
+  if (!isObject(error) || typeof error['message'] !== 'string') {
+    return null;
+  }
+
+  return error['message'];
+}
+
+function isAnnouncementPriorityColumnMissing(error: unknown): boolean {
+  const message = readErrorMessage(error);
+
+  return Boolean(
+    message &&
+    readErrorCode(error) === '42703' &&
+    message.includes('announcement.priority'),
+  );
+}
 
 @Injectable()
 export class AnnouncementsService {
@@ -55,23 +87,18 @@ export class AnnouncementsService {
     page?: number,
     limit?: number,
   ): Promise<{ data: AnnouncementDto[]; total: number }> {
-    const adminClient = this.supabaseService.getClient();
     const paginationLimit = this.resolvePaginationLimit(limit);
     const paginationPage = this.resolvePaginationPage(page);
 
-    // Get all published announcements
     const { data: allAnnouncements, error: announcementsError } =
-      await adminClient
-        .from('announcement')
-        .select(ANNOUNCEMENT_SELECT_FIELDS)
-        .eq('status', 'published')
-        .order('published_at', { ascending: false });
+      await this.readPublishedAnnouncements();
 
     if (announcementsError) {
       if (!accessToken) {
         console.error('Public announcements listing failed', {
           context: 'announcements.list.public',
-          message: announcementsError.message,
+          code: readErrorCode(announcementsError),
+          message: readErrorMessage(announcementsError),
         });
         return {
           data: [],
@@ -80,7 +107,7 @@ export class AnnouncementsService {
       }
 
       throw new Error(
-        `Failed to list announcements: ${announcementsError.message}`,
+        `Failed to list announcements: ${readErrorMessage(announcementsError) ?? 'unknown error'}`,
       );
     }
 
@@ -110,6 +137,7 @@ export class AnnouncementsService {
     }
 
     // Get participant's enrollments
+    const adminClient = this.supabaseService.getClient();
     const { data: enrollments, error: enrollmentsError } = await adminClient
       .from('enrollment')
       .select('program_id, cohort_id')
@@ -139,6 +167,84 @@ export class AnnouncementsService {
       data: paginated,
       total: sorted.length,
     };
+  }
+
+  private async readPublishedAnnouncements(): Promise<{
+    data: AnnouncementRow[] | null;
+    error: unknown;
+  }> {
+    return this.readAnnouncementQuery<AnnouncementRow[] | null>(
+      (selectClause) =>
+        this.supabaseService
+          .getClient()
+          .from('announcement')
+          .select(selectClause)
+          .eq('status', 'published')
+          .order('published_at', { ascending: false }) as PromiseLike<{
+          data: AnnouncementRow[] | null;
+          error: unknown;
+        }>,
+      'announcements.list',
+    );
+  }
+
+  private async readPublishedAnnouncementById(id: string): Promise<{
+    data: AnnouncementRow | null;
+    error: unknown;
+  }> {
+    return this.readAnnouncementQuery<AnnouncementRow | null>(
+      (selectClause) =>
+        this.supabaseService
+          .getClient()
+          .from('announcement')
+          .select(selectClause)
+          .eq('id', id)
+          .eq('status', 'published')
+          .single() as PromiseLike<{
+          data: AnnouncementRow | null;
+          error: unknown;
+        }>,
+      'announcements.getById',
+    );
+  }
+
+  private async readAnnouncementQuery<T>(
+    loadQuery: (
+      selectClause: string,
+    ) => PromiseLike<{ data: T; error: unknown }>,
+    context: string,
+  ): Promise<{ data: T; error: unknown }> {
+    const primaryResult = await loadQuery(ANNOUNCEMENT_SELECT_FIELDS);
+
+    if (!primaryResult.error) {
+      return primaryResult;
+    }
+
+    if (!isAnnouncementPriorityColumnMissing(primaryResult.error)) {
+      return primaryResult;
+    }
+
+    console.warn('Announcement priority column missing; retrying fallback', {
+      context,
+      code: readErrorCode(primaryResult.error),
+      message: readErrorMessage(primaryResult.error),
+    });
+
+    const fallbackResult = await loadQuery(
+      ANNOUNCEMENT_SELECT_FIELDS_WITHOUT_PRIORITY,
+    );
+
+    if (!fallbackResult.error) {
+      return fallbackResult;
+    }
+
+    console.error('Announcement fallback query failed', {
+      context,
+      code: readErrorCode(fallbackResult.error),
+      message: readErrorMessage(fallbackResult.error),
+    });
+
+    return fallbackResult;
   }
 
   private resolvePaginationLimit(limit?: number): number {
@@ -171,16 +277,8 @@ export class AnnouncementsService {
     id: string,
     accessToken: string,
   ): Promise<AnnouncementDto> {
-    const adminClient = this.supabaseService.getClient();
-
-    // Get the announcement
     const { data: announcementData, error: announcementError } =
-      await adminClient
-        .from('announcement')
-        .select(ANNOUNCEMENT_SELECT_FIELDS)
-        .eq('id', id)
-        .eq('status', 'published')
-        .single();
+      await this.readPublishedAnnouncementById(id);
 
     if (announcementError || !announcementData) {
       throw new NotFoundException('Announcement not found or not published');
@@ -333,7 +431,7 @@ export class AnnouncementsService {
       id: row.id,
       title: row.title,
       body: row.body,
-      priority: row.priority,
+      priority: row.priority ?? 'normal',
       audienceType: row.audience_type,
       programId: row.program_id,
       cohortId: row.cohort_id,

--- a/apps/api/src/announcements/announcements.service.ts
+++ b/apps/api/src/announcements/announcements.service.ts
@@ -14,6 +14,12 @@ import {
   sortAnnouncementsByPriority,
 } from '@kraak/domain';
 import { SupabaseService } from '../supabase/supabase.service';
+import {
+  isSupabaseColumnMissingError,
+  readSupabaseErrorCode,
+  readSupabaseErrorMessage,
+  readSupabaseQueryWithFallback,
+} from '../shared/supabase-query-fallback.utils';
 
 const ANNOUNCEMENT_SELECT_FIELDS =
   'id, title, body, priority, audience_type, program_id, cohort_id, status, published_at, created_by_user_id, created_at, updated_at';
@@ -40,34 +46,8 @@ type EnrollmentRow = {
   cohort_id: string | null;
 };
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function readErrorCode(error: unknown): string | null {
-  if (!isObject(error) || typeof error['code'] !== 'string') {
-    return null;
-  }
-
-  return error['code'];
-}
-
-function readErrorMessage(error: unknown): string | null {
-  if (!isObject(error) || typeof error['message'] !== 'string') {
-    return null;
-  }
-
-  return error['message'];
-}
-
 function isAnnouncementPriorityColumnMissing(error: unknown): boolean {
-  const message = readErrorMessage(error);
-
-  return Boolean(
-    message &&
-    readErrorCode(error) === '42703' &&
-    message.includes('announcement.priority'),
-  );
+  return isSupabaseColumnMissingError(error, ['announcement.priority']);
 }
 
 @Injectable()
@@ -97,8 +77,8 @@ export class AnnouncementsService {
       if (!accessToken) {
         console.error('Public announcements listing failed', {
           context: 'announcements.list.public',
-          code: readErrorCode(announcementsError),
-          message: readErrorMessage(announcementsError),
+          code: readSupabaseErrorCode(announcementsError),
+          message: readSupabaseErrorMessage(announcementsError),
         });
         return {
           data: [],
@@ -107,16 +87,15 @@ export class AnnouncementsService {
       }
 
       throw new Error(
-        `Failed to list announcements: ${readErrorMessage(announcementsError) ?? 'unknown error'}`,
+        `Failed to list announcements: ${readSupabaseErrorMessage(announcementsError) ?? 'unknown error'}`,
       );
     }
 
     // Public mode: return all published announcements when no token is provided.
     if (!accessToken) {
+      const announcementRows = allAnnouncements ?? [];
       const sorted = sortAnnouncementsByPriority(
-        ((allAnnouncements ?? []) as AnnouncementRow[]).map((row) =>
-          this.mapAnnouncement(row),
-        ),
+        announcementRows.map((row) => this.mapAnnouncement(row)),
       );
       const offset = (paginationPage - 1) * paginationLimit;
       const paginated = sorted.slice(offset, offset + paginationLimit);
@@ -149,9 +128,11 @@ export class AnnouncementsService {
     }
 
     // Filter announcements based on participant's scope
+    const announcementRows = allAnnouncements ?? [];
+    const enrollmentRows = (enrollments ?? []) as EnrollmentRow[];
     const visibleAnnouncements = this.filterAnnouncementsByScope(
-      (allAnnouncements ?? []) as AnnouncementRow[],
-      (enrollments ?? []) as EnrollmentRow[],
+      announcementRows,
+      enrollmentRows,
     );
 
     // Sort by priority and publishedAt
@@ -214,37 +195,15 @@ export class AnnouncementsService {
     ) => PromiseLike<{ data: T; error: unknown }>,
     context: string,
   ): Promise<{ data: T; error: unknown }> {
-    const primaryResult = await loadQuery(ANNOUNCEMENT_SELECT_FIELDS);
-
-    if (!primaryResult.error) {
-      return primaryResult;
-    }
-
-    if (!isAnnouncementPriorityColumnMissing(primaryResult.error)) {
-      return primaryResult;
-    }
-
-    console.warn('Announcement priority column missing; retrying fallback', {
+    return readSupabaseQueryWithFallback({
+      loadQuery,
+      primarySelect: ANNOUNCEMENT_SELECT_FIELDS,
+      fallbackSelect: ANNOUNCEMENT_SELECT_FIELDS_WITHOUT_PRIORITY,
+      shouldRetry: isAnnouncementPriorityColumnMissing,
       context,
-      code: readErrorCode(primaryResult.error),
-      message: readErrorMessage(primaryResult.error),
+      retryNotice: 'Announcement priority column missing; retrying fallback',
+      fallbackFailureNotice: 'Announcement fallback query failed',
     });
-
-    const fallbackResult = await loadQuery(
-      ANNOUNCEMENT_SELECT_FIELDS_WITHOUT_PRIORITY,
-    );
-
-    if (!fallbackResult.error) {
-      return fallbackResult;
-    }
-
-    console.error('Announcement fallback query failed', {
-      context,
-      code: readErrorCode(fallbackResult.error),
-      message: readErrorMessage(fallbackResult.error),
-    });
-
-    return fallbackResult;
   }
 
   private resolvePaginationLimit(limit?: number): number {
@@ -284,7 +243,7 @@ export class AnnouncementsService {
       throw new NotFoundException('Announcement not found or not published');
     }
 
-    const announcement = announcementData as AnnouncementRow;
+    const announcement = announcementData;
 
     // Get participant ID from access token
     const participantId = await this.resolveParticipantId(accessToken);

--- a/apps/api/src/programs/programs.service.spec.ts
+++ b/apps/api/src/programs/programs.service.spec.ts
@@ -324,6 +324,93 @@ describe('ProgramsService', () => {
     );
   });
 
+  // Given un schéma staging sans colonnes de progression enrollment
+  // When la liste programmes est demandée
+  // Then un fallback sans colonnes de progression est utilisé
+  it('Given des colonnes de progression absentes, When listPrograms est appelé, Then les programmes restent renvoyés avec une progression vide', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentQueryWithMissingProgress = createListQuery({
+      data: null,
+      error: {
+        code: '42703',
+        message:
+          'column enrollment.progress_completed_session_ids does not exist',
+      },
+    });
+    const enrollmentFallbackQuery = createListQuery({
+      data: [
+        {
+          id: 'enrollment-1',
+          status: 'active',
+          completed_at: null,
+          program_id: 'program-1',
+          cohort_id: 'cohort-1',
+          program: {
+            id: 'program-1',
+            slug: 'leadership-essentials',
+            title: 'Leadership Essentials',
+            summary: 'Bases du leadership.',
+            description: 'Parcours complet.',
+            status: 'published',
+            visibility: 'participants',
+            created_at: '2026-04-01T00:00:00.000Z',
+            updated_at: '2026-04-01T00:00:00.000Z',
+          },
+          cohort: {
+            id: 'cohort-1',
+            program_id: 'program-1',
+            name: 'Cohorte Avril',
+            code: 'APR-26',
+            status: 'active',
+            start_date: '2026-04-10',
+            end_date: null,
+            capacity: 25,
+            created_at: '2026-04-01T00:00:00.000Z',
+            updated_at: '2026-04-01T00:00:00.000Z',
+          },
+        },
+      ],
+      error: null,
+    });
+    const sessionsByCohortQuery = createListQuery({
+      data: [{ id: 'session-1', cohort_id: 'cohort-1' }],
+      error: null,
+    });
+
+    let enrollmentCalls = 0;
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        enrollmentCalls += 1;
+        return enrollmentCalls === 1
+          ? enrollmentQueryWithMissingProgress
+          : enrollmentFallbackQuery;
+      }
+
+      if (tableName === 'session') {
+        return sessionsByCohortQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listPrograms('access-token')).resolves.toMatchObject([
+      {
+        enrollmentId: 'enrollment-1',
+        progress: {
+          totalSessions: 1,
+          completedSessions: 0,
+        },
+      },
+    ]);
+  });
+
   // Given un programme accessible avec cohorte
   // When le détail programme est demandé
   // Then le détail inclut sessions, ressources et annonces visibles
@@ -1095,6 +1182,116 @@ describe('ProgramsService', () => {
     await expect(
       service.getProgramDetail('access-token', 'program-1'),
     ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  // Given un schéma staging sans colonnes de progression enrollment
+  // When le détail programme est demandé
+  // Then le fallback d'enrollment sans progression permet de charger le détail
+  it('Given des colonnes de progression absentes, When getProgramDetail est appelé, Then le détail programme reste disponible', async () => {
+    const participantQuery = createSingleRowQuery({
+      data: { id: 'participant-1' },
+      error: null,
+    });
+    const enrollmentQueryWithMissingProgress = createSingleRowQuery({
+      data: null,
+      error: {
+        code: '42703',
+        message: 'column enrollment.progress_updated_at does not exist',
+      },
+    });
+    const enrollmentFallbackQuery = createSingleRowQuery({
+      data: {
+        id: 'enrollment-1',
+        status: 'active',
+        completed_at: null,
+        program_id: 'program-1',
+        cohort_id: 'cohort-1',
+        program: {
+          id: 'program-1',
+          slug: 'leadership-essentials',
+          title: 'Leadership Essentials',
+          summary: 'Bases du leadership.',
+          description: 'Parcours complet.',
+          status: 'published',
+          visibility: 'participants',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+        cohort: {
+          id: 'cohort-1',
+          program_id: 'program-1',
+          name: 'Cohorte Avril',
+          code: 'APR-26',
+          status: 'active',
+          start_date: '2026-04-10',
+          end_date: null,
+          capacity: 25,
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      },
+      error: null,
+    });
+    const sessionsQuery = createListQuery({
+      data: [
+        {
+          id: 'session-1',
+          cohort_id: 'cohort-1',
+          title: 'Atelier Vision',
+          description: 'Vision et priorités',
+          status: 'scheduled',
+          starts_at: '2026-05-02T09:00:00.000Z',
+          ends_at: '2026-05-02T11:00:00.000Z',
+          location_type: 'online',
+          location_label: null,
+          meeting_link: 'https://meet.example.com/kraak',
+          trainer_user_id: null,
+          created_at: '2026-04-20T00:00:00.000Z',
+          updated_at: '2026-04-20T00:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const resourcesQuery = createListQuery({ data: [], error: null });
+    const announcementsQuery = createListQuery({ data: [], error: null });
+
+    let enrollmentCalls = 0;
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'participant') {
+        return participantQuery;
+      }
+
+      if (tableName === 'enrollment') {
+        enrollmentCalls += 1;
+        return enrollmentCalls === 1
+          ? enrollmentQueryWithMissingProgress
+          : enrollmentFallbackQuery;
+      }
+
+      if (tableName === 'session') {
+        return sessionsQuery;
+      }
+
+      if (tableName === 'resource') {
+        return resourcesQuery;
+      }
+
+      if (tableName === 'announcement') {
+        return announcementsQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getProgramDetail('access-token', 'program-1'),
+    ).resolves.toMatchObject({
+      enrollmentId: 'enrollment-1',
+      progress: {
+        totalSessions: 1,
+        completedSessions: 0,
+      },
+    });
   });
 
   // Given une erreur DB sur sessions dans getProgramDetail

--- a/apps/api/src/programs/programs.service.ts
+++ b/apps/api/src/programs/programs.service.ts
@@ -30,6 +30,11 @@ import type {
 } from '@kraak/contracts';
 import { SupabaseService } from '../supabase/supabase.service';
 import { mapResource, type ResourceRow } from '../shared/resource-mapper.utils';
+import {
+  isSupabaseColumnMissingError,
+  readSupabaseQueryWithFallback,
+  type SupabaseQueryResult,
+} from '../shared/supabase-query-fallback.utils';
 
 type ParticipantRow = {
   id: string;
@@ -120,37 +125,31 @@ function normalizeRelation<T>(value: T | T[] | null | undefined): T | null {
   return value ?? null;
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function readErrorCode(error: unknown): string | null {
-  if (!isObject(error) || typeof error['code'] !== 'string') {
-    return null;
-  }
-
-  return error['code'];
-}
-
-function readErrorMessage(error: unknown): string | null {
-  if (!isObject(error) || typeof error['message'] !== 'string') {
-    return null;
-  }
-
-  return error['message'];
-}
-
 function isEnrollmentProgressColumnMissing(error: unknown): boolean {
-  const message = readErrorMessage(error);
+  return isSupabaseColumnMissingError(error, [
+    'progress_completed_session_ids',
+    'progress_updated_at',
+  ]);
+}
 
-  if (!message || readErrorCode(error) !== '42703') {
-    return false;
-  }
+type SupabaseQueryLoader<T> = (
+  selectClause: string,
+) => PromiseLike<SupabaseQueryResult<T>>;
 
-  return (
-    message.includes('progress_completed_session_ids') ||
-    message.includes('progress_updated_at')
-  );
+function executeEnrollmentQueryWithFallback<T>(
+  loadQuery: SupabaseQueryLoader<T>,
+  context: string,
+): Promise<SupabaseQueryResult<T>> {
+  return readSupabaseQueryWithFallback({
+    loadQuery,
+    primarySelect: enrollmentProgramSelect,
+    fallbackSelect: enrollmentProgramSelectWithoutProgress,
+    shouldRetry: isEnrollmentProgressColumnMissing,
+    context,
+    retryNotice: 'Enrollment progress columns missing; retrying fallback',
+    fallbackFailureNotice: 'Enrollment fallback query failed',
+    primaryFailureNotice: 'Enrollment query failed',
+  });
 }
 
 @Injectable()
@@ -235,38 +234,10 @@ export class ProgramsService {
     errorMessage: string,
     context: string,
   ): Promise<T> {
-    const primaryResult = await loadQuery(enrollmentProgramSelect);
+    const result = await executeEnrollmentQueryWithFallback(loadQuery, context);
 
-    if (!primaryResult.error) {
-      return primaryResult.data;
-    }
-
-    if (isEnrollmentProgressColumnMissing(primaryResult.error)) {
-      console.warn('Enrollment progress columns missing; retrying fallback', {
-        context,
-        code: readErrorCode(primaryResult.error),
-        message: readErrorMessage(primaryResult.error),
-      });
-
-      const fallbackResult = await loadQuery(
-        enrollmentProgramSelectWithoutProgress,
-      );
-
-      if (!fallbackResult.error) {
-        return fallbackResult.data;
-      }
-
-      console.error('Enrollment fallback query failed', {
-        context,
-        code: readErrorCode(fallbackResult.error),
-        message: readErrorMessage(fallbackResult.error),
-      });
-    } else {
-      console.error('Enrollment query failed', {
-        context,
-        code: readErrorCode(primaryResult.error),
-        message: readErrorMessage(primaryResult.error),
-      });
+    if (!result.error) {
+      return result.data;
     }
 
     throw new InternalServerErrorException({

--- a/apps/api/src/programs/programs.service.ts
+++ b/apps/api/src/programs/programs.service.ts
@@ -66,8 +66,8 @@ type EnrollmentRow = {
   completed_at: string | null;
   program_id: string;
   cohort_id: string | null;
-  progress_completed_session_ids: string[] | null;
-  progress_updated_at: string | null;
+  progress_completed_session_ids?: string[] | null;
+  progress_updated_at?: string | null;
   program: ProgramRow | ProgramRow[] | null;
   cohort: CohortRow | CohortRow[] | null;
 };
@@ -102,6 +102,8 @@ type AnnouncementPreviewRow = Pick<
 
 const enrollmentProgramSelect =
   'id, status, completed_at, program_id, cohort_id, progress_completed_session_ids, progress_updated_at, program:program(id, slug, title, summary, description, status, visibility, created_at, updated_at), cohort:cohort(id, program_id, name, code, status, start_date, end_date, capacity, created_at, updated_at)';
+const enrollmentProgramSelectWithoutProgress =
+  'id, status, completed_at, program_id, cohort_id, program:program(id, slug, title, summary, description, status, visibility, created_at, updated_at), cohort:cohort(id, program_id, name, code, status, start_date, end_date, capacity, created_at, updated_at)';
 
 const progressUpdateErrorMessage =
   'Impossible de mettre à jour la progression du programme.';
@@ -116,6 +118,39 @@ function normalizeRelation<T>(value: T | T[] | null | undefined): T | null {
   }
 
   return value ?? null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readErrorCode(error: unknown): string | null {
+  if (!isObject(error) || typeof error['code'] !== 'string') {
+    return null;
+  }
+
+  return error['code'];
+}
+
+function readErrorMessage(error: unknown): string | null {
+  if (!isObject(error) || typeof error['message'] !== 'string') {
+    return null;
+  }
+
+  return error['message'];
+}
+
+function isEnrollmentProgressColumnMissing(error: unknown): boolean {
+  const message = readErrorMessage(error);
+
+  if (!message || readErrorCode(error) !== '42703') {
+    return false;
+  }
+
+  return (
+    message.includes('progress_completed_session_ids') ||
+    message.includes('progress_updated_at')
+  );
 }
 
 @Injectable()
@@ -135,23 +170,7 @@ export class ProgramsService {
       return [];
     }
 
-    const adminClient = this.supabaseService.getClient();
-    const { data, error } = await adminClient
-      .from('enrollment')
-      .select(enrollmentProgramSelect)
-      .eq('participant_id', participantId)
-      .in('status', ['pending', 'active', 'completed'])
-      .order('enrolled_at', { ascending: false })
-      .limit(20);
-
-    if (error) {
-      throw new InternalServerErrorException({
-        success: false,
-        message: 'Impossible de charger la liste des programmes.',
-      });
-    }
-
-    const enrollments = (data as EnrollmentRow[] | null) ?? [];
+    const enrollments = await this.readParticipantEnrollments(participantId);
     const cohortIds = enrollments
       .map((row) => normalizeRelation(row.cohort)?.id ?? null)
       .filter((id): id is string => Boolean(id));
@@ -184,6 +203,76 @@ export class ProgramsService {
         };
       })
       .filter((item): item is ParticipantProgramListItemDto => item !== null);
+  }
+
+  private async readParticipantEnrollments(
+    participantId: string,
+  ): Promise<EnrollmentRow[]> {
+    const data = await this.readEnrollmentQuery<EnrollmentRow[] | null>(
+      (selectClause) =>
+        this.supabaseService
+          .getClient()
+          .from('enrollment')
+          .select(selectClause)
+          .eq('participant_id', participantId)
+          .in('status', ['pending', 'active', 'completed'])
+          .order('enrolled_at', { ascending: false })
+          .limit(20) as PromiseLike<{
+          data: EnrollmentRow[] | null;
+          error: unknown;
+        }>,
+      'Impossible de charger la liste des programmes.',
+      'programs.listPrograms',
+    );
+
+    return data ?? [];
+  }
+
+  private async readEnrollmentQuery<T>(
+    loadQuery: (
+      selectClause: string,
+    ) => PromiseLike<{ data: T; error: unknown }>,
+    errorMessage: string,
+    context: string,
+  ): Promise<T> {
+    const primaryResult = await loadQuery(enrollmentProgramSelect);
+
+    if (!primaryResult.error) {
+      return primaryResult.data;
+    }
+
+    if (isEnrollmentProgressColumnMissing(primaryResult.error)) {
+      console.warn('Enrollment progress columns missing; retrying fallback', {
+        context,
+        code: readErrorCode(primaryResult.error),
+        message: readErrorMessage(primaryResult.error),
+      });
+
+      const fallbackResult = await loadQuery(
+        enrollmentProgramSelectWithoutProgress,
+      );
+
+      if (!fallbackResult.error) {
+        return fallbackResult.data;
+      }
+
+      console.error('Enrollment fallback query failed', {
+        context,
+        code: readErrorCode(fallbackResult.error),
+        message: readErrorMessage(fallbackResult.error),
+      });
+    } else {
+      console.error('Enrollment query failed', {
+        context,
+        code: readErrorCode(primaryResult.error),
+        message: readErrorMessage(primaryResult.error),
+      });
+    }
+
+    throw new InternalServerErrorException({
+      success: false,
+      message: errorMessage,
+    });
   }
 
   private async listPublishedPrograms(): Promise<ProgramDto[]> {
@@ -586,23 +675,24 @@ export class ProgramsService {
     programId: string,
     errorMessage: string,
   ): Promise<EnrollmentRow | null> {
-    const adminClient = this.supabaseService.getClient();
-    const { data, error } = await adminClient
-      .from('enrollment')
-      .select(enrollmentProgramSelect)
-      .eq('participant_id', participantId)
-      .eq('program_id', programId)
-      .in('status', ['pending', 'active', 'completed'])
-      .maybeSingle();
+    const data = await this.readEnrollmentQuery<EnrollmentRow | null>(
+      (selectClause) =>
+        this.supabaseService
+          .getClient()
+          .from('enrollment')
+          .select(selectClause)
+          .eq('participant_id', participantId)
+          .eq('program_id', programId)
+          .in('status', ['pending', 'active', 'completed'])
+          .maybeSingle() as PromiseLike<{
+          data: EnrollmentRow | null;
+          error: unknown;
+        }>,
+      errorMessage,
+      'programs.readEnrollmentByProgram',
+    );
 
-    if (error) {
-      throw new InternalServerErrorException({
-        success: false,
-        message: errorMessage,
-      });
-    }
-
-    return data as EnrollmentRow | null;
+    return data;
   }
 
   private async readPublishedResources(

--- a/apps/api/src/shared/supabase-query-fallback.utils.spec.ts
+++ b/apps/api/src/shared/supabase-query-fallback.utils.spec.ts
@@ -1,0 +1,121 @@
+import {
+  isSupabaseColumnMissingError,
+  readSupabaseErrorCode,
+  readSupabaseErrorMessage,
+  readSupabaseQueryWithFallback,
+} from './supabase-query-fallback.utils';
+
+describe('readSupabaseErrorCode', () => {
+  it('Given une erreur Supabase avec code, When readSupabaseErrorCode est appele, Then le code est retourne', () => {
+    expect(readSupabaseErrorCode({ code: '42703' })).toBe('42703');
+  });
+
+  it('Given une erreur sans code exploitable, When readSupabaseErrorCode est appele, Then null est retourne', () => {
+    expect(readSupabaseErrorCode({ code: 42703 })).toBeNull();
+    expect(readSupabaseErrorCode(null)).toBeNull();
+  });
+});
+
+describe('readSupabaseErrorMessage', () => {
+  it('Given une erreur Supabase avec message, When readSupabaseErrorMessage est appele, Then le message est retourne', () => {
+    expect(
+      readSupabaseErrorMessage({
+        message: 'column announcement.priority does not exist',
+      }),
+    ).toBe('column announcement.priority does not exist');
+  });
+
+  it('Given une erreur sans message exploitable, When readSupabaseErrorMessage est appele, Then null est retourne', () => {
+    expect(readSupabaseErrorMessage({ message: false })).toBeNull();
+    expect(readSupabaseErrorMessage(undefined)).toBeNull();
+  });
+});
+
+describe('isSupabaseColumnMissingError', () => {
+  it('Given une erreur 42703 sur une colonne attendue, When isSupabaseColumnMissingError est appele, Then true est retourne', () => {
+    expect(
+      isSupabaseColumnMissingError(
+        {
+          code: '42703',
+          message: 'column enrollment.progress_updated_at does not exist',
+        },
+        ['progress_updated_at'],
+      ),
+    ).toBe(true);
+  });
+
+  it('Given une erreur non liee a une colonne attendue, When isSupabaseColumnMissingError est appele, Then false est retourne', () => {
+    expect(
+      isSupabaseColumnMissingError(
+        {
+          code: '23505',
+          message: 'duplicate key value violates unique constraint',
+        },
+        ['announcement.priority'],
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('readSupabaseQueryWithFallback', () => {
+  it('Given une erreur de colonne manquante, When readSupabaseQueryWithFallback est appele, Then la requete fallback est rejouee', async () => {
+    const loadQuery = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: '42703',
+          message: 'column announcement.priority does not exist',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'ann-1' }],
+        error: null,
+      });
+
+    await expect(
+      readSupabaseQueryWithFallback({
+        loadQuery,
+        primarySelect: 'priority',
+        fallbackSelect: 'without-priority',
+        shouldRetry: (error) =>
+          isSupabaseColumnMissingError(error, ['announcement.priority']),
+        context: 'announcements.list',
+        retryNotice: 'Announcement priority column missing; retrying fallback',
+        fallbackFailureNotice: 'Announcement fallback query failed',
+      }),
+    ).resolves.toEqual({
+      data: [{ id: 'ann-1' }],
+      error: null,
+    });
+
+    expect(loadQuery).toHaveBeenNthCalledWith(1, 'priority');
+    expect(loadQuery).toHaveBeenNthCalledWith(2, 'without-priority');
+  });
+
+  it('Given une erreur non eligible, When readSupabaseQueryWithFallback est appele, Then le resultat primaire est retourne sans fallback', async () => {
+    const primaryResult = {
+      data: null,
+      error: {
+        code: '42501',
+        message: 'permission denied',
+      },
+    };
+    const loadQuery = jest.fn().mockResolvedValue(primaryResult);
+
+    await expect(
+      readSupabaseQueryWithFallback({
+        loadQuery,
+        primarySelect: 'primary',
+        fallbackSelect: 'fallback',
+        shouldRetry: (error) =>
+          isSupabaseColumnMissingError(error, ['announcement.priority']),
+        context: 'announcements.list',
+        retryNotice: 'Announcement priority column missing; retrying fallback',
+        fallbackFailureNotice: 'Announcement fallback query failed',
+      }),
+    ).resolves.toBe(primaryResult);
+
+    expect(loadQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/shared/supabase-query-fallback.utils.ts
+++ b/apps/api/src/shared/supabase-query-fallback.utils.ts
@@ -1,0 +1,97 @@
+export type SupabaseQueryResult<T> = {
+  data: T;
+  error: unknown;
+};
+
+type ReadSupabaseQueryWithFallbackOptions<T> = {
+  loadQuery: (selectClause: string) => PromiseLike<SupabaseQueryResult<T>>;
+  primarySelect: string;
+  fallbackSelect: string;
+  shouldRetry: (error: unknown) => boolean;
+  context: string;
+  retryNotice: string;
+  fallbackFailureNotice: string;
+  primaryFailureNotice?: string;
+};
+
+function isObjectPayload(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function readSupabaseErrorCode(error: unknown): string | null {
+  if (!isObjectPayload(error) || typeof error['code'] !== 'string') {
+    return null;
+  }
+
+  return error['code'];
+}
+
+export function readSupabaseErrorMessage(error: unknown): string | null {
+  if (!isObjectPayload(error) || typeof error['message'] !== 'string') {
+    return null;
+  }
+
+  return error['message'];
+}
+
+export function isSupabaseColumnMissingError(
+  error: unknown,
+  columnFragments: string[],
+): boolean {
+  const message = readSupabaseErrorMessage(error);
+
+  if (!message || readSupabaseErrorCode(error) !== '42703') {
+    return false;
+  }
+
+  return columnFragments.some((columnFragment) =>
+    message.includes(columnFragment),
+  );
+}
+
+export async function readSupabaseQueryWithFallback<T>({
+  loadQuery,
+  primarySelect,
+  fallbackSelect,
+  shouldRetry,
+  context,
+  retryNotice,
+  fallbackFailureNotice,
+  primaryFailureNotice,
+}: ReadSupabaseQueryWithFallbackOptions<T>): Promise<SupabaseQueryResult<T>> {
+  const primaryResult = await loadQuery(primarySelect);
+
+  if (!primaryResult.error) {
+    return primaryResult;
+  }
+
+  if (!shouldRetry(primaryResult.error)) {
+    if (primaryFailureNotice) {
+      console.error(primaryFailureNotice, {
+        context,
+        code: readSupabaseErrorCode(primaryResult.error),
+        message: readSupabaseErrorMessage(primaryResult.error),
+      });
+    }
+
+    return primaryResult;
+  }
+
+  console.warn(retryNotice, {
+    context,
+    code: readSupabaseErrorCode(primaryResult.error),
+    message: readSupabaseErrorMessage(primaryResult.error),
+  });
+
+  const fallbackResult = await loadQuery(fallbackSelect);
+
+  if (fallbackResult.error) {
+    console.error(fallbackFailureNotice, {
+      context,
+      code: readSupabaseErrorCode(fallbackResult.error),
+      message: readSupabaseErrorMessage(fallbackResult.error),
+    });
+  }
+
+  return fallbackResult;
+}

--- a/supabase/migrations/20260503162559_remote_schema.sql
+++ b/supabase/migrations/20260503162559_remote_schema.sql
@@ -1,0 +1,17 @@
+drop extension if exists "pg_net";
+alter table "public"."announcement" drop constraint "announcement_mvp_audience_scope";
+alter table "public"."announcement" drop constraint "announcement_published_at_consistency";
+drop function if exists "public"."handle_auth_user_created"();
+drop index if exists "public"."idx_enrollment_progress_completed_session_ids";
+drop index if exists "public"."idx_resource_last_consulted_at";
+alter table "public"."announcement" drop column "priority";
+alter table "public"."enrollment" drop column "progress_completed_session_ids";
+alter table "public"."enrollment" drop column "progress_updated_at";
+alter table "public"."resource" drop column "consultation_count";
+alter table "public"."resource" drop column "last_consulted_at";
+alter table "public"."resource" drop column "resource_audience";
+alter table "public"."resource" drop column "resource_theme";
+drop type "public"."announcement_priority";
+drop type "public"."resource_audience";
+drop type "public"."resource_theme";
+drop trigger if exists "on_auth_user_created" on "auth"."users";

--- a/supabase/migrations/20260515113000_backfill_participant_schema_drift.sql
+++ b/supabase/migrations/20260515113000_backfill_participant_schema_drift.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- Migration : rattrapage du schéma participant MVP
+-- Contexte  : environnements en retard sur announcement.priority
+--             et enrollment.progress_* provoquant des 500 API
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'announcement_priority'
+  ) THEN
+    CREATE TYPE announcement_priority AS ENUM (
+      'low', 'normal', 'high', 'critical'
+    );
+  END IF;
+END $$;
+
+ALTER TABLE announcement
+  ADD COLUMN IF NOT EXISTS priority announcement_priority NOT NULL DEFAULT 'normal';
+
+ALTER TABLE enrollment
+  ADD COLUMN IF NOT EXISTS progress_completed_session_ids text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS progress_updated_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_enrollment_progress_completed_session_ids
+  ON enrollment USING gin (progress_completed_session_ids);


### PR DESCRIPTION
## Resume
- corrige les `500` de l'espace participant sur `GET /programs` et `GET /announcements` quand certaines colonnes attendues par l'API sont absentes sur Supabase staging
- ajoute des fallbacks defensifs cibles dans les services `programs` et `announcements` au lieu de remonter une erreur 500 sur un drift de schema connu (`42703`)
- partage le mecanisme de fallback Supabase dans un utilitaire commun pour faire tomber la duplication Sonar sans changer le comportement metier
- ajoute une migration idempotente de backfill et versionne la migration distante manquante qui expliquait le drift constate sur staging

## Fichiers suivis dans ce PR
- `apps/api/src/programs/programs.service.ts`
- `apps/api/src/programs/programs.service.spec.ts`
- `apps/api/src/announcements/announcements.service.ts`
- `apps/api/src/announcements/announcements.service.spec.ts`
- `apps/api/src/shared/supabase-query-fallback.utils.ts`
- `apps/api/src/shared/supabase-query-fallback.utils.spec.ts`
- `supabase/migrations/20260503162559_remote_schema.sql`
- `supabase/migrations/20260515113000_backfill_participant_schema_drift.sql`

## Validation
- `pnpm.cmd --filter @kraak/api test -- src/programs/programs.service.spec.ts src/announcements/announcements.service.spec.ts`
- `pnpm.cmd --filter @kraak/api test -- src/shared/supabase-query-fallback.utils.spec.ts src/programs/programs.service.spec.ts src/announcements/announcements.service.spec.ts`
- `pnpm.cmd --filter @kraak/api build`
- `pnpm.cmd --filter @kraak/api lint`
- Newman local contre API locale branchee sur Supabase staging
- Newman contre `https://kraak-api-staging.onrender.com` apres application de la migration staging (`17/17` assertions OK)

## Notes de tracabilite
- des ajustements locaux de collection et des rapports Postman sous `test-results/postman/` ont ete utilises pendant la validation, mais restent gitignores et ne font pas partie du diff versionne
- premier `GET /health` lent observe sur Render pendant le smoke final, coherent avec un cold start, sans echec fonctionnel ensuite

Closes #427
