### PR TITLE
fix(tests): harmonize global object usage and clean observability merge artifacts

### DIFF
--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -30,16 +30,10 @@ jobs:
             api_url: https://kraak-api-prod.onrender.com
             alert_issue_title: "[ALERT][DEP-05][production] Observability check failure"
     env:
-<<<<<<< HEAD
       KRAAK_OBSERVABILITY_ENVIRONMENT: ${{ matrix.environment }}
       KRAAK_OBSERVABILITY_WEB_URL: ${{ matrix.web_url }}
       KRAAK_OBSERVABILITY_API_URL: ${{ matrix.api_url }}
       ALERT_ISSUE_TITLE: ${{ matrix.alert_issue_title }}
-=======
-      KRAAK_OBSERVABILITY_WEB_URL: https://kraak-consulting.vercel.app
-      KRAAK_OBSERVABILITY_API_URL: https://kraak-api-staging.onrender.com
-      ALERT_ISSUE_TITLE: '[ALERT][DEP-05] Observability check failure'
->>>>>>> 2226091 (fix(ci): point observability web URL to production Vercel URL)
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 

--- a/apps/client/projects/web/src/app/core/animations/gsap-animations.service.spec.ts
+++ b/apps/client/projects/web/src/app/core/animations/gsap-animations.service.spec.ts
@@ -23,7 +23,7 @@ describe('GsapAnimationsService', () => {
 
   describe('initializeFigureAnimations', () => {
     it('Given reduced motion is enabled, When figure animations initialize, Then no transform is applied', () => {
-      vi.spyOn(window, 'matchMedia').mockReturnValue({
+      vi.spyOn(globalThis, 'matchMedia').mockReturnValue({
         matches: true,
         media: '(prefers-reduced-motion: reduce)',
         onchange: null,
@@ -32,7 +32,7 @@ describe('GsapAnimationsService', () => {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(),
-      } as MediaQueryList);
+      });
 
       const div = document.createElement('div');
       const figure = document.createElement('figure');

--- a/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.spec.ts
+++ b/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.spec.ts
@@ -49,7 +49,7 @@ describe('ScrollToTop', () => {
 
   describe('Scroll to top functionality', () => {
     it('should scroll to top when button is clicked', () => {
-      const scrollToSpy = vi.spyOn(window, 'scrollTo');
+      const scrollToSpy = vi.spyOn(globalThis, 'scrollTo');
 
       component.scrollToTop();
 
@@ -66,7 +66,7 @@ describe('ScrollToTop', () => {
       const updateVisibilitySpy = vi.spyOn(component, 'updateVisibility');
 
       // Simulate scroll event
-      window.dispatchEvent(new Event('scroll'));
+      globalThis.dispatchEvent(new Event('scroll'));
 
       expect(updateVisibilitySpy).toHaveBeenCalled();
 
@@ -75,7 +75,7 @@ describe('ScrollToTop', () => {
 
     it('should set isVisible to true when scrollY > threshold', () => {
       // Mock window.scrollY
-      Object.defineProperty(window, 'scrollY', {
+      Object.defineProperty(globalThis, 'scrollY', {
         writable: true,
         configurable: true,
         value: 500,
@@ -87,7 +87,7 @@ describe('ScrollToTop', () => {
     });
 
     it('should set isVisible to false when scrollY < threshold', () => {
-      Object.defineProperty(window, 'scrollY', {
+      Object.defineProperty(globalThis, 'scrollY', {
         writable: true,
         configurable: true,
         value: 100,
@@ -101,7 +101,7 @@ describe('ScrollToTop', () => {
 
   describe('Lifecycle', () => {
     it('should attach scroll listener on init', () => {
-      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+      const addEventListenerSpy = vi.spyOn(globalThis, 'addEventListener');
 
       component.ngOnInit();
 
@@ -114,7 +114,10 @@ describe('ScrollToTop', () => {
     });
 
     it('should remove scroll listener on destroy', () => {
-      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+      const removeEventListenerSpy = vi.spyOn(
+        globalThis,
+        'removeEventListener',
+      );
 
       component.ngOnDestroy();
 


### PR DESCRIPTION
## Résumé\n- supprime les marqueurs de conflit restants dans le workflow observability\n- harmonise les tests web pour utiliser globalThis (matchMedia, spies et événements)\n- conserve strictement les 3 fichiers demandés\n\n## Fichiers modifiés\n- .github/workflows/observability.yml\n- apps/client/projects/web/src/app/core/animations/gsap-animations.service.spec.ts\n- apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.spec.ts\n\n## Validation\n- hooks pre-push exécutés en entier (typecheck, format, lint, tests unitaires, Playwright)\n- push branch réussi