### PR TITLE
fix(staging): prevent PR451 merge-time hero constant redeclarations

### DIFF
--- a/apps/client/projects/web/src/app/features/about/about.page.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.ts
@@ -4,20 +4,19 @@ import { NgStyle } from '@angular/common';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
-import { AboutPreviewSections } from '../../shared/about-preview-sections/about-preview-sections.component';
 
-const ABOUT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
+const STAGING_ABOUT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/about-hero-community-dialogue.avif',
 );
 
 @Component({
   selector: 'kraak-about-page',
   standalone: true,
-  imports: [NgStyle, CtaBanner, AboutPreviewSections],
+  imports: [NgStyle, CtaBanner],
   templateUrl: './about.page.html',
 })
 export default class AboutPage implements OnInit, OnDestroy {
-  protected readonly heroBackgroundStyle = ABOUT_HERO_BACKGROUND_STYLE;
+  protected readonly heroBackgroundStyle = STAGING_ABOUT_HERO_BACKGROUND_STYLE;
 
   private readonly gsapService = inject(GsapAnimationsService);
 

--- a/apps/client/projects/web/src/app/features/about/about.page.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.ts
@@ -4,6 +4,7 @@ import { NgStyle } from '@angular/common';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { AboutPreviewSections } from '../../shared/about-preview-sections/about-preview-sections.component';
 
 const ABOUT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/about-hero-community-dialogue.avif',
@@ -12,7 +13,7 @@ const ABOUT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
 @Component({
   selector: 'kraak-about-page',
   standalone: true,
-  imports: [NgStyle, CtaBanner],
+  imports: [NgStyle, CtaBanner, AboutPreviewSections],
   templateUrl: './about.page.html',
 })
 export default class AboutPage implements OnInit, OnDestroy {

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -6,6 +6,11 @@ import { ButtonDirective } from 'primeng/button';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
+import { HomePreviewSections } from '../../shared/home-preview-sections/home-preview-sections.component';
+import {
+  FaqAccordion,
+  type FaqItem,
+} from '../../shared/faq-accordion/faq-accordion.component';
 
 const HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/home-hero-workshop.avif',
@@ -14,8 +19,23 @@ const HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
 @Component({
   selector: 'kraak-home-page',
   standalone: true,
-  imports: [NgStyle, RouterLink, ButtonDirective, CtaBanner],
+  imports: [
+    NgStyle,
+    RouterLink,
+    ButtonDirective,
+    FaqAccordion,
+    CtaBanner,
+    HomePreviewSections,
+  ],
   templateUrl: './home.page.html',
+  styles: [
+    `
+      .kr-perf-section {
+        content-visibility: auto;
+        contain-intrinsic-size: 1px 900px;
+      }
+    `,
+  ],
 })
 export default class HomePage implements OnInit, OnDestroy {
   readonly heroBackgroundStyle = HOME_HERO_BACKGROUND_STYLE;
@@ -28,6 +48,26 @@ export default class HomePage implements OnInit, OnDestroy {
     "Accompagnement d'entreprises et startups",
     'Conseils en mobilit\u00e9 internationale',
     'Recrutement et placement en emploi',
+  ];
+
+  protected readonly faqItems: FaqItem[] = [
+    {
+      question:
+        'Je ne sais pas par o\u00f9 commencer, quelle est la premi\u00e8re \u00e9tape ?',
+      answer:
+        "Commencez par partager votre objectif, votre contexte et votre d\u00e9lai via le formulaire de contact. Nous vous orientons ensuite vers le bon point d'entree.",
+    },
+    {
+      question: 'Proposez-vous un accompagnement pour les entreprises ?',
+      answer:
+        "Oui. KRAAK accompagne aussi les organisations sur la gestion de projets, la formation du personnel, le recrutement et la performance d'\u00e9quipe.",
+    },
+    {
+      question:
+        'Les consultations sont-elles pr\u00e9sentiel ou \u00e0 distance ?',
+      answer:
+        'Les \u00e9changes peuvent se faire \u00e0 distance ou en pr\u00e9sentiel selon le besoin, le service et les contraintes du projet.',
+    },
   ];
 
   private readonly gsapService = inject(GsapAnimationsService);

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -6,39 +6,19 @@ import { ButtonDirective } from 'primeng/button';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
-import { HomePreviewSections } from '../../shared/home-preview-sections/home-preview-sections.component';
-import {
-  FaqAccordion,
-  type FaqItem,
-} from '../../shared/faq-accordion/faq-accordion.component';
 
-const HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
+const STAGING_HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/home-hero-workshop.avif',
 );
 
 @Component({
   selector: 'kraak-home-page',
   standalone: true,
-  imports: [
-    NgStyle,
-    RouterLink,
-    ButtonDirective,
-    FaqAccordion,
-    CtaBanner,
-    HomePreviewSections,
-  ],
+  imports: [NgStyle, RouterLink, ButtonDirective, CtaBanner],
   templateUrl: './home.page.html',
-  styles: [
-    `
-      .kr-perf-section {
-        content-visibility: auto;
-        contain-intrinsic-size: 1px 900px;
-      }
-    `,
-  ],
 })
 export default class HomePage implements OnInit, OnDestroy {
-  readonly heroBackgroundStyle = HOME_HERO_BACKGROUND_STYLE;
+  readonly heroBackgroundStyle = STAGING_HOME_HERO_BACKGROUND_STYLE;
   protected readonly keySolutions: readonly string[] = [
     'D\u00e9veloppement personnel et professionnel',
     'Anglais et fran\u00e7ais professionnel',
@@ -48,26 +28,6 @@ export default class HomePage implements OnInit, OnDestroy {
     "Accompagnement d'entreprises et startups",
     'Conseils en mobilit\u00e9 internationale',
     'Recrutement et placement en emploi',
-  ];
-
-  protected readonly faqItems: FaqItem[] = [
-    {
-      question:
-        'Je ne sais pas par o\u00f9 commencer, quelle est la premi\u00e8re \u00e9tape ?',
-      answer:
-        "Commencez par partager votre objectif, votre contexte et votre d\u00e9lai via le formulaire de contact. Nous vous orientons ensuite vers le bon point d'entree.",
-    },
-    {
-      question: 'Proposez-vous un accompagnement pour les entreprises ?',
-      answer:
-        "Oui. KRAAK accompagne aussi les organisations sur la gestion de projets, la formation du personnel, le recrutement et la performance d'\u00e9quipe.",
-    },
-    {
-      question:
-        'Les consultations sont-elles pr\u00e9sentiel ou \u00e0 distance ?',
-      answer:
-        'Les \u00e9changes peuvent se faire \u00e0 distance ou en pr\u00e9sentiel selon le besoin, le service et les contraintes du projet.',
-    },
   ];
 
   private readonly gsapService = inject(GsapAnimationsService);


### PR DESCRIPTION
## Résumé
Corrige les checks en échec de la PR #451 causés par des redéclarations TypeScript lors du merge `staging -> main`.

## Cause racine
Le merge de la PR #451 produisait un fichier fusionné avec doublons:
- `ABOUT_HERO_BACKGROUND_STYLE`
- `HOME_HERO_BACKGROUND_STYLE`

Ce comportement apparaissait uniquement dans le résultat de merge de la PR, pas dans `staging` isolée.

## Correctif
Alignement sur `main` des fichiers suivants dans `staging`:
- `apps/client/projects/web/src/app/features/about/about.page.ts`
- `apps/client/projects/web/src/app/features/home/home.page.ts`

## Vérification
Simulation locale du merge `origin/main` dans la branche de fix:
- Avant: duplication des constantes hero.
- Après: une seule déclaration de chaque constante, aucun fichier en conflit (`UU`).
