### PR TITLE
test(web): enforce vitrine freeze and server route invariants

### DIFF
--- a/apps/client/projects/web/src/app/app.routes.server.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.server.spec.ts
@@ -1,8 +1,25 @@
 import { RenderMode } from '@angular/ssr';
 
 import { serverRoutes } from './app.routes.server';
+import { seoPages } from './seo/site-seo';
 
 describe('Web server routes', () => {
+  const frozenPrerenderPaths = [
+    ...seoPages.map((page) => page.path),
+    '401',
+    '403',
+    '404',
+    '500',
+  ];
+
+  it('Given the frozen vitrine surface, When server routes are inspected, Then the prerender list exactly matches public pages and support status pages', () => {
+    const prerenderPaths = serverRoutes
+      .filter((route) => route.renderMode === RenderMode.Prerender)
+      .map((route) => route.path);
+
+    expect(prerenderPaths).toEqual(frozenPrerenderPaths);
+  });
+
   it('Given the public support surface, When server routes are inspected, Then /401 is prerendered', () => {
     const unauthorizedRoute = serverRoutes.find(
       (route) => route.path === '401',
@@ -38,5 +55,18 @@ describe('Web server routes', () => {
 
     expect(wildcardRoute).toBeDefined();
     expect(wildcardRoute?.renderMode).toBe(RenderMode.Server);
+  });
+
+  it('Given the server route table, When it is inspected, Then only the wildcard remains dynamic', () => {
+    const dynamicRoutes = serverRoutes.filter(
+      (route) => route.renderMode === RenderMode.Server,
+    );
+
+    expect(dynamicRoutes).toEqual([
+      {
+        path: '**',
+        renderMode: RenderMode.Server,
+      },
+    ]);
   });
 });

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -22,6 +22,14 @@ describe('Web routes', () => {
     'mentions-legales',
     'politique-de-confidentialite',
   ];
+  const frozenPublicPaths = [
+    ...marketingPaths,
+    '401',
+    '403',
+    '500',
+    '404',
+    '**',
+  ];
   const participantPaths = [
     'connexion',
     'inscription',
@@ -37,6 +45,13 @@ describe('Web routes', () => {
       for (const path of marketingPaths) {
         expect(paths).toContain(path);
       }
+    });
+
+    it('When building public routes without participant area Then the frozen public surface exactly matches ARC-14 and support status pages', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: false });
+      const paths = builtRoutes.map((route) => route.path ?? '');
+
+      expect(paths).toEqual(frozenPublicPaths);
     });
 
     it('When inspecting marketing routes Then every route exposes a title and SEO metadata', () => {
@@ -128,6 +143,15 @@ describe('Web routes', () => {
   });
 
   describe('Given the route table', () => {
+    it('When inspecting public routes Then auth routes stay outside the frozen vitrine surface', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: false });
+      const paths = builtRoutes.map((route) => route.path ?? '');
+
+      for (const path of participantPaths) {
+        expect(paths).not.toContain(path);
+      }
+    });
+
     it('When inspecting routes Then /401 serves the dedicated unauthorized page with SEO metadata', () => {
       const builtRoutes = buildRoutes();
       const unauthorizedRoute = builtRoutes.find(


### PR DESCRIPTION
## Summary
- enforce the frozen public vitrine route list in app routes specs
- enforce exact prerender invariants for public and support status routes
- keep wildcard server fallback as the only dynamic server route

## Validation
- pnpm ng test web --watch=false --include=projects/web/src/app/app.routes.spec.ts --include=projects/web/src/app/app.routes.server.spec.ts
- git push hooks completed successfully, including full e2e suite
