### PR TITLE
fix(web): remove duplicated programs gallery section

### DIFF
--- a/apps/client/projects/web/src/app/features/programs/programs.page.html
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.html
@@ -32,33 +32,6 @@
       >
         <img
           src="/assets/site-visuals/photos/programs-analytics.avif"
-          alt="Groupe réuni autour d'une présentation dans un cadre de programme collectif"
-          loading="lazy"
-          class="h-56 w-full object-cover"
-        />
-      </figure>
-      <figure
-        class="reveal-on-scroll rounded-card shadow-card overflow-hidden bg-neutral-50"
-      >
-        <img
-          src="/assets/site-visuals/photos/programs-workshop.avif"
-          alt="Participants assis face à un écran pendant un atelier ou un forum"
-          loading="lazy"
-          class="h-56 w-full object-cover"
-        />
-      </figure>
-    </div>
-  </div>
-</section>
-
-<section class="bg-brand-white py-10">
-  <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <div class="grid gap-6 md:grid-cols-2">
-      <figure
-        class="reveal-on-scroll rounded-card shadow-card overflow-hidden bg-neutral-50"
-      >
-        <img
-          src="/assets/site-visuals/photos/programs-analytics.avif"
           alt="Groupe réuni autour d'une présentation de programme collectif"
           loading="lazy"
           class="h-56 w-full object-cover"


### PR DESCRIPTION
## Résumé\n- supprime un bloc galerie dupliqué sur la page Programmes\n- conserve une seule section visuelle cohérente avec le contenu actuel\n\n## Validation\n- pnpm --dir apps/client ng test web --watch=false --include=projects/web/src/app/features/programs/programs.page.spec.ts\n\n## Impact\n- pas de changement API\n- pas de migration\n