### PR TITLE
feat(web): add dedicated support error pages

### DIFF
--- a/apps/client/projects/web/src/app/app.routes.server.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.server.spec.ts
@@ -3,11 +3,34 @@ import { RenderMode } from '@angular/ssr';
 import { serverRoutes } from './app.routes.server';
 
 describe('Web server routes', () => {
+  it('Given the public support surface, When server routes are inspected, Then /401 is prerendered', () => {
+    const unauthorizedRoute = serverRoutes.find(
+      (route) => route.path === '401',
+    );
+
+    expect(unauthorizedRoute).toBeDefined();
+    expect(unauthorizedRoute?.renderMode).toBe(RenderMode.Prerender);
+  });
+
+  it('Given the public support surface, When server routes are inspected, Then /403 is prerendered', () => {
+    const forbiddenRoute = serverRoutes.find((route) => route.path === '403');
+
+    expect(forbiddenRoute).toBeDefined();
+    expect(forbiddenRoute?.renderMode).toBe(RenderMode.Prerender);
+  });
+
   it('Given the public support surface, When server routes are inspected, Then /404 is prerendered with the marketing pages', () => {
     const notFoundRoute = serverRoutes.find((route) => route.path === '404');
 
     expect(notFoundRoute).toBeDefined();
     expect(notFoundRoute?.renderMode).toBe(RenderMode.Prerender);
+  });
+
+  it('Given the public support surface, When server routes are inspected, Then /500 is prerendered', () => {
+    const serverErrorRoute = serverRoutes.find((route) => route.path === '500');
+
+    expect(serverErrorRoute).toBeDefined();
+    expect(serverErrorRoute?.renderMode).toBe(RenderMode.Prerender);
   });
 
   it('Given unknown routes, When server routes are inspected, Then dynamic fallback remains available', () => {

--- a/apps/client/projects/web/src/app/app.routes.server.ts
+++ b/apps/client/projects/web/src/app/app.routes.server.ts
@@ -2,7 +2,11 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 import { seoPages } from './seo/site-seo';
 
-const publicPrerenderPaths = [...seoPages.map((page) => page.path), '404'];
+const supportPrerenderPaths = ['401', '403', '404', '500'];
+const publicPrerenderPaths = [
+  ...seoPages.map((page) => page.path),
+  ...supportPrerenderPaths,
+];
 
 const publicPrerenderRoutes: ServerRoute[] = publicPrerenderPaths.map(
   (path) => ({

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -128,6 +128,44 @@ describe('Web routes', () => {
   });
 
   describe('Given the route table', () => {
+    it('When inspecting routes Then /401 serves the dedicated unauthorized page with SEO metadata', () => {
+      const builtRoutes = buildRoutes();
+      const unauthorizedRoute = builtRoutes.find(
+        (route) => route.path === '401',
+      );
+
+      expect(unauthorizedRoute).toBeDefined();
+      expect(unauthorizedRoute!.loadComponent).toBeDefined();
+      expect(unauthorizedRoute!.title).toBe(
+        'Authentification requise | KRAAK Consulting',
+      );
+      expect(unauthorizedRoute!.data?.['seo']).toBeDefined();
+    });
+
+    it('When inspecting routes Then /403 serves the dedicated forbidden page with SEO metadata', () => {
+      const builtRoutes = buildRoutes();
+      const forbiddenRoute = builtRoutes.find((route) => route.path === '403');
+
+      expect(forbiddenRoute).toBeDefined();
+      expect(forbiddenRoute!.loadComponent).toBeDefined();
+      expect(forbiddenRoute!.title).toBe('Accès refusé | KRAAK Consulting');
+      expect(forbiddenRoute!.data?.['seo']).toBeDefined();
+    });
+
+    it('When inspecting routes Then /500 serves the dedicated server-error page with SEO metadata', () => {
+      const builtRoutes = buildRoutes();
+      const serverErrorRoute = builtRoutes.find(
+        (route) => route.path === '500',
+      );
+
+      expect(serverErrorRoute).toBeDefined();
+      expect(serverErrorRoute!.loadComponent).toBeDefined();
+      expect(serverErrorRoute!.title).toBe(
+        'Incident technique | KRAAK Consulting',
+      );
+      expect(serverErrorRoute!.data?.['seo']).toBeDefined();
+    });
+
     it('When inspecting routes Then /404 serves the dedicated not-found page with SEO metadata', () => {
       const builtRoutes = buildRoutes();
       const notFoundRoute = builtRoutes.find((route) => route.path === '404');

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -1,11 +1,10 @@
 import { Route, Routes } from '@angular/router';
 
 import { findSeoPageByPath, type SeoPageDefinition } from './seo/site-seo';
-import {
-  participantAreaCanMatch,
-  participantAreaRoutes,
-} from './participant-area.routes';
+import { participantAreaRoutes } from './participant-area.routes';
 import { environment } from '../environments/environment';
+
+export { participantAreaCanMatch } from './participant-area.routes';
 
 export const buildMarketingRoute = (
   path: string,
@@ -73,7 +72,59 @@ const notFoundSeo: SeoPageDefinition = {
   },
 };
 
-export { participantAreaCanMatch };
+const unauthorizedSeo: SeoPageDefinition = {
+  path: '401',
+  title: 'Authentification requise | KRAAK Consulting',
+  description:
+    'Cette ressource nécessite une authentification. Connectez-vous pour poursuivre votre parcours KRAAK.',
+  openGraph: {
+    title: 'Authentification requise | KRAAK Consulting',
+    description:
+      'Cette ressource nécessite une authentification. Connectez-vous pour poursuivre votre parcours KRAAK.',
+    imagePath: '/open-graph/kraak-share-card.svg',
+    imageAlt: 'Carte de partage KRAAK Consulting.',
+  },
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
+
+const forbiddenSeo: SeoPageDefinition = {
+  path: '403',
+  title: 'Accès refusé | KRAAK Consulting',
+  description:
+    'Cette ressource est protégée. Contactez KRAAK si vous pensez disposer des droits nécessaires.',
+  openGraph: {
+    title: 'Accès refusé | KRAAK Consulting',
+    description:
+      'Cette ressource est protégée. Contactez KRAAK si vous pensez disposer des droits nécessaires.',
+    imagePath: '/open-graph/kraak-share-card.svg',
+    imageAlt: 'Carte de partage KRAAK Consulting.',
+  },
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
+
+const serverErrorSeo: SeoPageDefinition = {
+  path: '500',
+  title: 'Incident technique | KRAAK Consulting',
+  description:
+    'Une erreur technique est survenue. Réessayez dans un instant ou contactez KRAAK.',
+  openGraph: {
+    title: 'Incident technique | KRAAK Consulting',
+    description:
+      'Une erreur technique est survenue. Réessayez dans un instant ou contactez KRAAK.',
+    imagePath: '/open-graph/kraak-share-card.svg',
+    imageAlt: 'Carte de partage KRAAK Consulting.',
+  },
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
 
 interface BuildRoutesOptions {
   readonly includeParticipantArea?: boolean;
@@ -86,6 +137,24 @@ export function buildRoutes(options: BuildRoutesOptions = {}): Routes {
   return [
     ...marketingRoutes,
     ...(includeParticipantArea ? participantAreaRoutes : []),
+    {
+      path: '401',
+      title: unauthorizedSeo.title,
+      data: { seo: unauthorizedSeo },
+      loadComponent: () => import('./features/support/unauthorized.page'),
+    },
+    {
+      path: '403',
+      title: forbiddenSeo.title,
+      data: { seo: forbiddenSeo },
+      loadComponent: () => import('./features/support/forbidden.page'),
+    },
+    {
+      path: '500',
+      title: serverErrorSeo.title,
+      data: { seo: serverErrorSeo },
+      loadComponent: () => import('./features/support/server-error.page'),
+    },
     {
       path: '404',
       title: notFoundSeo.title,

--- a/apps/client/projects/web/src/app/features/support/forbidden.page.html
+++ b/apps/client/projects/web/src/app/features/support/forbidden.page.html
@@ -1,0 +1,53 @@
+<section
+  class="bg-brand-page relative isolate min-h-screen overflow-hidden px-4 py-12 sm:px-6 lg:px-8"
+>
+  <div aria-hidden="true" class="absolute inset-0">
+    <div
+      class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(76,195,217,0.2),transparent_28%),radial-gradient(circle_at_bottom_right,rgba(28,78,134,0.24),transparent_34%),linear-gradient(180deg,#f3f3f3_0%,#ffffff_100%)]"
+    ></div>
+  </div>
+
+  <div
+    class="relative z-10 mx-auto flex min-h-[calc(100vh-6rem)] max-w-4xl items-center justify-center"
+  >
+    <div
+      class="border-brand-blue/12 bg-brand-white/95 w-full rounded-3xl border px-6 py-10 text-center shadow-[0_24px_60px_rgb(18_43_74/14%)] backdrop-blur-sm sm:px-10 lg:px-14 lg:py-14"
+    >
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.2em] uppercase"
+      >
+        Acc&egrave;s refus&eacute;
+      </p>
+      <h1
+        class="text-brand-navy mt-5 text-5xl font-bold sm:text-6xl lg:text-7xl"
+      >
+        403
+      </h1>
+      <p class="text-brand-navy mx-auto mt-6 max-w-2xl text-lg leading-8">
+        Vous n'avez pas les droits n&eacute;cessaires pour consulter cette page.
+        Contactez notre &eacute;quipe si vous pensez qu'il s'agit d'une erreur.
+      </p>
+
+      <div class="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+        <a
+          pButton
+          routerLink="/"
+          label="Retour à l'accueil"
+          icon="pi pi-home"
+          size="large"
+          class="kr-button-primary"
+          aria-label="Retour à la page d'accueil"
+        ></a>
+        <a
+          pButton
+          routerLink="/contact"
+          label="Nous contacter"
+          icon="pi pi-envelope"
+          size="large"
+          class="kr-button-ghost"
+          aria-label="Contacter KRAAK"
+        ></a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/support/forbidden.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/support/forbidden.page.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import ForbiddenPage from './forbidden.page';
+
+describe('ForbiddenPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ForbiddenPage],
+      providers: [provideRouter([])],
+    }).compileComponents();
+  });
+
+  it('Given the forbidden page When the component is created Then it should instantiate', () => {
+    const fixture = TestBed.createComponent(ForbiddenPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the forbidden page When it renders Then it should show the access guidance', () => {
+    const fixture = TestBed.createComponent(ForbiddenPage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Accès refusé');
+    expect(content).toContain("Retour à l'accueil");
+    expect(content).toContain('Nous contacter');
+  });
+});

--- a/apps/client/projects/web/src/app/features/support/forbidden.page.ts
+++ b/apps/client/projects/web/src/app/features/support/forbidden.page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+@Component({
+  selector: 'kraak-forbidden-page',
+  standalone: true,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './forbidden.page.html',
+})
+export default class ForbiddenPage {}

--- a/apps/client/projects/web/src/app/features/support/server-error.page.html
+++ b/apps/client/projects/web/src/app/features/support/server-error.page.html
@@ -1,0 +1,53 @@
+<section
+  class="bg-brand-page relative isolate min-h-screen overflow-hidden px-4 py-12 sm:px-6 lg:px-8"
+>
+  <div aria-hidden="true" class="absolute inset-0">
+    <div
+      class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(76,195,217,0.2),transparent_28%),radial-gradient(circle_at_bottom_right,rgba(28,78,134,0.24),transparent_34%),linear-gradient(180deg,#f3f3f3_0%,#ffffff_100%)]"
+    ></div>
+  </div>
+
+  <div
+    class="relative z-10 mx-auto flex min-h-[calc(100vh-6rem)] max-w-4xl items-center justify-center"
+  >
+    <div
+      class="border-brand-blue/12 bg-brand-white/95 w-full rounded-3xl border px-6 py-10 text-center shadow-[0_24px_60px_rgb(18_43_74/14%)] backdrop-blur-sm sm:px-10 lg:px-14 lg:py-14"
+    >
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.2em] uppercase"
+      >
+        Incident technique
+      </p>
+      <h1
+        class="text-brand-navy mt-5 text-5xl font-bold sm:text-6xl lg:text-7xl"
+      >
+        500
+      </h1>
+      <p class="text-brand-navy mx-auto mt-6 max-w-2xl text-lg leading-8">
+        Une erreur interne emp&ecirc;che momentan&eacute;ment l'affichage de
+        cette page. Merci de r&eacute;essayer dans un instant.
+      </p>
+
+      <div class="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+        <a
+          pButton
+          routerLink="/"
+          label="Retour à l'accueil"
+          icon="pi pi-home"
+          size="large"
+          class="kr-button-primary"
+          aria-label="Retour à la page d'accueil"
+        ></a>
+        <a
+          pButton
+          routerLink="/contact"
+          label="Signaler un problème"
+          icon="pi pi-exclamation-triangle"
+          size="large"
+          class="kr-button-ghost"
+          aria-label="Signaler un problème à KRAAK"
+        ></a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/support/server-error.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/support/server-error.page.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import ServerErrorPage from './server-error.page';
+
+describe('ServerErrorPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ServerErrorPage],
+      providers: [provideRouter([])],
+    }).compileComponents();
+  });
+
+  it('Given the server-error page When the component is created Then it should instantiate', () => {
+    const fixture = TestBed.createComponent(ServerErrorPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the server-error page When it renders Then it should show the outage guidance', () => {
+    const fixture = TestBed.createComponent(ServerErrorPage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Incident technique');
+    expect(content).toContain("Retour à l'accueil");
+    expect(content).toContain('Signaler un problème');
+  });
+});

--- a/apps/client/projects/web/src/app/features/support/server-error.page.ts
+++ b/apps/client/projects/web/src/app/features/support/server-error.page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+@Component({
+  selector: 'kraak-server-error-page',
+  standalone: true,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './server-error.page.html',
+})
+export default class ServerErrorPage {}

--- a/apps/client/projects/web/src/app/features/support/unauthorized.page.html
+++ b/apps/client/projects/web/src/app/features/support/unauthorized.page.html
@@ -1,0 +1,53 @@
+<section
+  class="bg-brand-page relative isolate min-h-screen overflow-hidden px-4 py-12 sm:px-6 lg:px-8"
+>
+  <div aria-hidden="true" class="absolute inset-0">
+    <div
+      class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(76,195,217,0.2),transparent_28%),radial-gradient(circle_at_bottom_right,rgba(28,78,134,0.24),transparent_34%),linear-gradient(180deg,#f3f3f3_0%,#ffffff_100%)]"
+    ></div>
+  </div>
+
+  <div
+    class="relative z-10 mx-auto flex min-h-[calc(100vh-6rem)] max-w-4xl items-center justify-center"
+  >
+    <div
+      class="border-brand-blue/12 bg-brand-white/95 w-full rounded-3xl border px-6 py-10 text-center shadow-[0_24px_60px_rgb(18_43_74/14%)] backdrop-blur-sm sm:px-10 lg:px-14 lg:py-14"
+    >
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.2em] uppercase"
+      >
+        Authentification requise
+      </p>
+      <h1
+        class="text-brand-navy mt-5 text-5xl font-bold sm:text-6xl lg:text-7xl"
+      >
+        401
+      </h1>
+      <p class="text-brand-navy mx-auto mt-6 max-w-2xl text-lg leading-8">
+        Cette ressource est r&eacute;serv&eacute;e aux utilisateurs
+        connect&eacute;s. Connectez-vous pour continuer votre parcours.
+      </p>
+
+      <div class="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+        <a
+          pButton
+          routerLink="/connexion"
+          label="Se connecter"
+          icon="pi pi-sign-in"
+          size="large"
+          class="kr-button-primary"
+          aria-label="Accéder à la page de connexion"
+        ></a>
+        <a
+          pButton
+          routerLink="/contact"
+          label="Demander de l'aide"
+          icon="pi pi-envelope"
+          size="large"
+          class="kr-button-ghost"
+          aria-label="Contacter KRAAK"
+        ></a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/support/unauthorized.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/support/unauthorized.page.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import UnauthorizedPage from './unauthorized.page';
+
+describe('UnauthorizedPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UnauthorizedPage],
+      providers: [provideRouter([])],
+    }).compileComponents();
+  });
+
+  it('Given the unauthorized page When the component is created Then it should instantiate', () => {
+    const fixture = TestBed.createComponent(UnauthorizedPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the unauthorized page When it renders Then it should show the authentication guidance', () => {
+    const fixture = TestBed.createComponent(UnauthorizedPage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Authentification requise');
+    expect(content).toContain('Se connecter');
+    expect(content).toContain("Demander de l'aide");
+  });
+});

--- a/apps/client/projects/web/src/app/features/support/unauthorized.page.ts
+++ b/apps/client/projects/web/src/app/features/support/unauthorized.page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+@Component({
+  selector: 'kraak-unauthorized-page',
+  standalone: true,
+  imports: [RouterLink, ButtonDirective],
+  templateUrl: './unauthorized.page.html',
+})
+export default class UnauthorizedPage {}

--- a/apps/client/tests/e2e/accessibility-performance.spec.ts
+++ b/apps/client/tests/e2e/accessibility-performance.spec.ts
@@ -75,6 +75,41 @@ const parseImpactSummary = (
   return summary;
 };
 
+const isTransientNavigationError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /Execution context was destroyed|Target page, context or browser has been closed/i.test(
+    error.message,
+  );
+};
+
+const analyzeWithRetry = async (
+  page: Parameters<typeof AxeBuilder>[0]['page'],
+) => {
+  const maxAttempts = 2;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await new AxeBuilder({ page }).analyze();
+    } catch (error) {
+      if (!isTransientNavigationError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+
+      await page.waitForLoadState('load');
+      await page.waitForFunction(
+        () =>
+          document.readyState === 'interactive' ||
+          document.readyState === 'complete',
+      );
+    }
+  }
+
+  throw new Error('Axe analyze retry loop exhausted unexpectedly.');
+};
+
 test.describe.serial('Checks pré-pilot accessibilité/performance', () => {
   test('Given les pages MVP clés, When les checks sont exécutés, Then un rapport a11y/performance est produit', async ({
     page,
@@ -84,6 +119,11 @@ test.describe.serial('Checks pré-pilot accessibilité/performance', () => {
     for (const routeCheck of criticalRoutes) {
       await page.emulateMedia({ reducedMotion: 'reduce' });
       await page.goto(routeCheck.route, { waitUntil: 'load' });
+      await page.waitForFunction(
+        () =>
+          document.readyState === 'interactive' ||
+          document.readyState === 'complete',
+      );
 
       // Stabilise visual state before axe scan to avoid animation-driven contrast false positives.
       await page.addStyleTag({
@@ -91,7 +131,7 @@ test.describe.serial('Checks pré-pilot accessibilité/performance', () => {
           '*,:before,:after{animation:none !important;transition:none !important;scroll-behavior:auto !important;}.kr-perf-section,section,figure.reveal-on-scroll,h1,h2,main{opacity:1 !important;transform:none !important;filter:none !important;}',
       });
 
-      const axe = await new AxeBuilder({ page }).analyze();
+      const axe = await analyzeWithRetry(page);
       const axeSummary = parseImpactSummary(
         axe.violations.map((violation) => ({
           impact: violation.impact ?? null,

--- a/apps/client/tests/e2e/contact-form.spec.ts
+++ b/apps/client/tests/e2e/contact-form.spec.ts
@@ -51,6 +51,20 @@ test.describe(`Page contact — comportement formulaire`, () => {
 
     await page.goto('/contact');
 
+    // Evite qu'une soumission native SSR recharge la page avant l'hydratation Angular.
+    await page
+      .locator('form')
+      .first()
+      .evaluate((form) => {
+        form.addEventListener(
+          'submit',
+          (event) => {
+            event.preventDefault();
+          },
+          { capture: true },
+        );
+      });
+
     const nameField = page.getByRole('textbox', { name: 'Nom complet' });
     const emailField = page.getByRole('textbox', { name: 'Adresse e-mail' });
     const subjectField = page.getByRole('textbox', { name: 'Objectif' });
@@ -87,7 +101,14 @@ test.describe(`Page contact — comportement formulaire`, () => {
         { timeout: 500 },
       );
 
+      const submitRequest = page.waitForRequest(
+        (request) =>
+          request.method() === 'POST' && request.url().endsWith('/contact'),
+        { timeout: 10_000 },
+      );
+
       await page.getByRole('button', { name: 'Envoyer ma demande' }).click();
+      await submitRequest;
 
       await expect(
         page.getByText(


### PR DESCRIPTION
## Summary
- add dedicated support pages for 401, 403, 404 and 500 with standalone TS/HTML/spec architecture
- wire dedicated support routes with SEO metadata and prerender coverage on server routes
- harden flaky Playwright checks for contact-form success and accessibility-performance scan retries

## Validation
- targeted Playwright specs for contact-form and accessibility-performance pass locally
- pre-push hook suite executed during git push (typecheck, format:check, lint, tests)
