### PR TITLE
test(web): finalize vitrine analytics coverage and event mapping

### DIFF
--- a/apps/client/tests/e2e/analytics.spec.ts
+++ b/apps/client/tests/e2e/analytics.spec.ts
@@ -34,6 +34,8 @@ const PUBLIC_CTA_SURFACES = [
   },
 ] as const;
 
+const PUBLIC_CTA_MATRIX_TIMEOUT_MS = 90000;
+
 function isAnalyticsRequestUrl(url: string): boolean {
   return (
     url.includes('googletagmanager.com') || url.includes('google-analytics.com')
@@ -75,6 +77,8 @@ test.describe('Analytics — gating GA4', () => {
   test(`Given aucun identifiant GA4 configuré, When les pages publiques à CTA se chargent puis déclenchent leur CTA principal, Then aucun loader GA4 ni requête tierce n'est émis`, async ({
     page,
   }) => {
+    test.setTimeout(PUBLIC_CTA_MATRIX_TIMEOUT_MS);
+
     for (const surface of PUBLIC_CTA_SURFACES) {
       const capturedRequests: string[] = [];
       const captureRequest = (request: { url: () => string }) =>

--- a/apps/client/tests/e2e/analytics.spec.ts
+++ b/apps/client/tests/e2e/analytics.spec.ts
@@ -3,6 +3,43 @@ import { expect, test } from '@playwright/test';
 // Analytics E2E — vérification du gating GA4
 // Given/When/Then : sans identifiant GA4 configuré, aucun script GA n'est chargé.
 
+const PUBLIC_CTA_SURFACES = [
+  {
+    path: '/',
+    ctaLabel: 'Réserver une consultation',
+  },
+  {
+    path: '/a-propos',
+    ctaLabel: 'Nous contacter',
+  },
+  {
+    path: '/services',
+    ctaLabel: 'Réserver une consultation',
+  },
+  {
+    path: '/ressources',
+    ctaLabel: 'Demander une orientation',
+  },
+  {
+    path: '/programmes',
+    ctaLabel: 'Demander une orientation',
+  },
+  {
+    path: '/mentions-legales',
+    ctaLabel: 'Nous contacter',
+  },
+  {
+    path: '/politique-de-confidentialite',
+    ctaLabel: 'Nous contacter',
+  },
+] as const;
+
+function isAnalyticsRequestUrl(url: string): boolean {
+  return (
+    url.includes('googletagmanager.com') || url.includes('google-analytics.com')
+  );
+}
+
 test.describe('Analytics — gating GA4', () => {
   test(`Given aucun identifiant GA4 configuré, When la page d'accueil se charge, Then aucun loader gtag.js n'est injecté`, async ({
     page,
@@ -33,5 +70,46 @@ test.describe('Analytics — gating GA4', () => {
     await expect(page.getByRole('banner')).toBeVisible();
 
     expect(gtagRequests).toEqual([]);
+  });
+
+  test(`Given aucun identifiant GA4 configuré, When les pages publiques à CTA se chargent puis déclenchent leur CTA principal, Then aucun loader GA4 ni requête tierce n'est émis`, async ({
+    page,
+  }) => {
+    for (const surface of PUBLIC_CTA_SURFACES) {
+      const capturedRequests: string[] = [];
+      const captureRequest = (request: { url: () => string }) =>
+        capturedRequests.push(...[request.url()].filter(isAnalyticsRequestUrl));
+
+      page.on('request', captureRequest);
+
+      try {
+        await page.goto(surface.path, { waitUntil: 'domcontentloaded' });
+
+        await expect(
+          page.locator('script[data-kraak-analytics="loader"]'),
+        ).toHaveCount(0);
+
+        const ctaBanner = page.locator('kraak-cta-banner');
+        await expect(ctaBanner).toBeVisible();
+
+        const ctaLink = ctaBanner.getByRole('link', {
+          name: surface.ctaLabel,
+        });
+        await expect(ctaLink).toBeVisible();
+
+        await Promise.all([
+          page.waitForURL('**/contact', {
+            timeout: 10000,
+            waitUntil: 'domcontentloaded',
+          }),
+          ctaLink.click(),
+        ]);
+
+        await expect(page).toHaveTitle(/Contact/i);
+        expect(capturedRequests).toEqual([]);
+      } finally {
+        page.off('request', captureRequest);
+      }
+    }
   });
 });

--- a/docs/runbooks/ANALYTICS_EVENTS.md
+++ b/docs/runbooks/ANALYTICS_EVENTS.md
@@ -25,6 +25,15 @@ dossier.
 - `footer_social` : réseaux sociaux du pied de page.
 - `legal_mentions`, `privacy_controller`, `privacy_rights` : pages légales et
   confidentialité.
+- Les CTA de conversion `conversion_cta_click` sont suivis sur les surfaces
+  publiques suivantes via `kraak-cta-banner` :
+  - `/` (`home_main_cta`)
+  - `/a-propos` (`about_main_cta`)
+  - `/services` (`services_main_cta`)
+  - `/ressources` (`resources_main_cta`)
+  - `/programmes` (`programs_main_cta`)
+  - `/mentions-legales` (`legal_mentions_cta`)
+  - `/politique-de-confidentialite` (`legal_privacy_cta`)
 
 ## Règles de maintenance
 


### PR DESCRIPTION
- **test(web): extend analytics e2e coverage for public cta paths**
- **docs(docs): align analytics events runbook with implemented public ctas**
- **fix(web): stabilize analytics cta e2e timeout on firefox**

# Pull Request

## Resume

## Pourquoi

## Type de changement

- [ ] bug
- [ ] amelioration
- [ ] contenu
- [ ] design
- [ ] maintenance

## Checklist

- [ ] Tache liée a une issue
- [ ] Portée MVP respectée
- [ ] Tests RED -> GREEN -> REFACTOR appliques (si code)
- [ ] Evidence de validation ajoutée (tests/captures)
- [ ] Documentation mise a jour si nécessaire
- [ ] Aucun secret/variable sensible commit

## Validation

- [ ] Tests unitaires
- [ ] Tests integration
- [ ] Tests E2E/smoke
- [ ] Verification manuelle

## Captures / preuves
