### PR TITLE
[BUG][WEB] Unifier la FAQ publique et renforcer la visibilite sociale

### DIFF
--- a/apps/client/projects/web/public/sitemap.xml
+++ b/apps/client/projects/web/public/sitemap.xml
@@ -16,11 +16,6 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://kraak-consulting.vercel.app/faq</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://kraak-consulting.vercel.app/programmes</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/apps/client/projects/web/src/app/features/contact/contact.page.html
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.html
@@ -140,12 +140,12 @@
                   [href]="social.href"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="border-brand-white/35 hover:border-brand-cyan hover:text-brand-cyan text-brand-white bg-brand-white/10 flex h-10 w-10 items-center justify-center rounded-full border transition-all hover:-translate-y-px"
+                  class="border-brand-white/35 hover:border-brand-cyan hover:text-brand-cyan text-brand-white bg-brand-white/10 flex h-12 w-12 items-center justify-center rounded-full border shadow-sm transition-all hover:-translate-y-px hover:scale-[1.03]"
                   [attr.aria-label]="social.label"
                   [attr.title]="social.label"
                 >
                   <i
-                    [class]="'pi ' + social.icon + ' text-sm'"
+                    [class]="'pi ' + social.icon + ' text-lg'"
                     aria-hidden="true"
                   ></i>
                 </a>
@@ -478,12 +478,6 @@
         </p>
       </div>
     </div>
-  </div>
-</section>
-
-<section class="kr-perf-section bg-neutral-50 pb-6 lg:pb-10">
-  <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <kraak-faq-accordion [items]="faqItems" />
   </div>
 </section>
 

--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -47,7 +47,7 @@ describe('ContactPage', () => {
   // Given la page de contact est chargée
   // When le composant est instancié
   // Then il doit être créé sans erreur
-  it('devrait créer le composant', () => {
+  it('Given la page de contact When le composant est instancie Then il se cree sans erreur', () => {
     const fixture = TestBed.createComponent(ContactPage);
     expect(fixture.componentInstance).toBeTruthy();
   });
@@ -55,7 +55,7 @@ describe('ContactPage', () => {
   // Given la page de contact est affichée
   // When le contenu est rendu
   // Then le titre principal doit \u00EAtre visible
-  it('devrait afficher le titre principal "Parlez-nous de votre objectif."', () => {
+  it('Given la page de contact When le contenu est rendu Then le titre principal est visible', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
@@ -65,7 +65,7 @@ describe('ContactPage', () => {
   // Given le formulaire de contact est affich\u00E9
   // When l'utilisateur n'a pas encore soumis
   // Then le formulaire avec tous ses champs doit \u00EAtre pr\u00E9sent
-  it('devrait afficher le formulaire avec les champs requis', () => {
+  it('Given la page de contact When le formulaire est rendu Then tous les champs requis sont presents', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const form = fixture.nativeElement.querySelector('form');
@@ -78,7 +78,7 @@ describe('ContactPage', () => {
     expect(fixture.nativeElement.querySelector('#message')).toBeTruthy();
   });
 
-  it('devrait afficher une action WhatsApp visible pour un contact rapide', () => {
+  it('Given la page de contact When le bloc de contact est rendu Then une action WhatsApp visible est presente', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
 
@@ -91,10 +91,37 @@ describe('ContactPage', () => {
     expect(whatsappLink?.getAttribute('href')).toBe(WHATSAPP_URL);
   });
 
+  it('Given la page de contact When le bloc de contact est rendu Then les boutons sociaux sont plus visibles', () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const socialButton = page.querySelector(
+      'nav[aria-label="Réseaux sociaux KRAAK"] a[aria-label="Facebook"]',
+    ) as HTMLAnchorElement | null;
+    const socialIcon = socialButton?.querySelector('i');
+
+    expect(socialButton).toBeTruthy();
+    expect(socialButton?.className).toContain('h-12');
+    expect(socialButton?.className).toContain('w-12');
+    expect(socialIcon?.className).toContain('text-lg');
+  });
+
+  it('Given the contact page When it renders Then it does not duplicate the dedicated FAQ route content', () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    const faqAccordion = element.querySelector('kraak-faq-accordion');
+
+    expect(faqAccordion).toBeNull();
+    expect(element.textContent).not.toContain('Questions fr\u00E9quentes');
+  });
+
   // Given le formulaire est vide
   // When l'utilisateur soumet le formulaire
   // Then le formulaire doit \u00EAtre invalide et les erreurs affich\u00E9es
-  it('devrait marquer le formulaire comme invalide si les champs sont vides \u00E0 la soumission', () => {
+  it('Given un formulaire vide When la soumission est declenchee Then le formulaire devient invalide', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;
@@ -108,7 +135,7 @@ describe('ContactPage', () => {
   // Given l'état initial
   // When le composant est créé
   // Then le signal de succès doit être false
-  it('devrait initialiser success à false', () => {
+  it('Given la page de contact When le composant est cree Then le signal success vaut false', () => {
     const fixture = TestBed.createComponent(ContactPage);
     expect(fixture.componentInstance.success()).toBe(false);
   });
@@ -116,7 +143,7 @@ describe('ContactPage', () => {
   // Given le formulaire de contact
   // When on remplit tous les champs avec des donn\u00E9es valides
   // Then le formulaire doit \u00EAtre valide
-  it('devrait valider le formulaire avec des donn\u00E9es correctes', () => {
+  it('Given le formulaire de contact When tous les champs valides sont renseignes Then le formulaire devient valide', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;
@@ -136,7 +163,7 @@ describe('ContactPage', () => {
   // Given l'\u00E9tat initial de chargement
   // When le composant est cr\u00E9\u00E9
   // Then loading doit \u00EAtre false
-  it('devrait initialiser loading \u00E0 false', () => {
+  it('Given la page de contact When le composant est cree Then le signal loading vaut false', () => {
     const fixture = TestBed.createComponent(ContactPage);
     expect(fixture.componentInstance.loading()).toBe(false);
   });
@@ -144,7 +171,7 @@ describe('ContactPage', () => {
   // Given un formulaire valide
   // When la soumission API réussit
   // Then le formulaire est réinitialisé et le message de succès est affiché
-  it('devrait afficher un succès après une soumission réussie', () => {
+  it('Given un formulaire valide When la soumission reussit Then un retour de succes est affiche', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;
@@ -196,7 +223,7 @@ describe('ContactPage', () => {
   // Given un succès précédent
   // When l'utilisateur soumet à nouveau le formulaire
   // Then success doit repasser à false immédiatement avant la réponse HTTP
-  it("devrait réinitialiser success à false au début d'une nouvelle soumission", () => {
+  it('Given un succes precedent When une nouvelle soumission commence Then success repasse immediatement a false', () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;
@@ -238,7 +265,7 @@ describe('ContactPage', () => {
   // Given un formulaire valide
   // When l'API répond avec des erreurs de validation
   // Then les erreurs API doivent être affichées dans la page
-  it('devrait afficher les erreurs API renvoyées par le backend', () => {
+  it("Given un formulaire valide When l'API renvoie des erreurs de validation Then elles sont affichees dans la page", () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;
@@ -276,7 +303,7 @@ describe('ContactPage', () => {
   // Given un formulaire valide
   // When l'API répond avec une erreur sans tableau errors structuré
   // Then le message d'erreur générique est affiché
-  it('devrait afficher le message générique si la réponse erreur ne contient pas de tableau errors', () => {
+  it("Given un formulaire valide When l'API renvoie une erreur non structuree Then le message generique est affiche", () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;

--- a/apps/client/projects/web/src/app/features/contact/contact.page.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.ts
@@ -1,6 +1,6 @@
 import { NgClass, NgStyle } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import {
   AbstractControl,
   FormControl,
@@ -8,14 +8,15 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import type { ContactFormDto } from '@kraak/contracts';
+import { logDebugError } from '@kraak/api-client';
 import { MessageService } from 'primeng/api';
 import { ButtonDirective } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
 import { Message } from 'primeng/message';
 import { Textarea } from 'primeng/textarea';
-import { logDebugError } from '@kraak/api-client';
-import type { ContactFormDto } from '@kraak/contracts';
 
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import {
   CONTACT_EMAIL,
   CONTACT_VISUAL_URL,
@@ -24,12 +25,7 @@ import {
   type SocialLink,
 } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
-import {
-  FaqAccordion,
-  type FaqItem,
-} from '../../shared/faq-accordion/faq-accordion.component';
 import { ContactService } from './contact.service';
-import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 
 type ServiceType =
   | 'formation'
@@ -46,7 +42,7 @@ interface ServiceOption {
 }
 
 const GENERIC_CONTACT_ERROR_MESSAGE =
-  'Une erreur est survenue. Veuillez r\u00E9essayer plus tard.';
+  'Une erreur est survenue. Veuillez r\u00e9essayer plus tard.';
 
 @Component({
   selector: 'kraak-contact-page',
@@ -59,7 +55,6 @@ const GENERIC_CONTACT_ERROR_MESSAGE =
     InputText,
     Textarea,
     Message,
-    FaqAccordion,
     CtaBanner,
   ],
   templateUrl: './contact.page.html',
@@ -76,7 +71,6 @@ export default class ContactPage implements OnInit, OnDestroy {
   protected readonly contactVisualUrl = CONTACT_VISUAL_URL;
   protected readonly contactEmail = CONTACT_EMAIL;
   protected readonly contactEmailHref = `mailto:${CONTACT_EMAIL}`;
-
   protected readonly heroBackgroundStyle = HERO_BACKGROUND_STYLE;
 
   private readonly contactService = inject(ContactService);
@@ -105,41 +99,6 @@ export default class ContactPage implements OnInit, OnDestroy {
     KRAAK_SOCIAL_LINKS.find((social) => social.label === 'WhatsApp')?.href ??
     '';
 
-  protected readonly faqItems: FaqItem[] = [
-    {
-      question: 'Comment obtenir un accompagnement personnalisé avec KRAAK ?',
-      answer:
-        'Remplissez le formulaire de contact avec votre objectif principal. Notre équipe analyse votre besoin et vous propose une orientation claire sous 48h ouvrées.',
-    },
-    {
-      question: 'Quels types de services propose KRAAK ?',
-      answer:
-        "Nous intervenons sur la formation, la recherche et gestion de projets, les programmes KRAAK, les solutions entreprises et l'accompagnement en études et immigration.",
-    },
-    {
-      question: 'Puis-je vous contacter directement sur WhatsApp ?',
-      answer:
-        'Oui. Si vous préférez un échange rapide, le canal WhatsApp reste disponible en complément du formulaire de contact.',
-    },
-    {
-      question: 'Combien de temps faut-il pour recevoir une première réponse ?',
-      answer:
-        'Après soumission de votre demande, nous revenons généralement vers vous sous 48h ouvrées avec une proposition de prochaine étape.',
-    },
-  ];
-
-  ngOnInit(): void {
-    this.gsapService.animatePageIn();
-    this.gsapService.initializeFigureAnimations('figure.reveal-on-scroll');
-    this.gsapService.initializeInteractiveCardAnimations('article');
-    this.gsapService.initializeButtonTransitions();
-    this.gsapService.initializeFormFieldAnimations();
-    this.gsapService.initializeSectionAnimations();
-  }
-
-  ngOnDestroy(): void {
-    this.gsapService.killAllAnimations();
-  }
   readonly form = new FormGroup({
     name: new FormControl('', [Validators.required, Validators.minLength(2)]),
     email: new FormControl('', [Validators.required, Validators.email]),
@@ -159,21 +118,39 @@ export default class ContactPage implements OnInit, OnDestroy {
   readonly success = signal(false);
   readonly apiErrors = signal<string[]>([]);
 
+  ngOnInit(): void {
+    this.gsapService.animatePageIn();
+    this.gsapService.initializeFigureAnimations('figure.reveal-on-scroll');
+    this.gsapService.initializeInteractiveCardAnimations('article');
+    this.gsapService.initializeButtonTransitions();
+    this.gsapService.initializeFormFieldAnimations();
+    this.gsapService.initializeSectionAnimations();
+  }
+
+  ngOnDestroy(): void {
+    this.gsapService.killAllAnimations();
+  }
+
   get name(): AbstractControl {
     return this.form.get('name')!;
   }
+
   get email(): AbstractControl {
     return this.form.get('email')!;
   }
+
   get subject(): AbstractControl {
     return this.form.get('subject')!;
   }
+
   get country(): AbstractControl {
     return this.form.get('country')!;
   }
+
   get serviceType(): AbstractControl {
     return this.form.get('serviceType')!;
   }
+
   get message(): AbstractControl {
     return this.form.get('message')!;
   }
@@ -204,7 +181,7 @@ export default class ContactPage implements OnInit, OnDestroy {
           severity: 'success',
           summary: 'Contact',
           detail:
-            'Votre message a bien été envoyé. Notre équipe revient vers vous rapidement.',
+            'Votre message a bien \u00e9t\u00e9 envoy\u00e9. Notre \u00e9quipe revient vers vous rapidement.',
           life: 6000,
         });
         this.form.reset();

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -257,12 +257,6 @@
 
 <kraak-home-preview-sections />
 
-<section class="kr-perf-section bg-neutral-50 pb-6 lg:pb-10">
-  <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <kraak-faq-accordion [items]="faqItems" />
-  </div>
-</section>
-
 <kraak-cta-banner
   heading="Pr&ecirc;t &agrave; construire la suite ?"
   body="Parlez-nous de votre objectif et identifions ensemble le meilleur accompagnement."

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import HomePage from './home.page';
+
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import HomePage from './home.page';
 
 const gsapAnimationsServiceMock: Pick<
   GsapAnimationsService,
@@ -46,7 +47,7 @@ describe('HomePage', () => {
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
     expect(heading?.textContent).toContain(
-      'D\u00E9veloppez vos comp\u00E9tences',
+      'D\u00e9veloppez vos comp\u00e9tences',
     );
   });
 
@@ -55,8 +56,8 @@ describe('HomePage', () => {
     fixture.detectChanges();
 
     const element = fixture.nativeElement as HTMLElement;
-    expect(element.textContent).toContain('R\u00E9server une consultation');
-    expect(element.textContent).toContain('D\u00E9couvrir nos services');
+    expect(element.textContent).toContain('R\u00e9server une consultation');
+    expect(element.textContent).toContain('D\u00e9couvrir nos services');
     expect(element.textContent).toContain('Recherche & Gestion de projets');
   });
 
@@ -78,26 +79,25 @@ describe('HomePage', () => {
 
     const content = fixture.nativeElement.textContent as string;
 
-    expect(content).toContain('Développement personnel et professionnel');
-    expect(content).toContain('Anglais et français professionnel');
+    expect(content).toContain('D\u00e9veloppement personnel et professionnel');
+    expect(content).toContain('Anglais et fran\u00e7ais professionnel');
     expect(content).toContain('Leadership et prise de parole');
-    expect(content).toContain('Préparation aux entretiens');
+    expect(content).toContain('Pr\u00e9paration aux entretiens');
     expect(content).toContain('Structuration de projets');
     expect(content).toContain("Accompagnement d'entreprises et startups");
-    expect(content).toContain('Conseils en mobilité internationale');
+    expect(content).toContain('Conseils en mobilit\u00e9 internationale');
     expect(content).toContain('Recrutement et placement en emploi');
   });
 
-  it('Given the home page When it renders Then it includes the home-specific FAQ section', () => {
+  it('Given the home page When it renders Then it does not duplicate the dedicated FAQ route content', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
 
-    const content = fixture.nativeElement.textContent as string;
+    const element = fixture.nativeElement as HTMLElement;
+    const faqAccordion = element.querySelector('kraak-faq-accordion');
 
-    expect(content).toContain('Questions fr\u00E9quentes');
-    expect(content).toContain(
-      'Je ne sais pas par o\u00F9 commencer, quelle est la premi\u00E8re \u00E9tape ?',
-    );
+    expect(faqAccordion).toBeNull();
+    expect(element.textContent).not.toContain('Questions fr\u00e9quentes');
   });
 
   it('Given the local web build When the home page renders Then the preview sections stay visible for review', () => {
@@ -107,7 +107,11 @@ describe('HomePage', () => {
     const content = fixture.nativeElement.textContent as string;
 
     expect(content).toContain('Partenaires et clients de confiance');
-    expect(content).toContain('Prévisualisation du format témoignages');
-    expect(content).toContain('Chiffres d’impact en prévisualisation');
+    expect(content).toContain(
+      'Pr\u00e9visualisation du format t\u00e9moignages',
+    );
+    expect(content).toContain(
+      'Chiffres d\u2019impact en pr\u00e9visualisation',
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -1,15 +1,11 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
 
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { HERO_BACKGROUND_STYLE } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
-import {
-  FaqAccordion,
-  type FaqItem,
-} from '../../shared/faq-accordion/faq-accordion.component';
-import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { HomePreviewSections } from '../../shared/home-preview-sections/home-preview-sections.component';
 
 @Component({
@@ -19,57 +15,22 @@ import { HomePreviewSections } from '../../shared/home-preview-sections/home-pre
     NgStyle,
     RouterLink,
     ButtonDirective,
-    FaqAccordion,
     CtaBanner,
     HomePreviewSections,
   ],
   templateUrl: './home.page.html',
-  styles: [
-    `
-      .kr-perf-section {
-        content-visibility: auto;
-        contain-intrinsic-size: 1px 900px;
-      }
-    `,
-  ],
 })
 export default class HomePage implements OnInit, OnDestroy {
   readonly heroBackgroundStyle = HERO_BACKGROUND_STYLE;
   protected readonly keySolutions: readonly string[] = [
-    'Développement personnel et professionnel',
-    'Anglais et français professionnel',
+    'D\u00e9veloppement personnel et professionnel',
+    'Anglais et fran\u00e7ais professionnel',
     'Leadership et prise de parole',
-    'Préparation aux entretiens',
+    'Pr\u00e9paration aux entretiens',
     'Structuration de projets',
     "Accompagnement d'entreprises et startups",
-    'Conseils en mobilité internationale',
+    'Conseils en mobilit\u00e9 internationale',
     'Recrutement et placement en emploi',
-  ];
-
-  protected readonly faqItems: FaqItem[] = [
-    {
-      question:
-        'Je ne sais pas par où commencer, quelle est la première étape ?',
-      answer:
-        "Commencez par une consultation d'orientation. Nous clarifions votre objectif, vos contraintes et les options réalistes pour définir un point de départ concret.",
-    },
-    {
-      question: 'Quels services KRAAK peuvent répondre à mon objectif ?',
-      answer:
-        'Nous partons de votre priorité du moment pour vous orienter vers le bon point d’entrée entre formation, recherche et gestion de projets, études et immigration, programmes KRAAK ou besoin entreprise.',
-    },
-    {
-      question:
-        'Proposez-vous des programmes pour les jeunes, les étudiants et les organisations ?',
-      answer:
-        'Oui. Nos programmes et accompagnements s’adressent aux étudiants, jeunes professionnels, entreprises, diaspora et organisations avec des formats courts, structurés et orientés résultats.',
-    },
-    {
-      question:
-        'En combien de temps puis-je recevoir une réponse après contact ?',
-      answer:
-        'Après votre message, nous revenons généralement vers vous sous 48h ouvrées avec une première orientation et les prochaines étapes recommandées.',
-    },
   ];
 
   private readonly gsapService = inject(GsapAnimationsService);

--- a/apps/client/projects/web/src/app/features/services/services.page.html
+++ b/apps/client/projects/web/src/app/features/services/services.page.html
@@ -388,12 +388,6 @@
   </div>
 </section>
 
-<section class="bg-neutral-50 pb-6 lg:pb-10">
-  <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <kraak-faq-accordion [items]="faqItems" />
-  </div>
-</section>
-
 <kraak-cta-banner
   heading="Choisissez le bon accompagnement pour votre objectif."
   body="Une consultation suffit souvent &agrave; clarifier la bonne prochaine &eacute;tape."

--- a/apps/client/projects/web/src/app/features/services/services.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+
 import ServicesPage from './services.page';
 
 describe('ServicesPage', () => {
@@ -10,49 +11,51 @@ describe('ServicesPage', () => {
     }).compileComponents();
   });
 
-  it('should create', () => {
+  it('Given the services page When the component is created Then the instance exists', () => {
     const fixture = TestBed.createComponent(ServicesPage);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render the heading', () => {
+  it('Given the services page When it renders Then the page heading is visible', () => {
     const fixture = TestBed.createComponent(ServicesPage);
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
     expect(heading?.textContent).toContain(
-      'Des solutions adapt\u00E9es pour former, structurer et d\u00E9velopper',
+      'Des solutions adapt\u00e9es pour former, structurer et d\u00e9velopper',
     );
   });
 
-  it('should render the four consulting service families', () => {
+  it('Given the services page When it renders Then the four consulting service families are visible', () => {
     const fixture = TestBed.createComponent(ServicesPage);
     fixture.detectChanges();
     const content = fixture.nativeElement.textContent as string;
 
-    expect(content).toContain('Des compétences solides pour ouvrir des portes');
     expect(content).toContain(
-      'Des idées bien structurées deviennent des projets durables',
+      'Des comp\u00e9tences solides pour ouvrir des portes',
     );
     expect(content).toContain(
-      'Votre projet international mérite une préparation claire et stratégique',
+      'Des id\u00e9es bien structur\u00e9es deviennent des projets durables',
     );
     expect(content).toContain(
-      'Des \u00E9quipes performantes construisent des organisations solides',
+      'Votre projet international m\u00e9rite une pr\u00e9paration claire et strat\u00e9gique',
     );
-    expect(content).toContain('Rédaction CV');
+    expect(content).toContain(
+      'Des \u00e9quipes performantes construisent des organisations solides',
+    );
+    expect(content).toContain('R\u00e9daction CV');
     expect(content).toContain('Identification et recrutement de talents');
-    expect(content).toContain("Politiques et stratégies d'immigration");
-    expect(content).toContain("Santé et culture d'entreprise");
+    expect(content).toContain("Politiques et strat\u00e9gies d'immigration");
+    expect(content).toContain("Sant\u00e9 et culture d'entreprise");
   });
 
-  it('should render service-specific FAQ section', () => {
+  it('Given the services page When it renders Then it does not duplicate the dedicated FAQ route content', () => {
     const fixture = TestBed.createComponent(ServicesPage);
     fixture.detectChanges();
-    const content = fixture.nativeElement.textContent as string;
 
-    expect(content).toContain('Questions fr\u00E9quentes');
-    expect(content).toContain(
-      'Comment choisir le service le plus adapt\u00E9 \u00E0 mon objectif ?',
-    );
+    const element = fixture.nativeElement as HTMLElement;
+    const faqAccordion = element.querySelector('kraak-faq-accordion');
+
+    expect(faqAccordion).toBeNull();
+    expect(element.textContent).not.toContain('Questions fr\u00e9quentes');
   });
 });

--- a/apps/client/projects/web/src/app/features/services/services.page.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.ts
@@ -1,47 +1,19 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { HERO_BACKGROUND_STYLE } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
-import {
-  FaqAccordion,
-  type FaqItem,
-} from '../../shared/faq-accordion/faq-accordion.component';
-import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 
 @Component({
   selector: 'kraak-services-page',
   standalone: true,
-  imports: [NgStyle, RouterLink, FaqAccordion, CtaBanner],
+  imports: [NgStyle, RouterLink, CtaBanner],
   templateUrl: './services.page.html',
 })
 export default class ServicesPage implements OnInit, OnDestroy {
   protected readonly heroBackgroundStyle = HERO_BACKGROUND_STYLE;
-
-  protected readonly faqItems: FaqItem[] = [
-    {
-      question: 'Comment choisir le service le plus adapté à mon objectif ?',
-      answer:
-        'Nous clarifions d’abord votre besoin, votre contexte et la prochaine décision à prendre. Ensuite, nous vous orientons vers le bon point d’entrée entre formation, projet, études et immigration, programmes ou solutions entreprises.',
-    },
-    {
-      question:
-        'Intervenez-vous pour les particuliers, les entreprises et la diaspora ?',
-      answer:
-        'Oui. KRAAK accompagne étudiants, professionnels, entrepreneurs, entreprises, diaspora et organisations avec des formats individuels, équipe ou sur mesure.',
-    },
-    {
-      question: 'Puis-je combiner plusieurs services dans un même parcours ?',
-      answer:
-        'Oui. Un parcours peut articuler formation, structuration de projet, orientation internationale et accompagnement entreprise si cela sert mieux votre objectif.',
-    },
-    {
-      question: 'Quel est le délai pour démarrer après une prise de contact ?',
-      answer:
-        'Après votre demande, nous revenons vers vous sous 48h ouvrées avec une première orientation et une proposition de prochaine étape.',
-    },
-  ];
 
   private readonly gsapService = inject(GsapAnimationsService);
 

--- a/apps/client/projects/web/src/app/features/support/faq.page.ts
+++ b/apps/client/projects/web/src/app/features/support/faq.page.ts
@@ -21,33 +21,33 @@ export default class FaqPage {
     {
       question: 'Comment choisir le bon accompagnement chez KRAAK ?',
       answer:
-        'Nous partons de votre objectif, de votre niveau de maturit� et de vos contraintes. Ensuite, nous vous orientons vers le service, le programme ou le format le plus pertinent.',
+        'Nous partons de votre objectif, de votre niveau de maturité et de vos contraintes. Ensuite, nous vous orientons vers le service, le programme ou le format le plus pertinent.',
     },
     {
-      question: 'Les accompagnements KRAAK sont-ils disponibles � distance ?',
+      question: 'Les accompagnements KRAAK sont-ils disponibles à distance ?',
       answer:
-        'Oui. Une grande partie de nos parcours peut �tre suivie � distance, avec un cadrage clair, des sessions planifi�es et un suivi adapt� � votre rythme.',
+        'Oui. Une grande partie de nos parcours peut être suivie à distance, avec un cadrage clair, des sessions planifiées et un suivi adapté à votre rythme.',
     },
     {
       question: 'Intervenez-vous uniquement pour les particuliers ?',
       answer:
-        'Non. Nous accompagnons aussi les �quipes, organisations, associations et entreprises sur des besoins de formation, structuration et mise en oeuvre de projets.',
+        'Non. Nous accompagnons aussi les équipes, organisations, associations et entreprises sur des besoins de formation, structuration et mise en oeuvre de projets.',
     },
     {
-      question: 'Sous quel d�lai recevez-vous une r�ponse apr�s contact ?',
+      question: 'Sous quel délai recevez-vous une réponse après contact ?',
       answer:
-        'Nous revenons en g�n�ral sous 48h ouvr�es avec une premi�re orientation et, si n�cessaire, une proposition de rendez-vous.',
+        'Nous revenons en général sous 48h ouvrées avec une première orientation et, si nécessaire, une proposition de rendez-vous.',
     },
     {
       question:
-        "Pouvez-vous aider sur un projet d'immigration ou de mobilit� internationale ?",
+        "Pouvez-vous aider sur un projet d'immigration ou de mobilité internationale ?",
       answer:
-        "Oui. Nous apportons un accompagnement de clarification, de pr�paration et d'orientation sur les �tapes cl�s selon votre profil et votre destination cible.",
+        "Oui. Nous apportons un accompagnement de clarification, de préparation et d'orientation sur les étapes clés selon votre profil et votre destination cible.",
     },
     {
-      question: 'Faut-il d�j� avoir un projet finalis� pour vous contacter ?',
+      question: 'Faut-il déjà avoir un projet finalisé pour vous contacter ?',
       answer:
-        "Non. Vous pouvez nous contacter d�s la phase d'id�e. Notre r�le est aussi de vous aider � structurer la prochaine �tape utile.",
+        "Non. Vous pouvez nous contacter dès la phase d'idée. Notre rôle est aussi de vous aider à structurer la prochaine étape utile.",
     },
   ];
 }

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.html
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.html
@@ -73,11 +73,11 @@
           [href]="social.href"
           target="_blank"
           rel="noopener noreferrer"
-          class="border-brand-blue/20 hover:border-brand-blue/35 text-secondary hover:text-primary bg-brand-white hover:bg-brand-cream/90 flex h-9.5 w-9.5 items-center justify-center rounded-full border p-2 shadow-sm transition-all hover:-translate-y-px"
+          class="border-brand-blue/20 hover:border-brand-blue/35 text-secondary hover:text-primary bg-brand-white hover:bg-brand-cream/90 flex h-12 w-12 items-center justify-center rounded-full border p-2.5 shadow-sm transition-all hover:-translate-y-px hover:scale-[1.03]"
           [attr.aria-label]="social.label"
           [attr.title]="social.label"
         >
-          <i [class]="'pi ' + social.icon + ' text-sm'"></i>
+          <i [class]="'pi ' + social.icon + ' text-xl'"></i>
         </a>
       }
     </nav>

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
@@ -19,14 +19,14 @@ describe('Footer', () => {
     }).compileComponents();
   });
 
-  it('Given the footer component, when Angular creates it, then the instance is available', () => {
+  it('Given the footer component When Angular creates it Then the instance is available', () => {
     const fixture = TestBed.createComponent(Footer);
     fixture.detectChanges();
 
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given the footer links, when the component renders, then it shows the brand and social navigation', () => {
+  it('Given the footer links When the component renders Then it shows the brand and social navigation', () => {
     const fixture = TestBed.createComponent(Footer);
     fixture.detectChanges();
 
@@ -44,15 +44,19 @@ describe('Footer', () => {
     const tiktokLink = element.querySelector(
       'a[aria-label="TikTok"]',
     ) as HTMLAnchorElement | null;
+    const facebookIcon = facebookLink?.querySelector('i');
     expect(brandImage?.getAttribute('src')).toContain('kraak-symbol.png');
     expect(footerLinks.length).toBeGreaterThan(0);
     expect(socialButtons.every(Boolean)).toBe(true);
     expect(facebookLink?.getAttribute('href')).toBe(expectedFacebookUrl);
     expect(tiktokLink?.getAttribute('href')).toBe(expectedTiktokUrl);
+    expect(facebookLink?.className).toContain('h-12');
+    expect(facebookLink?.className).toContain('w-12');
+    expect(facebookIcon?.className).toContain('text-xl');
     expect(element.textContent).toContain('FAQ');
   });
 
-  it('Given the footer navigation, when the component renders, then each public link is unique', () => {
+  it('Given the footer navigation When the component renders Then each public link is unique', () => {
     const fixture = TestBed.createComponent(Footer);
     fixture.detectChanges();
 

--- a/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.spec.ts
@@ -29,7 +29,7 @@ describe('FaqAccordion', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given une liste d items, When le composant est rendu, Then chaque question est présente', () => {
+  it('Given une liste d items, When le composant est rendu, Then chaque question est presente', () => {
     const fixture = TestBed.createComponent(FaqAccordion);
     fixture.componentRef.setInput('items', SAMPLE_ITEMS);
     fixture.detectChanges();
@@ -39,7 +39,7 @@ describe('FaqAccordion', () => {
     expect(text).toContain('Comment nous contacter ?');
   });
 
-  it('Given une liste d items, When le composant est rendu, Then chaque réponse est présente dans le DOM', () => {
+  it('Given une liste d items, When le composant est rendu, Then chaque reponse est presente dans le DOM', () => {
     const fixture = TestBed.createComponent(FaqAccordion);
     fixture.componentRef.setInput('items', SAMPLE_ITEMS);
     fixture.detectChanges();
@@ -48,5 +48,41 @@ describe('FaqAccordion', () => {
       'p-accordion-content p',
     );
     expect(answers.length).toBe(SAMPLE_ITEMS.length);
+  });
+
+  it('Given une liste d items, When une question est ouverte, Then la reponse devient visible', async () => {
+    const fixture = TestBed.createComponent(FaqAccordion);
+    fixture.componentRef.setInput('items', SAMPLE_ITEMS);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    const firstHeader = element.querySelector(
+      'p-accordion-header',
+    ) as HTMLElement | null;
+
+    expect(firstHeader).toBeTruthy();
+
+    firstHeader?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const firstContent = element.querySelector(
+      'p-accordion-content',
+    ) as HTMLElement | null;
+    const motionElement = element.querySelector(
+      'p-accordion-content p-motion',
+    ) as HTMLElement | null;
+    const answer = element.querySelector(
+      'p-accordion-content p',
+    ) as HTMLElement | null;
+
+    expect(firstHeader?.getAttribute('aria-expanded')).toBe('true');
+    expect(firstContent?.getAttribute('data-p-active')).toBe('true');
+    expect(window.getComputedStyle(motionElement as Element).visibility).toBe(
+      'visible',
+    );
+    expect(answer?.textContent).toContain(
+      'KRAAK est un cabinet de conseil en formation',
+    );
   });
 });

--- a/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.ts
+++ b/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.ts
@@ -19,6 +19,15 @@ export interface FaqItem {
   templateUrl: './faq-accordion.component.html',
   styles: [
     `
+      .kr-glass-faq .p-accordioncontent {
+        overflow: hidden;
+      }
+
+      .kr-glass-faq .p-accordioncontent[data-p-active='true'] .p-motion {
+        visibility: visible !important;
+        max-height: none !important;
+      }
+
       .kr-glass-faq .p-accordioncontent-content {
         background-color: transparent !important;
         padding-bottom: 0 !important;


### PR DESCRIPTION
﻿## Résumé

- retire les sections FAQ dupliquées des pages `home`, `services` et `contact` pour garder `/faq` comme point d'entrée unique
- corrige l'affichage des réponses dans l'accordéon FAQ et harmonise le contenu de la page FAQ
- agrandit les boutons sociaux et leurs icônes dans le footer et sur la page contact
- intègre les ajustements déjà présents sur le sitemap et le texte FAQ dans le même lot versionné

## Pourquoi

La FAQ existait sur plusieurs surfaces publiques alors qu'une route dédiée `/faq` existe déjà. Cette duplication diluait le parcours, compliquait la maintenance et réduisait la lisibilité. En parallèle, les boutons sociaux manquaient de présence visuelle et les réponses FAQ pouvaient rester masquées après ouverture.

## Impact

- une seule FAQ canonique pour le site vitrine
- de meilleurs repères visuels pour les réseaux sociaux sur les surfaces de conversion
- un comportement FAQ cohérent et visible côté utilisateur

## Validation

- `pnpm.cmd --filter @kraak/client exec ng test web --watch=false --include=projects/web/src/app/features/home/home.page.spec.ts --include=projects/web/src/app/features/services/services.page.spec.ts --include=projects/web/src/app/features/contact/contact.page.spec.ts --include=projects/web/src/app/layouts/footer/footer.component.spec.ts --include=projects/web/src/app/shared/faq-accordion/faq-accordion.component.spec.ts`
- `pnpm.cmd --filter @kraak/client exec ng test web --watch=false --include=projects/web/src/app/features/support/faq.page.spec.ts`
- `pnpm.cmd --filter @kraak/client exec ng lint web`
- `pnpm.cmd --filter @kraak/client exec ng build web`
- hooks de push complets: typecheck, lint, tests unitaires, tests API, Playwright E2E

Closes #429
