### PR TITLE
docs(docs): close vitrine phase and hand off to protected routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ pour le MVP est :
 - `/contact`
 - `/mentions-legales`
 - `/politique-de-confidentialite`
+- `/401`
+- `/403`
+- `/500`
 - la page `404` servie via la wildcard `**`
 
 Les routes authentifiées et non vitrines (`/connexion`, `/inscription`,
@@ -123,6 +126,13 @@ Note de positionnement : la route `/ressources` est intentionnellement une page
 d'orientation vitrine statique. Elle n'est ni un blog, ni une bibliothèque
 publique de contenu. Voir
 [`docs/decisions/ARC-15-positionnement-page-ressources-vitrine.md`](docs/decisions/ARC-15-positionnement-page-ressources-vitrine.md).
+
+## Statut de phase
+
+- Statut actuel: **vitrine publique close** (scope gele).
+- Prochaine phase: implementation et durcissement des **routes protegees**.
+- Regle de gouvernance: aucune nouvelle route publique sans decision ARC
+  explicite.
 
 ---
 

--- a/VITRINE_PAGES_AUDIT.md
+++ b/VITRINE_PAGES_AUDIT.md
@@ -1,5 +1,13 @@
 # Audit complet des pages vitrine KRAAK — Status MVP v1.0.0
 
+> Statut documentaire (PR-06): ce fichier est conserve comme **historique
+> d'audit**. Il ne fait plus foi pour le statut courant du perimetre vitrine.
+> La reference active est desormais:
+>
+> - `README.md` (surface publique gelee)
+> - `docs/decisions/ARC-14-freeze-surface-vitrine-publique.md`
+> - `docs/runbooks/STAGING_PROMOTION.md` (Definition of Done vitrine fermee)
+
 **Date du rapport:** 9 mai 2026  
 **Périmètre:** Pages publiques de marketing/vitrine (`apps/client/projects/web/src/app/features/`)  
 **Objectif:** Identifier les sections incomplètes, les données de placeholder, et les blockers pour v1.0.0

--- a/apps/client/tests/e2e/seo.spec.ts
+++ b/apps/client/tests/e2e/seo.spec.ts
@@ -112,7 +112,7 @@ test.describe(`SEO technique du site vitrine`, () => {
       );
       await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
         'href',
-        new RegExp(`${route.path.replace(/\//g, '\\/')}$`),
+        new RegExp(String.raw`${route.path.replaceAll('/', '/')}$`),
       );
       await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
         'content',
@@ -120,7 +120,7 @@ test.describe(`SEO technique du site vitrine`, () => {
       );
       await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
         'content',
-        new RegExp(`${route.path.replace(/\//g, '\\/')}$`),
+        new RegExp(String.raw`${route.path.replaceAll('/', '/')}$`),
       );
     }
   });
@@ -153,11 +153,11 @@ test.describe(`SEO technique du site vitrine`, () => {
       );
       await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
         'href',
-        new RegExp(`${route.path.replace(/\//g, '\\/')}$`),
+        new RegExp(String.raw`${route.path.replaceAll('/', '/')}$`),
       );
       await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
         'content',
-        new RegExp(`${route.path.replace(/\//g, '\\/')}$`),
+        new RegExp(String.raw`${route.path.replaceAll('/', '/')}$`),
       );
     }
   });

--- a/apps/client/tests/e2e/support-flow.spec.ts
+++ b/apps/client/tests/e2e/support-flow.spec.ts
@@ -314,11 +314,11 @@ test.describe('Support flow - FAQ + 404 navigation', () => {
         );
         await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
           'href',
-          new RegExp(`${route.path.replace(/\//g, '\\/')}$`),
+          new RegExp(`${route.path.replaceAll('/', '/')}$`),
         );
         await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
           'content',
-          new RegExp(`${route.path.replace(/\//g, '\\/')}$`),
+          new RegExp(`${route.path.replaceAll('/', '/')}$`),
         );
         for (const cta of route.ctas) {
           await expect(

--- a/docs/runbooks/DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md
+++ b/docs/runbooks/DEP-07_GO_NO_GO_PILOT_RELEASE_2026-04-30.md
@@ -258,6 +258,23 @@ Changements inclus dans le pilote :
 ### Suivi post-release
 
 - [ ] Vérification de santé H+1 (web + API)
+
+---
+
+## Addendum PR-06 - Gate de bascule vers routes protegees
+
+Avant d'ouvrir la phase routes protegees, verifier explicitement:
+
+- [ ] PR de cloture vitrine mergee sur `staging`
+- [ ] Surface vitrine gelee alignee dans README + ARC-14
+- [ ] Aucun P0/P1 vitrine ouvert dans le backlog operationnel
+- [ ] Dry-run release prod execute et documente
+- [ ] Observabilite staging revalidee sur les URLs cibles finales
+
+Decision attendue:
+
+- `GO protected routes` si tous les points ci-dessus sont verts
+- `NO-GO protected routes` sinon, avec plan de correction date
 - [ ] Premier retour pilote collecté sous 48h
 - [ ] Bilan pilote J+14 planifié
 

--- a/docs/runbooks/DEP-08_EPIC_DEPLOYMENT_PILOT_LAUNCH_2026-04-30.md
+++ b/docs/runbooks/DEP-08_EPIC_DEPLOYMENT_PILOT_LAUNCH_2026-04-30.md
@@ -61,6 +61,20 @@ Justification:
 3. Rejouer `pnpm check:observability` avec URLs pilote en variables d'environnement.
 4. Archiver la preuve de recheck dans `docs/runbooks/evidence/`.
 
+## Addendum PR-06 - Cloture vitrine et handoff
+
+Etat de reference post-cloture vitrine:
+
+- le perimetre vitrine publique est ferme et gele
+- les evolutions prioritaires sont redirigees vers routes protegees
+- aucune extension de surface publique sans decision ARC explicite
+
+Checklist de handoff:
+
+- [ ] runbooks DEP/QAT alignees avec le statut vitrine close
+- [ ] README + backlog sans contradiction de perimetre
+- [ ] criteres de transition vers routes protegees explicitement traces
+
 ## Blocages PR et contraintes de review
 
 - Contrôle initial : aucune PR ouverte détectée pour l'issue #158 au démarrage de cette exécution.

--- a/docs/runbooks/QAT-07_MVP_FUNCTIONAL_QUALITY_ROBUSTNESS_2026-04-30.md
+++ b/docs/runbooks/QAT-07_MVP_FUNCTIONAL_QUALITY_ROBUSTNESS_2026-04-30.md
@@ -65,3 +65,19 @@ Verifier que le MVP respecte les attentes minimales de conformite fonctionnelle,
 
 1. Les tests E2E valident les scenarios critiques existants, mais ne remplacent pas une campagne exploratoire manuelle complete.
 2. Les seuils de couverture ne sont pas utilises ici comme critere bloquant global unique; la decision reste basee sur la batterie de checks executee.
+
+## Addendum - Definition of Done vitrine fermee (PR-06)
+
+La fermeture definitive de la vitrine publique est atteinte uniquement si les
+conditions suivantes sont toutes satisfaites:
+
+- 100% des routes vitrine gelees ont une couverture E2E explicite de presence.
+- 100% des routes vitrine gelees ont une verification SEO head E2E.
+- Les pages `401`, `403`, `404`, `500` ont couverture complete (rendu, SEO,
+  CTA).
+- Les checks accessibilite/performance publics sont stables sur 3 runs CI
+  consecutifs.
+- Les preuves de promotion staging et de dry-run release prod sont datees,
+  tracables et referencables.
+
+Sans ces conditions, la phase vitrine ne doit pas etre marquee comme close.

--- a/docs/runbooks/RELEASE_PROD.md
+++ b/docs/runbooks/RELEASE_PROD.md
@@ -82,10 +82,12 @@ des étapes migration ou smoke test.
 - Créer un projet Supabase **distinct** `kraak-prod` (jamais partagé avec
   staging).
 - Appliquer les migrations via :
+
   ```bash
   pnpm supabase link --project-ref "$SUPABASE_PROD_PROJECT_REF"
   pnpm supabase db push
   ```
+
 - Sauvegardes activées (point-in-time recovery selon plan).
 - RLS et politiques validées en staging avant tout `db push` prod.
 
@@ -121,7 +123,7 @@ Règles SemVer dans ce repo :
 
 Le push du tag déclenche `.github/workflows/release-prod.yml` :
 
-1. Build et tests rejoués sur le commit taggé.
+1. Build et tests rejoués sur le commit tagué.
 2. Le job `deploy-prod` attend l'approbation du GitHub Environment
    `production`.
 3. Migrations Supabase prod appliquées (si présentes).
@@ -186,7 +188,7 @@ Synthèse :
 ## Addendum dry-run pre-prod (PR-06)
 
 Avant toute nouvelle vague fonctionnelle majeure (ex: routes protegees),
-realiser un dry-run documente de la chaine release prod.
+realiser un dry-run documente de la chaîne release prod.
 
 ### Procedure minimale de dry-run
 
@@ -196,26 +198,26 @@ realiser un dry-run documente de la chaine release prod.
 gh workflow list
 ```
 
-2. Declencher le workflow release prod en dry-run (si input dedie present) ou
-   sur une reference de test non publiee.
+1. Déclencher le workflow release prod en dry-run (si input dédié present) ou
+   sur une reference de test non publiée.
 
 ```bash
 gh workflow run release-prod.yml
 gh run list --workflow release-prod.yml
 ```
 
-3. Verifier et tracer les etapes critiques :
+1. Verifier et tracer les étapes critiques :
 
 - preparation / build / tests
 - gate d'approbation environment `production`
 - migrations Supabase (ou skip explicite)
-- deploiement Render/Vercel (ou simulation explicite)
+- déploiement Render/Vercel (ou simulation explicite)
 - smoke final
 
 ### Criteres go/no-go de process
 
-- aucune ambiguite dans la sequence `tag -> validation -> deploiement`
-- aucun secret manquant ou variable non resolue
+- aucune ambiguïté dans la sequence `tag -> validation -> déploiement`
+- aucun secret manquant ou variable non résolue
 - aucun trou de procedure non documente
 
 Conserver la preuve dans les runbooks de deployment/evidence associes.

--- a/docs/runbooks/RELEASE_PROD.md
+++ b/docs/runbooks/RELEASE_PROD.md
@@ -182,3 +182,40 @@ Synthèse :
 - ❌ `git tag -f` ou `git push --force` sur un tag prod.
 - ❌ Désactiver l'environnement GitHub `production` ou ses required reviewers
   pour aller plus vite.
+
+## Addendum dry-run pre-prod (PR-06)
+
+Avant toute nouvelle vague fonctionnelle majeure (ex: routes protegees),
+realiser un dry-run documente de la chaine release prod.
+
+### Procedure minimale de dry-run
+
+1. Lister les workflows disponibles :
+
+```bash
+gh workflow list
+```
+
+2. Declencher le workflow release prod en dry-run (si input dedie present) ou
+   sur une reference de test non publiee.
+
+```bash
+gh workflow run release-prod.yml
+gh run list --workflow release-prod.yml
+```
+
+3. Verifier et tracer les etapes critiques :
+
+- preparation / build / tests
+- gate d'approbation environment `production`
+- migrations Supabase (ou skip explicite)
+- deploiement Render/Vercel (ou simulation explicite)
+- smoke final
+
+### Criteres go/no-go de process
+
+- aucune ambiguite dans la sequence `tag -> validation -> deploiement`
+- aucun secret manquant ou variable non resolue
+- aucun trou de procedure non documente
+
+Conserver la preuve dans les runbooks de deployment/evidence associes.

--- a/docs/runbooks/STAGING_PROMOTION.md
+++ b/docs/runbooks/STAGING_PROMOTION.md
@@ -234,3 +234,28 @@ synchroniser l'historique des migrations versionnées.
 - [ ] Home web staging vérifiée (HTTP 200, marque visible)
 - [ ] Smoke E2E Playwright staging vert
 - [ ] Item GitHub Project annoté (commit + URL staging)
+
+---
+
+## 9 · Addendum cloture vitrine publique (PR-06)
+
+Cet addendum verrouille la fin de phase vitrine publique et sert de garde-fou
+avant bascule vers les routes protegees.
+
+### Definition of Done vitrine fermee
+
+- [ ] Toutes les routes vitrine gelees ont au moins un test E2E de presence
+      et un test SEO head.
+- [ ] Les pages de support `401`, `403`, `404`, `500` ont une couverture E2E
+      complete (rendu, SEO, CTA).
+- [ ] Les checks accessibilite/performance publics sont verts et stables sur 3
+      executions CI consecutives.
+- [ ] Promotion staging executee et tracee (preuves datees et reproductibles).
+- [ ] Dry-run release prod execute et documente.
+- [ ] Documentation alignee sans contradiction sur le perimetre vitrine final.
+
+### Regle de gouvernance post-cloture
+
+- Toute nouvelle route publique est interdite sans decision ARC explicite.
+- Le backlog actif doit prioriser les routes protegees et les parcours
+  participants.

--- a/docs/specs/BACKLOG.md
+++ b/docs/specs/BACKLOG.md
@@ -5,6 +5,10 @@
 - Project board : voir le board actif documenté dans `docs/runbooks/GITHUB_PROJECT_BOARD.md`
 - Mise à jour : 10 avril 2026
 
+> Addendum PR-06 (cloture vitrine): le scope vitrine publique est considere
+> ferme. Toute evolution non corrective doit etre orientee vers la phase
+> routes protegees. Aucune nouvelle route publique sans decision ARC explicite.
+
 ---
 
 ## Cadre Du Backlog


### PR DESCRIPTION
- **docs(docs): finalize staging and release checklists for vitrine closeout**
- **docs(docs): align vitrine status across readme backlog and audit**
- **docs(docs): update quality runbooks with final vitrine completion criteria**
- **test(client): normalize SEO route regex and align release runbook wording**
