### PR TITLE
feat(cms): add admin dashboard and generalize article soft-delete rules

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AnnouncementsModule } from './announcements/announcements.module';
+import { ArticlesModule } from './articles/articles.module';
 import { AuthModule } from './auth/auth.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { ProgramsModule } from './programs/programs.module';
@@ -20,6 +21,7 @@ import { SupportModule } from './support/support.module';
     SupabaseModule,
     AuthModule,
     AnnouncementsModule,
+    ArticlesModule,
     DashboardModule,
     ProgramsModule,
     ResourcesModule,

--- a/apps/api/src/articles/articles.controller.spec.ts
+++ b/apps/api/src/articles/articles.controller.spec.ts
@@ -1,0 +1,150 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  RequestMethod,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ArticlesController } from './articles.controller';
+import { ArticlesService } from './articles.service';
+
+describe('ArticlesController', () => {
+  let controller: ArticlesController;
+
+  const articlesService = {
+    listArticles: jest.fn(),
+    getArticleById: jest.fn(),
+    createArticle: jest.fn(),
+    updateArticle: jest.fn(),
+    deleteArticle: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    articlesService.listArticles.mockResolvedValue([]);
+    articlesService.getArticleById.mockResolvedValue({
+      id: 'article-1',
+      slug: 'article-1',
+      title: 'Article 1',
+      excerpt: 'Résumé article 1',
+      content: '<p>Contenu 1</p>',
+      status: 'draft',
+      coverImageUrl: null,
+      seoTitle: null,
+      seoDescription: null,
+      publishedAt: null,
+      authorId: 'author-1',
+      categoryIds: ['category-1'],
+      tagIds: ['tag-1'],
+      createdAt: '2026-05-24T10:00:00.000Z',
+      updatedAt: '2026-05-24T10:00:00.000Z',
+    });
+    articlesService.createArticle.mockResolvedValue(
+      articlesService.getArticleById(),
+    );
+    articlesService.updateArticle.mockResolvedValue(
+      articlesService.getArticleById(),
+    );
+    articlesService.deleteArticle.mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ArticlesController],
+      providers: [
+        {
+          provide: ArticlesService,
+          useValue: articlesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ArticlesController>(ArticlesController);
+  });
+
+  it('Given le module articles admin, When on lit les métadonnées NestJS, Then le préfixe admin/articles est exposé', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, ArticlesController)).toBe(
+      'admin/articles',
+    );
+  });
+
+  it('Given le module articles admin, When on lit les routes, Then GET/POST/PATCH/DELETE sont exposées', () => {
+    expect(Reflect.getMetadata(METHOD_METADATA, controller.listArticles)).toBe(
+      RequestMethod.GET,
+    );
+    expect(
+      Reflect.getMetadata(METHOD_METADATA, controller.getArticleById),
+    ).toBe(RequestMethod.GET);
+    expect(Reflect.getMetadata(METHOD_METADATA, controller.createArticle)).toBe(
+      RequestMethod.POST,
+    );
+    expect(Reflect.getMetadata(METHOD_METADATA, controller.updateArticle)).toBe(
+      RequestMethod.PATCH,
+    );
+    expect(Reflect.getMetadata(METHOD_METADATA, controller.deleteArticle)).toBe(
+      RequestMethod.DELETE,
+    );
+  });
+
+  it('Given un header Authorization valide, When listArticles est appelé, Then le token est transmis au service', async () => {
+    await controller.listArticles('Bearer access-token');
+
+    expect(articlesService.listArticles).toHaveBeenCalledWith('access-token');
+  });
+
+  it('Given un header Authorization absent, When listArticles est appelé, Then une UnauthorizedException est renvoyée', async () => {
+    await expect(controller.listArticles()).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('Given un payload création invalide, When createArticle est appelé, Then une BadRequestException est renvoyée', async () => {
+    await expect(
+      controller.createArticle(
+        {
+          slug: '',
+        },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('Given un article introuvable, When getArticleById est appelé, Then la NotFoundException est propagée', async () => {
+    articlesService.getArticleById.mockRejectedValueOnce(
+      new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      }),
+    );
+
+    await expect(
+      controller.getArticleById('article-missing', 'Bearer access-token'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('Given un utilisateur non admin, When createArticle est appelé, Then la ForbiddenException est propagée', async () => {
+    articlesService.createArticle.mockRejectedValueOnce(
+      new ForbiddenException({
+        success: false,
+        message: 'Accès admin requis.',
+      }),
+    );
+
+    await expect(
+      controller.createArticle(
+        {
+          slug: 'article-1',
+          title: 'Title',
+          excerpt: 'Résumé suffisamment long.',
+          content: '<p>Contenu</p>',
+          status: 'draft',
+          authorId: 'author-1',
+          categoryIds: ['category-1'],
+          tagIds: ['tag-1'],
+        },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/api/src/articles/articles.controller.ts
+++ b/apps/api/src/articles/articles.controller.ts
@@ -1,0 +1,305 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { ArticleDto } from '@kraak/contracts';
+import { extractAccessToken } from '../auth/auth.dto';
+import {
+  validateCreateArticlePayload,
+  validateUpdateArticlePayload,
+} from './articles.dto';
+import { ArticlesService } from './articles.service';
+
+const publicationStatusEnum = ['draft', 'published', 'archived'];
+
+const articleSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'slug',
+    'title',
+    'excerpt',
+    'content',
+    'status',
+    'coverImageUrl',
+    'seoTitle',
+    'seoDescription',
+    'publishedAt',
+    'authorId',
+    'categoryIds',
+    'tagIds',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    slug: { type: 'string' },
+    title: { type: 'string' },
+    excerpt: { type: 'string' },
+    content: { type: 'string' },
+    status: { type: 'string', enum: publicationStatusEnum },
+    coverImageUrl: { type: 'string', nullable: true },
+    seoTitle: { type: 'string', nullable: true },
+    seoDescription: { type: 'string', nullable: true },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+    authorId: { type: 'string' },
+    categoryIds: { type: 'array', items: { type: 'string' } },
+    tagIds: { type: 'array', items: { type: 'string' } },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const createArticleBodySchema = {
+  type: 'object',
+  required: [
+    'slug',
+    'title',
+    'excerpt',
+    'content',
+    'status',
+    'authorId',
+    'categoryIds',
+    'tagIds',
+  ],
+  properties: {
+    slug: { type: 'string' },
+    title: { type: 'string' },
+    excerpt: { type: 'string' },
+    content: { type: 'string' },
+    status: { type: 'string', enum: publicationStatusEnum },
+    coverImageUrl: { type: 'string', nullable: true },
+    seoTitle: { type: 'string', nullable: true },
+    seoDescription: { type: 'string', nullable: true },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+    authorId: { type: 'string' },
+    categoryIds: { type: 'array', items: { type: 'string' } },
+    tagIds: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+const updateArticleBodySchema = {
+  type: 'object',
+  properties: {
+    slug: { type: 'string' },
+    title: { type: 'string' },
+    excerpt: { type: 'string' },
+    content: { type: 'string' },
+    status: { type: 'string', enum: publicationStatusEnum },
+    coverImageUrl: { type: 'string', nullable: true },
+    seoTitle: { type: 'string', nullable: true },
+    seoDescription: { type: 'string', nullable: true },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+    authorId: { type: 'string' },
+    categoryIds: { type: 'array', items: { type: 'string' } },
+    tagIds: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+const apiErrorSchema = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', example: false },
+    message: { type: 'string' },
+    errors: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+@ApiTags('Admin Articles')
+@Controller('admin/articles')
+export class ArticlesController {
+  constructor(private readonly articlesService: ArticlesService) {}
+
+  @Get()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Lister tous les articles administrables' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Liste des articles chargée avec succès.',
+    schema: { type: 'array', items: articleSchema },
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Session invalide.',
+    schema: apiErrorSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Accès admin requis.',
+    schema: apiErrorSchema,
+  })
+  async listArticles(
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto[]> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.articlesService.listArticles(accessToken.data);
+  }
+
+  @Get(':id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Récupérer un article par son identifiant' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Article chargé avec succès.',
+    schema: articleSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Article introuvable.',
+    schema: apiErrorSchema,
+  })
+  async getArticleById(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.articlesService.getArticleById(accessToken.data, id);
+  }
+
+  @Post()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Créer un article' })
+  @ApiBody({ schema: createArticleBodySchema })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Article créé avec succès.',
+    schema: articleSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Payload invalide.',
+    schema: apiErrorSchema,
+  })
+  async createArticle(
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const validated = validateCreateArticlePayload(body);
+
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.articlesService.createArticle(accessToken.data, validated.data);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Mettre à jour un article' })
+  @ApiBody({ schema: updateArticleBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Article mis à jour avec succès.',
+    schema: articleSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Payload invalide.',
+    schema: apiErrorSchema,
+  })
+  async updateArticle(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const validated = validateUpdateArticlePayload(body);
+
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.articlesService.updateArticle(
+      accessToken.data,
+      id,
+      validated.data,
+    );
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Supprimer un article' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Article supprimé avec succès.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Article introuvable.',
+    schema: apiErrorSchema,
+  })
+  async deleteArticle(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<void> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    await this.articlesService.deleteArticle(accessToken.data, id);
+  }
+}

--- a/apps/api/src/articles/articles.dto.spec.ts
+++ b/apps/api/src/articles/articles.dto.spec.ts
@@ -91,4 +91,54 @@ describe('Articles DTO validation', () => {
       errors: ['Au moins un champ doit être fourni pour la mise à jour.'],
     });
   });
+
+  it('Given un corps invalide, When la validation création ou mise à jour est appelée, Then une erreur de corps invalide est renvoyée', () => {
+    expect(validateCreateArticlePayload(null)).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    });
+
+    expect(validateUpdateArticlePayload('invalid')).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    });
+  });
+
+  it('Given des champs optionnels invalides en mise à jour, When validateUpdateArticlePayload est appelé, Then les erreurs associées sont renvoyées', () => {
+    const result = validateUpdateArticlePayload({
+      slug: '   ',
+      status: 'invalid',
+      categoryIds: [],
+      tagIds: [],
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ slug est requis.',
+        'Le champ status est invalide.',
+        'Le champ categoryIds doit contenir au moins une valeur.',
+        'Le champ tagIds doit contenir au moins une valeur.',
+      ],
+    });
+  });
+
+  it('Given des valeurs nullable en mise à jour, When validateUpdateArticlePayload est appelé, Then les champs sont normalisés', () => {
+    const result = validateUpdateArticlePayload({
+      coverImageUrl: 'not-a-url',
+      publishedAt: 'not-a-date',
+      seoTitle: '  ',
+      seoDescription: ' Description SEO ',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        coverImageUrl: null,
+        publishedAt: null,
+        seoTitle: null,
+        seoDescription: 'Description SEO',
+      },
+    });
+  });
 });

--- a/apps/api/src/articles/articles.dto.spec.ts
+++ b/apps/api/src/articles/articles.dto.spec.ts
@@ -1,0 +1,94 @@
+import {
+  validateCreateArticlePayload,
+  validateUpdateArticlePayload,
+} from './articles.dto';
+
+describe('Articles DTO validation', () => {
+  it('Given un payload création valide, When validateCreateArticlePayload est appelé, Then le payload normalisé est renvoyé', () => {
+    const result = validateCreateArticlePayload({
+      slug: '  nouvel-article  ',
+      title: '  Un titre  ',
+      excerpt: '  Un résumé suffisamment long pour le test.  ',
+      content: '  <p>Contenu</p>  ',
+      status: 'draft',
+      coverImageUrl: 'https://cdn.kraak.test/cover.jpg',
+      seoTitle: '  SEO title  ',
+      seoDescription: '  SEO description  ',
+      publishedAt: null,
+      authorId: ' author-1 ',
+      categoryIds: [' category-1 ', 'category-2'],
+      tagIds: [' tag-1 '],
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        slug: 'nouvel-article',
+        title: 'Un titre',
+        excerpt: 'Un résumé suffisamment long pour le test.',
+        content: '<p>Contenu</p>',
+        status: 'draft',
+        coverImageUrl: 'https://cdn.kraak.test/cover.jpg',
+        seoTitle: 'SEO title',
+        seoDescription: 'SEO description',
+        publishedAt: null,
+        authorId: 'author-1',
+        categoryIds: ['category-1', 'category-2'],
+        tagIds: ['tag-1'],
+      },
+    });
+  });
+
+  it('Given un payload création invalide, When validateCreateArticlePayload est appelé, Then les erreurs explicites sont renvoyées', () => {
+    const result = validateCreateArticlePayload({
+      slug: '',
+      title: '',
+      excerpt: '',
+      content: '',
+      status: 'invalid',
+      authorId: '',
+      categoryIds: [],
+      tagIds: [],
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ slug est requis.',
+        'Le champ title est requis.',
+        'Le champ excerpt est requis.',
+        'Le champ content est requis.',
+        'Le champ authorId est requis.',
+        'Le champ status est invalide.',
+        'Le champ categoryIds doit contenir au moins une valeur.',
+        'Le champ tagIds doit contenir au moins une valeur.',
+      ],
+    });
+  });
+
+  it('Given un payload mise à jour partiel valide, When validateUpdateArticlePayload est appelé, Then le payload normalisé est renvoyé', () => {
+    const result = validateUpdateArticlePayload({
+      title: '  Nouveau titre  ',
+      categoryIds: [' category-3 '],
+      tagIds: [' tag-4 '],
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        title: 'Nouveau titre',
+        categoryIds: ['category-3'],
+        tagIds: ['tag-4'],
+      },
+    });
+  });
+
+  it('Given un payload mise à jour vide, When validateUpdateArticlePayload est appelé, Then une erreur explicite est renvoyée', () => {
+    const result = validateUpdateArticlePayload({});
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Au moins un champ doit être fourni pour la mise à jour.'],
+    });
+  });
+});

--- a/apps/api/src/articles/articles.dto.spec.ts
+++ b/apps/api/src/articles/articles.dto.spec.ts
@@ -123,10 +123,10 @@ describe('Articles DTO validation', () => {
     });
   });
 
-  it('Given des valeurs nullable en mise à jour, When validateUpdateArticlePayload est appelé, Then les champs sont normalisés', () => {
+  it('Given des valeurs nullable valides en mise à jour, When validateUpdateArticlePayload est appelé, Then les champs sont normalisés', () => {
     const result = validateUpdateArticlePayload({
-      coverImageUrl: 'not-a-url',
-      publishedAt: 'not-a-date',
+      coverImageUrl: '',
+      publishedAt: '  ',
       seoTitle: '  ',
       seoDescription: ' Description SEO ',
     });
@@ -139,6 +139,44 @@ describe('Articles DTO validation', () => {
         seoTitle: null,
         seoDescription: 'Description SEO',
       },
+    });
+  });
+
+  it('Given des valeurs nullable invalides en mise à jour, When validateUpdateArticlePayload est appelé, Then des erreurs explicites sont renvoyées', () => {
+    const result = validateUpdateArticlePayload({
+      coverImageUrl: 'not-a-url',
+      publishedAt: 'not-a-date',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ coverImageUrl est invalide.',
+        'Le champ publishedAt est invalide.',
+      ],
+    });
+  });
+
+  it('Given des valeurs nullable invalides en création, When validateCreateArticlePayload est appelé, Then des erreurs explicites sont renvoyées', () => {
+    const result = validateCreateArticlePayload({
+      slug: 'nouvel-article',
+      title: 'Titre',
+      excerpt: 'Résumé',
+      content: '<p>Contenu</p>',
+      status: 'draft',
+      coverImageUrl: 'bad-url',
+      publishedAt: 'bad-date',
+      authorId: 'author-1',
+      categoryIds: ['category-1'],
+      tagIds: ['tag-1'],
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ coverImageUrl est invalide.',
+        'Le champ publishedAt est invalide.',
+      ],
     });
   });
 });

--- a/apps/api/src/articles/articles.dto.ts
+++ b/apps/api/src/articles/articles.dto.ts
@@ -1,0 +1,276 @@
+import type { CreateArticleDto, UpdateArticleDto } from '@kraak/contracts';
+import {
+  isObjectPayload,
+  readTrimmedString,
+} from '../shared/dto-validation.utils';
+
+type ValidationSuccess<T> = {
+  valid: true;
+  data: T;
+};
+
+type ValidationFailure = {
+  valid: false;
+  errors: string[];
+};
+
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+const publicationStatuses = new Set(['draft', 'published', 'archived']);
+
+function readNullableString(value: unknown): string | null {
+  const normalized = readTrimmedString(value);
+  return normalized || null;
+}
+
+function readNullableUrl(value: unknown): string | null {
+  const normalized = readTrimmedString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    new URL(normalized);
+    return normalized;
+  } catch {
+    return null;
+  }
+}
+
+function readNullableDate(value: unknown): string | null {
+  const normalized = readTrimmedString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((entry) => readTrimmedString(entry)).filter(Boolean);
+}
+
+function assignRequiredStringUpdate(
+  body: Record<string, unknown>,
+  sourceKey: keyof UpdateArticleDto,
+  errors: string[],
+  updates: UpdateArticleDto,
+): void {
+  if (!(sourceKey in body)) {
+    return;
+  }
+
+  const value = readTrimmedString(body[sourceKey]);
+
+  if (value.length === 0) {
+    errors.push(`Le champ ${sourceKey} est requis.`);
+    return;
+  }
+
+  updates[sourceKey] = value as never;
+}
+
+function assignStatusUpdate(
+  body: Record<string, unknown>,
+  errors: string[],
+  updates: UpdateArticleDto,
+): void {
+  if (!('status' in body)) {
+    return;
+  }
+
+  const status = readTrimmedString(body['status']);
+
+  if (publicationStatuses.has(status) === false) {
+    errors.push('Le champ status est invalide.');
+    return;
+  }
+
+  updates.status = status as UpdateArticleDto['status'];
+}
+
+function assignArrayUpdate(
+  body: Record<string, unknown>,
+  field: 'categoryIds' | 'tagIds',
+  errors: string[],
+  updates: UpdateArticleDto,
+): void {
+  if (!(field in body)) {
+    return;
+  }
+
+  const values = readStringArray(body[field]);
+
+  if (values.length === 0) {
+    errors.push(`Le champ ${field} doit contenir au moins une valeur.`);
+    return;
+  }
+
+  updates[field] = values;
+}
+
+function assignNullableStringUpdate(
+  body: Record<string, unknown>,
+  field: 'seoTitle' | 'seoDescription',
+  updates: UpdateArticleDto,
+): void {
+  if (!(field in body)) {
+    return;
+  }
+
+  updates[field] = readNullableString(body[field]);
+}
+
+function assignNullableUrlUpdate(
+  body: Record<string, unknown>,
+  updates: UpdateArticleDto,
+): void {
+  if (!('coverImageUrl' in body)) {
+    return;
+  }
+
+  updates.coverImageUrl =
+    body['coverImageUrl'] === null
+      ? null
+      : readNullableUrl(body['coverImageUrl']);
+}
+
+function assignNullableDateUpdate(
+  body: Record<string, unknown>,
+  updates: UpdateArticleDto,
+): void {
+  if (!('publishedAt' in body)) {
+    return;
+  }
+
+  updates.publishedAt =
+    body['publishedAt'] === null ? null : readNullableDate(body['publishedAt']);
+}
+
+function validateRequiredText(
+  value: string,
+  fieldName: keyof CreateArticleDto,
+  errors: string[],
+): void {
+  if (!value) {
+    errors.push(`Le champ ${fieldName} est requis.`);
+  }
+}
+
+function validateStatus(value: string, errors: string[]): void {
+  if (!publicationStatuses.has(value)) {
+    errors.push('Le champ status est invalide.');
+  }
+}
+
+export function validateCreateArticlePayload(
+  body: unknown,
+): ValidationResult<CreateArticleDto> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    };
+  }
+
+  const slug = readTrimmedString(body['slug']);
+  const title = readTrimmedString(body['title']);
+  const excerpt = readTrimmedString(body['excerpt']);
+  const content = readTrimmedString(body['content']);
+  const status = readTrimmedString(body['status']);
+  const coverImageUrl = readNullableUrl(body['coverImageUrl']);
+  const seoTitle = readNullableString(body['seoTitle']);
+  const seoDescription = readNullableString(body['seoDescription']);
+  const publishedAt =
+    body['publishedAt'] === null ? null : readNullableDate(body['publishedAt']);
+  const authorId = readTrimmedString(body['authorId']);
+  const categoryIds = readStringArray(body['categoryIds']);
+  const tagIds = readStringArray(body['tagIds']);
+
+  const errors: string[] = [];
+
+  validateRequiredText(slug, 'slug', errors);
+  validateRequiredText(title, 'title', errors);
+  validateRequiredText(excerpt, 'excerpt', errors);
+  validateRequiredText(content, 'content', errors);
+  validateRequiredText(authorId, 'authorId', errors);
+  validateStatus(status, errors);
+
+  if (categoryIds.length === 0) {
+    errors.push('Le champ categoryIds doit contenir au moins une valeur.');
+  }
+
+  if (tagIds.length === 0) {
+    errors.push('Le champ tagIds doit contenir au moins une valeur.');
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data: {
+      slug,
+      title,
+      excerpt,
+      content,
+      status: status as CreateArticleDto['status'],
+      coverImageUrl,
+      seoTitle,
+      seoDescription,
+      publishedAt,
+      authorId,
+      categoryIds,
+      tagIds,
+    },
+  };
+}
+
+export function validateUpdateArticlePayload(
+  body: unknown,
+): ValidationResult<UpdateArticleDto> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    };
+  }
+
+  const updates: UpdateArticleDto = {};
+  const errors: string[] = [];
+
+  assignRequiredStringUpdate(body, 'slug', errors, updates);
+  assignRequiredStringUpdate(body, 'title', errors, updates);
+  assignRequiredStringUpdate(body, 'excerpt', errors, updates);
+  assignRequiredStringUpdate(body, 'content', errors, updates);
+  assignRequiredStringUpdate(body, 'authorId', errors, updates);
+  assignStatusUpdate(body, errors, updates);
+  assignNullableUrlUpdate(body, updates);
+  assignNullableStringUpdate(body, 'seoTitle', updates);
+  assignNullableStringUpdate(body, 'seoDescription', updates);
+  assignNullableDateUpdate(body, updates);
+  assignArrayUpdate(body, 'categoryIds', errors, updates);
+  assignArrayUpdate(body, 'tagIds', errors, updates);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return {
+      valid: false,
+      errors: ['Au moins un champ doit être fourni pour la mise à jour.'],
+    };
+  }
+
+  return {
+    valid: true,
+    data: updates,
+  };
+}

--- a/apps/api/src/articles/articles.dto.ts
+++ b/apps/api/src/articles/articles.dto.ts
@@ -23,28 +23,36 @@ function readNullableString(value: unknown): string | null {
   return normalized || null;
 }
 
-function readNullableUrl(value: unknown): string | null {
+function readNullableUrl(value: unknown): {
+  value: string | null;
+  isInvalid: boolean;
+} {
   const normalized = readTrimmedString(value);
   if (!normalized) {
-    return null;
+    return { value: null, isInvalid: false };
   }
 
   try {
     new URL(normalized);
-    return normalized;
+    return { value: normalized, isInvalid: false };
   } catch {
-    return null;
+    return { value: null, isInvalid: true };
   }
 }
 
-function readNullableDate(value: unknown): string | null {
+function readNullableDate(value: unknown): {
+  value: string | null;
+  isInvalid: boolean;
+} {
   const normalized = readTrimmedString(value);
   if (!normalized) {
-    return null;
+    return { value: null, isInvalid: false };
   }
 
   const date = new Date(normalized);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  return Number.isNaN(date.getTime())
+    ? { value: null, isInvalid: true }
+    : { value: date.toISOString(), isInvalid: false };
 }
 
 function readStringArray(value: unknown): string[] {
@@ -128,28 +136,48 @@ function assignNullableStringUpdate(
 
 function assignNullableUrlUpdate(
   body: Record<string, unknown>,
+  errors: string[],
   updates: UpdateArticleDto,
 ): void {
   if (!('coverImageUrl' in body)) {
     return;
   }
 
-  updates.coverImageUrl =
-    body['coverImageUrl'] === null
-      ? null
-      : readNullableUrl(body['coverImageUrl']);
+  if (body['coverImageUrl'] === null) {
+    updates.coverImageUrl = null;
+    return;
+  }
+
+  const { value, isInvalid } = readNullableUrl(body['coverImageUrl']);
+  if (isInvalid) {
+    errors.push('Le champ coverImageUrl est invalide.');
+    return;
+  }
+
+  updates.coverImageUrl = value;
 }
 
 function assignNullableDateUpdate(
   body: Record<string, unknown>,
+  errors: string[],
   updates: UpdateArticleDto,
 ): void {
   if (!('publishedAt' in body)) {
     return;
   }
 
-  updates.publishedAt =
-    body['publishedAt'] === null ? null : readNullableDate(body['publishedAt']);
+  if (body['publishedAt'] === null) {
+    updates.publishedAt = null;
+    return;
+  }
+
+  const { value, isInvalid } = readNullableDate(body['publishedAt']);
+  if (isInvalid) {
+    errors.push('Le champ publishedAt est invalide.');
+    return;
+  }
+
+  updates.publishedAt = value;
 }
 
 function validateRequiredText(
@@ -183,11 +211,14 @@ export function validateCreateArticlePayload(
   const excerpt = readTrimmedString(body['excerpt']);
   const content = readTrimmedString(body['content']);
   const status = readTrimmedString(body['status']);
-  const coverImageUrl = readNullableUrl(body['coverImageUrl']);
+  const { value: coverImageUrl, isInvalid: isCoverImageUrlInvalid } =
+    readNullableUrl(body['coverImageUrl']);
   const seoTitle = readNullableString(body['seoTitle']);
   const seoDescription = readNullableString(body['seoDescription']);
-  const publishedAt =
-    body['publishedAt'] === null ? null : readNullableDate(body['publishedAt']);
+  const { value: normalizedPublishedAt, isInvalid: isPublishedAtInvalid } =
+    body['publishedAt'] === null
+      ? { value: null, isInvalid: false }
+      : readNullableDate(body['publishedAt']);
   const authorId = readTrimmedString(body['authorId']);
   const categoryIds = readStringArray(body['categoryIds']);
   const tagIds = readStringArray(body['tagIds']);
@@ -209,6 +240,14 @@ export function validateCreateArticlePayload(
     errors.push('Le champ tagIds doit contenir au moins une valeur.');
   }
 
+  if (isCoverImageUrlInvalid) {
+    errors.push('Le champ coverImageUrl est invalide.');
+  }
+
+  if (isPublishedAtInvalid) {
+    errors.push('Le champ publishedAt est invalide.');
+  }
+
   if (errors.length > 0) {
     return { valid: false, errors };
   }
@@ -224,7 +263,7 @@ export function validateCreateArticlePayload(
       coverImageUrl,
       seoTitle,
       seoDescription,
-      publishedAt,
+      publishedAt: normalizedPublishedAt,
       authorId,
       categoryIds,
       tagIds,
@@ -251,10 +290,10 @@ export function validateUpdateArticlePayload(
   assignRequiredStringUpdate(body, 'content', errors, updates);
   assignRequiredStringUpdate(body, 'authorId', errors, updates);
   assignStatusUpdate(body, errors, updates);
-  assignNullableUrlUpdate(body, updates);
+  assignNullableUrlUpdate(body, errors, updates);
   assignNullableStringUpdate(body, 'seoTitle', updates);
   assignNullableStringUpdate(body, 'seoDescription', updates);
-  assignNullableDateUpdate(body, updates);
+  assignNullableDateUpdate(body, errors, updates);
   assignArrayUpdate(body, 'categoryIds', errors, updates);
   assignArrayUpdate(body, 'tagIds', errors, updates);
 

--- a/apps/api/src/articles/articles.dto.ts
+++ b/apps/api/src/articles/articles.dto.ts
@@ -57,7 +57,7 @@ function readStringArray(value: unknown): string[] {
 
 function assignRequiredStringUpdate(
   body: Record<string, unknown>,
-  sourceKey: keyof UpdateArticleDto,
+  sourceKey: Extract<keyof UpdateArticleDto, string>,
   errors: string[],
   updates: UpdateArticleDto,
 ): void {
@@ -154,7 +154,7 @@ function assignNullableDateUpdate(
 
 function validateRequiredText(
   value: string,
-  fieldName: keyof CreateArticleDto,
+  fieldName: Extract<keyof CreateArticleDto, string>,
   errors: string[],
 ): void {
   if (!value) {

--- a/apps/api/src/articles/articles.module.ts
+++ b/apps/api/src/articles/articles.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ArticlesController } from './articles.controller';
+import { ArticlesService } from './articles.service';
+
+@Module({
+  controllers: [ArticlesController],
+  providers: [ArticlesService],
+})
+export class ArticlesModule {}

--- a/apps/api/src/articles/articles.service.spec.ts
+++ b/apps/api/src/articles/articles.service.spec.ts
@@ -241,6 +241,44 @@ describe('ArticlesService', () => {
     );
   });
 
+  it('Given un profil admin introuvable, When listArticles est appelé, Then une ForbiddenException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listArticles('access-token')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('Given un profil admin en erreur de lecture, When listArticles est appelé, Then une ForbiddenException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: null,
+      error: { message: 'db error' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listArticles('access-token')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
   it('Given une catégorie archivée, When createArticle est appelé, Then une BadRequestException est renvoyée', async () => {
     const appUserQuery = createSingleRowQuery({
       data: { id: 'user-1', role: 'admin' },
@@ -302,6 +340,67 @@ describe('ArticlesService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
 
     expect(articleInsertQuery.single).not.toHaveBeenCalled();
+  });
+
+  it('Given une erreur de persistance article, When createArticle est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+
+    const categoryQuery = createListQuery({
+      data: [{ id: 'category-1' }],
+      error: null,
+    });
+
+    const tagQuery = createListQuery({
+      data: [{ id: 'tag-1' }],
+      error: null,
+    });
+
+    const articleInsertQuery = createSingleRowQuery({
+      data: null,
+      error: { message: 'insert error' },
+    });
+
+    articleInsertQuery['insert'] = jest.fn().mockReturnThis();
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'category') {
+        return categoryQuery;
+      }
+
+      if (tableName === 'tag') {
+        return tagQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleInsertQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.createArticle('access-token', {
+        slug: 'article-1',
+        title: 'Article 1',
+        excerpt: 'Résumé article 1',
+        content: '<p>Contenu article 1</p>',
+        status: 'draft',
+        coverImageUrl: null,
+        seoTitle: null,
+        seoDescription: null,
+        publishedAt: null,
+        authorId: 'author-1',
+        categoryIds: ['category-1'],
+        tagIds: ['tag-1'],
+      }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
   it('Given un article existant, When deleteArticle est appelé, Then il est archivé sans suppression physique', async () => {
@@ -391,5 +490,67 @@ describe('ArticlesService', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
 
     expect(archivedArticleQuery.neq).toHaveBeenCalledWith('status', 'archived');
+  });
+
+  it('Given une erreur de lecture article, When deleteArticle est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const articleReadQuery = createSingleRowQuery({
+      data: null,
+      error: { message: 'db read error' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleReadQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteArticle('access-token', 'article-1'),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it('Given une erreur d archivage article, When deleteArticle est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+
+    const existingArticleQuery = createSingleRowQuery({
+      data: { id: 'article-1' },
+      error: null,
+    });
+
+    const archiveQuery = {
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ error: { message: 'archive error' } }),
+    };
+
+    let articleCallCount = 0;
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        articleCallCount += 1;
+        return articleCallCount === 1 ? existingArticleQuery : archiveQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteArticle('access-token', 'article-1'),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 });

--- a/apps/api/src/articles/articles.service.spec.ts
+++ b/apps/api/src/articles/articles.service.spec.ts
@@ -1,0 +1,395 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SupabaseService } from '../supabase/supabase.service';
+import { ArticlesService } from './articles.service';
+
+function createSingleRowQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    neq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue(result),
+    maybeSingle: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function createListQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    neq: jest.fn().mockReturnThis(),
+    in: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue(result),
+    single: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function createUpdateQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    neq: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(result),
+    single: jest.fn().mockResolvedValue(result),
+  };
+}
+
+describe('ArticlesService', () => {
+  let service: ArticlesService;
+
+  const authClient = {
+    auth: {
+      getUser: jest.fn(),
+    },
+  };
+
+  const adminClient = {
+    from: jest.fn(),
+  };
+
+  const supabaseService = {
+    createAuthClient: jest.fn(() => authClient),
+    getClient: jest.fn(() => adminClient),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    authClient.auth.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: 'user-1',
+        },
+      },
+      error: null,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArticlesService,
+        {
+          provide: SupabaseService,
+          useValue: supabaseService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ArticlesService>(ArticlesService);
+  });
+
+  it('Given un token admin valide, When listArticles est appelé, Then les articles mappés sont renvoyés', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+
+    const articleQuery = createListQuery({
+      data: [
+        {
+          id: 'article-1',
+          slug: 'article-1',
+          title: 'Article 1',
+          excerpt: 'Résumé article 1',
+          content: '<p>Contenu 1</p>',
+          status: 'draft',
+          cover_image_url: null,
+          seo_title: null,
+          seo_description: null,
+          published_at: null,
+          author_id: 'author-1',
+          created_at: '2026-05-24T10:00:00.000Z',
+          updated_at: '2026-05-24T10:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+
+    const articleCategoryQuery = createListQuery({
+      data: [{ article_id: 'article-1', category_id: 'category-1' }],
+      error: null,
+    });
+
+    const articleTagQuery = createListQuery({
+      data: [{ article_id: 'article-1', tag_id: 'tag-1' }],
+      error: null,
+    });
+
+    const categoryQuery = createListQuery({
+      data: [{ id: 'category-1' }],
+      error: null,
+    });
+
+    const tagQuery = createListQuery({
+      data: [{ id: 'tag-1' }],
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleQuery;
+      }
+
+      if (tableName === 'article_category') {
+        return articleCategoryQuery;
+      }
+
+      if (tableName === 'article_tag') {
+        return articleTagQuery;
+      }
+
+      if (tableName === 'category') {
+        return categoryQuery;
+      }
+
+      if (tableName === 'tag') {
+        return tagQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listArticles('access-token')).resolves.toEqual([
+      {
+        id: 'article-1',
+        slug: 'article-1',
+        title: 'Article 1',
+        excerpt: 'Résumé article 1',
+        content: '<p>Contenu 1</p>',
+        status: 'draft',
+        coverImageUrl: null,
+        seoTitle: null,
+        seoDescription: null,
+        publishedAt: null,
+        authorId: 'author-1',
+        categoryIds: ['category-1'],
+        tagIds: ['tag-1'],
+        createdAt: '2026-05-24T10:00:00.000Z',
+        updatedAt: '2026-05-24T10:00:00.000Z',
+      },
+    ]);
+
+    expect(articleQuery.neq).toHaveBeenCalledWith('status', 'archived');
+  });
+
+  it('Given un token invalide, When listArticles est appelé, Then une UnauthorizedException est renvoyée', async () => {
+    authClient.auth.getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'invalid token' },
+    });
+
+    await expect(service.listArticles('invalid-token')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('Given un utilisateur non admin, When listArticles est appelé, Then une ForbiddenException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'participant' },
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listArticles('access-token')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('Given une erreur de lecture article, When listArticles est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+
+    const articleQuery = createListQuery({
+      data: null,
+      error: { message: 'db error' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listArticles('access-token')).rejects.toBeInstanceOf(
+      InternalServerErrorException,
+    );
+  });
+
+  it('Given une catégorie archivée, When createArticle est appelé, Then une BadRequestException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+
+    const categoryQuery = createListQuery({
+      data: [],
+      error: null,
+    });
+
+    const tagQuery = createListQuery({
+      data: [{ id: 'tag-1' }],
+      error: null,
+    });
+
+    const articleInsertQuery = createSingleRowQuery({
+      data: {
+        id: 'article-1',
+      },
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'category') {
+        return categoryQuery;
+      }
+
+      if (tableName === 'tag') {
+        return tagQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleInsertQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.createArticle('access-token', {
+        slug: 'article-1',
+        title: 'Article 1',
+        excerpt: 'Résumé article 1',
+        content: '<p>Contenu article 1</p>',
+        status: 'draft',
+        coverImageUrl: null,
+        seoTitle: null,
+        seoDescription: null,
+        publishedAt: null,
+        authorId: 'author-1',
+        categoryIds: ['category-archived'],
+        tagIds: ['tag-1'],
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(articleInsertQuery.single).not.toHaveBeenCalled();
+  });
+
+  it('Given un article existant, When deleteArticle est appelé, Then il est archivé sans suppression physique', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const articleSoftDeleteQuery = createUpdateQuery({
+      data: { id: 'article-1', status: 'archived' },
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleSoftDeleteQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteArticle('access-token', 'article-1'),
+    ).resolves.toBeUndefined();
+    expect(articleSoftDeleteQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'archived',
+        published_at: null,
+      }),
+    );
+  });
+
+  it('Given un article absent, When deleteArticle est appelé, Then une NotFoundException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const articleMissingQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleMissingQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteArticle('access-token', 'article-missing'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('Given un article déjà archivé, When deleteArticle est appelé, Then une NotFoundException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const archivedArticleQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return archivedArticleQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteArticle('access-token', 'article-archived'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(archivedArticleQuery.neq).toHaveBeenCalledWith('status', 'archived');
+  });
+});

--- a/apps/api/src/articles/articles.service.spec.ts
+++ b/apps/api/src/articles/articles.service.spec.ts
@@ -403,6 +403,67 @@ describe('ArticlesService', () => {
     ).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
+  it('Given un article introuvable côté Supabase, When updateArticle est appelé, Then une NotFoundException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const articleUpdateQuery = createUpdateQuery({
+      data: null,
+      error: {
+        code: 'PGRST116',
+        message: 'JSON object requested, multiple (or no) rows returned',
+      },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleUpdateQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.updateArticle('access-token', 'article-missing', {
+        title: 'Titre mis à jour',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('Given une erreur Supabase non liée à l absence de ligne, When updateArticle est appelé, Then une InternalServerErrorException est renvoyée', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const articleUpdateQuery = createUpdateQuery({
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      if (tableName === 'article') {
+        return articleUpdateQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.updateArticle('access-token', 'article-1', {
+        title: 'Titre mis à jour',
+      }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
   it('Given un article existant, When deleteArticle est appelé, Then il est archivé sans suppression physique', async () => {
     const appUserQuery = createSingleRowQuery({
       data: { id: 'user-1', role: 'admin' },

--- a/apps/api/src/articles/articles.service.ts
+++ b/apps/api/src/articles/articles.service.ts
@@ -1,0 +1,566 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type {
+  ArticleDto,
+  CreateArticleDto,
+  UpdateArticleDto,
+} from '@kraak/contracts';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type ArticleRow = {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+  status: ArticleDto['status'];
+  cover_image_url: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
+  published_at: string | null;
+  author_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type AppUserRow = {
+  id: string;
+  role: string;
+};
+
+type ArticleCategoryRow = {
+  article_id: string;
+  category_id: string;
+};
+
+type ArticleTagRow = {
+  article_id: string;
+  tag_id: string;
+};
+
+type TaxonomyIdRow = {
+  id: string;
+};
+
+const articleSelectFields =
+  'id, slug, title, excerpt, content, status, cover_image_url, seo_title, seo_description, published_at, author_id, created_at, updated_at';
+
+@Injectable()
+export class ArticlesService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async listArticles(accessToken: string): Promise<ArticleDto[]> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('article')
+      .select(articleSelectFields)
+      .neq('status', 'archived')
+      .order('updated_at', { ascending: false })
+      .limit(100);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les articles.',
+      });
+    }
+
+    const rows = (data as ArticleRow[] | null) ?? [];
+    const relations = await this.readArticleRelations(
+      rows.map((row) => row.id),
+    );
+
+    return rows.map((row) => this.mapArticleRow(row, relations));
+  }
+
+  async getArticleById(
+    accessToken: string,
+    articleId: string,
+  ): Promise<ArticleDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('article')
+      .select(articleSelectFields)
+      .eq('id', articleId)
+      .neq('status', 'archived')
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+
+    const relations = await this.readArticleRelations([articleId]);
+
+    return this.mapArticleRow(data as ArticleRow, relations);
+  }
+
+  async createArticle(
+    accessToken: string,
+    payload: CreateArticleDto,
+  ): Promise<ArticleDto> {
+    await this.assertAdminAccess(accessToken);
+    await this.assertActiveTaxonomyIds(payload.categoryIds, payload.tagIds);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('article')
+      .insert({
+        slug: payload.slug,
+        title: payload.title,
+        excerpt: payload.excerpt,
+        content: payload.content,
+        status: payload.status,
+        cover_image_url: payload.coverImageUrl,
+        seo_title: payload.seoTitle,
+        seo_description: payload.seoDescription,
+        published_at: payload.publishedAt,
+        author_id: payload.authorId,
+      })
+      .select(articleSelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de créer l'article.",
+      });
+    }
+
+    const articleId = (data as ArticleRow).id;
+    await this.syncArticleRelations(
+      articleId,
+      payload.categoryIds,
+      payload.tagIds,
+    );
+
+    const relations = await this.readArticleRelations([articleId]);
+    return this.mapArticleRow(data as ArticleRow, relations);
+  }
+
+  async updateArticle(
+    accessToken: string,
+    articleId: string,
+    payload: UpdateArticleDto,
+  ): Promise<ArticleDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+
+    const updatePayload: Record<string, unknown> = {};
+
+    if (payload.slug !== undefined) {
+      updatePayload['slug'] = payload.slug;
+    }
+
+    if (payload.title !== undefined) {
+      updatePayload['title'] = payload.title;
+    }
+
+    if (payload.excerpt !== undefined) {
+      updatePayload['excerpt'] = payload.excerpt;
+    }
+
+    if (payload.content !== undefined) {
+      updatePayload['content'] = payload.content;
+    }
+
+    if (payload.status !== undefined) {
+      updatePayload['status'] = payload.status;
+    }
+
+    if (payload.coverImageUrl !== undefined) {
+      updatePayload['cover_image_url'] = payload.coverImageUrl;
+    }
+
+    if (payload.seoTitle !== undefined) {
+      updatePayload['seo_title'] = payload.seoTitle;
+    }
+
+    if (payload.seoDescription !== undefined) {
+      updatePayload['seo_description'] = payload.seoDescription;
+    }
+
+    if (payload.publishedAt !== undefined) {
+      updatePayload['published_at'] = payload.publishedAt;
+    }
+
+    if (payload.authorId !== undefined) {
+      updatePayload['author_id'] = payload.authorId;
+    }
+
+    const { data, error } = await adminClient
+      .from('article')
+      .update(updatePayload)
+      .eq('id', articleId)
+      .neq('status', 'archived')
+      .select(articleSelectFields)
+      .single();
+
+    if (!data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de mettre à jour l'article.",
+      });
+    }
+
+    if (payload.categoryIds !== undefined || payload.tagIds !== undefined) {
+      const currentRelations = await this.readArticleRelations([articleId]);
+      const nextCategoryIds =
+        payload.categoryIds ??
+        currentRelations.categoryByArticleId.get(articleId) ??
+        [];
+      const nextTagIds =
+        payload.tagIds ?? currentRelations.tagByArticleId.get(articleId) ?? [];
+
+      await this.syncArticleRelations(articleId, nextCategoryIds, nextTagIds);
+    }
+
+    const relations = await this.readArticleRelations([articleId]);
+    return this.mapArticleRow(data as ArticleRow, relations);
+  }
+
+  async deleteArticle(accessToken: string, articleId: string): Promise<void> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data: existing, error: existingError } = await adminClient
+      .from('article')
+      .select('id')
+      .eq('id', articleId)
+      .neq('status', 'archived')
+      .maybeSingle();
+
+    if (existingError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de supprimer l'article.",
+      });
+    }
+
+    if (!existing) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+
+    const { error: archiveError } = await adminClient
+      .from('article')
+      .update({
+        status: 'archived',
+        published_at: null,
+      })
+      .eq('id', articleId);
+
+    if (archiveError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible d'archiver l'article.",
+      });
+    }
+  }
+
+  private async assertAdminAccess(accessToken: string): Promise<string> {
+    const authClient = this.supabaseService.createAuthClient();
+    const { data, error } = await authClient.auth.getUser(accessToken);
+
+    if (error || !data.user) {
+      throw new UnauthorizedException({
+        success: false,
+        message: 'Session invalide.',
+      });
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data: appUser, error: appUserError } = await adminClient
+      .from('app_user')
+      .select('id, role')
+      .eq('id', data.user.id)
+      .maybeSingle();
+
+    if (appUserError || !appUser) {
+      throw new ForbiddenException({
+        success: false,
+        message: 'Accès admin requis.',
+      });
+    }
+
+    if ((appUser as AppUserRow).role !== 'admin') {
+      throw new ForbiddenException({
+        success: false,
+        message: 'Accès admin requis.',
+      });
+    }
+
+    return data.user.id;
+  }
+
+  private async syncArticleRelations(
+    articleId: string,
+    categoryIds: string[],
+    tagIds: string[],
+  ): Promise<void> {
+    await this.assertActiveTaxonomyIds(categoryIds, tagIds);
+
+    const adminClient = this.supabaseService.getClient();
+
+    const { error: deleteCategoryError } = await adminClient
+      .from('article_category')
+      .delete()
+      .eq('article_id', articleId);
+
+    if (deleteCategoryError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de mettre à jour les catégories de l'article.",
+      });
+    }
+
+    if (categoryIds.length > 0) {
+      const { error: insertCategoryError } = await adminClient
+        .from('article_category')
+        .insert(
+          categoryIds.map((categoryId) => ({
+            article_id: articleId,
+            category_id: categoryId,
+          })),
+        );
+
+      if (insertCategoryError) {
+        throw new InternalServerErrorException({
+          success: false,
+          message: "Impossible de mettre à jour les catégories de l'article.",
+        });
+      }
+    }
+
+    const { error: deleteTagError } = await adminClient
+      .from('article_tag')
+      .delete()
+      .eq('article_id', articleId);
+
+    if (deleteTagError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de mettre à jour les tags de l'article.",
+      });
+    }
+
+    if (tagIds.length > 0) {
+      const { error: insertTagError } = await adminClient
+        .from('article_tag')
+        .insert(
+          tagIds.map((tagId) => ({
+            article_id: articleId,
+            tag_id: tagId,
+          })),
+        );
+
+      if (insertTagError) {
+        throw new InternalServerErrorException({
+          success: false,
+          message: "Impossible de mettre à jour les tags de l'article.",
+        });
+      }
+    }
+  }
+
+  private async readArticleRelations(articleIds: string[]): Promise<{
+    categoryByArticleId: Map<string, string[]>;
+    tagByArticleId: Map<string, string[]>;
+  }> {
+    const categoryByArticleId = new Map<string, string[]>();
+    const tagByArticleId = new Map<string, string[]>();
+
+    if (articleIds.length === 0) {
+      return { categoryByArticleId, tagByArticleId };
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const [
+      { data: categoryRows, error: categoryError },
+      { data: tagRows, error: tagError },
+    ] = await Promise.all([
+      adminClient
+        .from('article_category')
+        .select('article_id, category_id')
+        .in('article_id', articleIds)
+        .limit(1000),
+      adminClient
+        .from('article_tag')
+        .select('article_id, tag_id')
+        .in('article_id', articleIds)
+        .limit(1000),
+    ]);
+
+    if (categoryError || tagError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les relations article.',
+      });
+    }
+
+    const relationCategoryIds = [
+      ...new Set(
+        ((categoryRows as ArticleCategoryRow[] | null) ?? []).map(
+          (row) => row.category_id,
+        ),
+      ),
+    ];
+    const relationTagIds = [
+      ...new Set(
+        ((tagRows as ArticleTagRow[] | null) ?? []).map((row) => row.tag_id),
+      ),
+    ];
+    const { activeCategoryIds, activeTagIds } =
+      await this.readActiveTaxonomyIdSets(relationCategoryIds, relationTagIds);
+
+    for (const row of (categoryRows as ArticleCategoryRow[] | null) ?? []) {
+      if (!activeCategoryIds.has(row.category_id)) {
+        continue;
+      }
+
+      const existing = categoryByArticleId.get(row.article_id) ?? [];
+      categoryByArticleId.set(row.article_id, [...existing, row.category_id]);
+    }
+
+    for (const row of (tagRows as ArticleTagRow[] | null) ?? []) {
+      if (!activeTagIds.has(row.tag_id)) {
+        continue;
+      }
+
+      const existing = tagByArticleId.get(row.article_id) ?? [];
+      tagByArticleId.set(row.article_id, [...existing, row.tag_id]);
+    }
+
+    return { categoryByArticleId, tagByArticleId };
+  }
+
+  private mapArticleRow(
+    row: ArticleRow,
+    relations: {
+      categoryByArticleId: Map<string, string[]>;
+      tagByArticleId: Map<string, string[]>;
+    },
+  ): ArticleDto {
+    return {
+      id: row.id,
+      slug: row.slug,
+      title: row.title,
+      excerpt: row.excerpt,
+      content: row.content,
+      status: row.status,
+      coverImageUrl: row.cover_image_url,
+      seoTitle: row.seo_title,
+      seoDescription: row.seo_description,
+      publishedAt: row.published_at,
+      authorId: row.author_id,
+      categoryIds: relations.categoryByArticleId.get(row.id) ?? [],
+      tagIds: relations.tagByArticleId.get(row.id) ?? [],
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private async assertActiveTaxonomyIds(
+    categoryIds: string[],
+    tagIds: string[],
+  ): Promise<void> {
+    const requestedCategoryIds = [...new Set(categoryIds)];
+    const requestedTagIds = [...new Set(tagIds)];
+
+    const { activeCategoryIds, activeTagIds } =
+      await this.readActiveTaxonomyIdSets(
+        requestedCategoryIds,
+        requestedTagIds,
+      );
+
+    if (
+      activeCategoryIds.size !== requestedCategoryIds.length ||
+      activeTagIds.size !== requestedTagIds.length
+    ) {
+      throw new BadRequestException({
+        success: false,
+        message:
+          'Certaines catégories ou certains tags sont introuvables ou archivés.',
+      });
+    }
+  }
+
+  private async readActiveTaxonomyIdSets(
+    categoryIds: string[],
+    tagIds: string[],
+  ): Promise<{
+    activeCategoryIds: Set<string>;
+    activeTagIds: Set<string>;
+  }> {
+    const adminClient = this.supabaseService.getClient();
+
+    const categoryQuery =
+      categoryIds.length === 0
+        ? Promise.resolve({
+            data: [] as TaxonomyIdRow[],
+            error: null,
+          })
+        : adminClient
+            .from('category')
+            .select('id')
+            .in('id', categoryIds)
+            .neq('status', 'archived')
+            .limit(1000);
+
+    const tagQuery =
+      tagIds.length === 0
+        ? Promise.resolve({
+            data: [] as TaxonomyIdRow[],
+            error: null,
+          })
+        : adminClient
+            .from('tag')
+            .select('id')
+            .in('id', tagIds)
+            .neq('status', 'archived')
+            .limit(1000);
+
+    const [
+      { data: categoriesData, error: categoryError },
+      { data: tagsData, error: tagError },
+    ] = await Promise.all([categoryQuery, tagQuery]);
+
+    if (categoryError || tagError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de valider les catégories et tags.',
+      });
+    }
+
+    const activeCategoryIds = new Set(
+      ((categoriesData as TaxonomyIdRow[] | null) ?? []).map((row) => row.id),
+    );
+    const activeTagIds = new Set(
+      ((tagsData as TaxonomyIdRow[] | null) ?? []).map((row) => row.id),
+    );
+
+    return { activeCategoryIds, activeTagIds };
+  }
+}

--- a/apps/api/src/articles/articles.service.ts
+++ b/apps/api/src/articles/articles.service.ts
@@ -50,6 +50,7 @@ type TaxonomyIdRow = {
 
 const articleSelectFields =
   'id, slug, title, excerpt, content, status, cover_image_url, seo_title, seo_description, published_at, author_id, created_at, updated_at';
+const notFoundSupabaseErrorCodes = new Set(['PGRST116']);
 
 @Injectable()
 export class ArticlesService {
@@ -209,17 +210,32 @@ export class ArticlesService {
       .select(articleSelectFields)
       .single();
 
+    if (error) {
+      const errorCode =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof error.code === 'string'
+          ? error.code
+          : null;
+
+      if (errorCode !== null && notFoundSupabaseErrorCodes.has(errorCode)) {
+        throw new NotFoundException({
+          success: false,
+          message: 'Article introuvable.',
+        });
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de mettre à jour l'article.",
+      });
+    }
+
     if (!data) {
       throw new NotFoundException({
         success: false,
         message: 'Article introuvable.',
-      });
-    }
-
-    if (error) {
-      throw new InternalServerErrorException({
-        success: false,
-        message: "Impossible de mettre à jour l'article.",
       });
     }
 

--- a/apps/api/src/integration/critical-modules.integration.spec.ts
+++ b/apps/api/src/integration/critical-modules.integration.spec.ts
@@ -1,8 +1,17 @@
-import { INestApplication, Provider, Type } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  INestApplication,
+  NotFoundException,
+  Provider,
+  Type,
+} from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { AnnouncementsController } from '../announcements/announcements.controller';
 import { AnnouncementsService } from '../announcements/announcements.service';
+import { ArticlesController } from '../articles/articles.controller';
+import { ArticlesService } from '../articles/articles.service';
 import { AuthController } from '../auth/auth.controller';
 import { AuthService } from '../auth/auth.service';
 import { ProgramsController } from '../programs/programs.controller';
@@ -295,6 +304,209 @@ describe('Critical API Modules Integration', () => {
         'participant-token',
         '1',
         '10',
+      );
+    });
+  });
+
+  describe('CMS-02.1 Admin Articles endpoints', () => {
+    let app: INestApplication;
+
+    const articlesServiceMock: jest.Mocked<
+      Pick<
+        ArticlesService,
+        | 'listArticles'
+        | 'getArticleById'
+        | 'createArticle'
+        | 'updateArticle'
+        | 'deleteArticle'
+      >
+    > = {
+      listArticles: jest.fn(),
+      getArticleById: jest.fn(),
+      createArticle: jest.fn(),
+      updateArticle: jest.fn(),
+      deleteArticle: jest.fn(),
+    };
+
+    const articleFixture = {
+      id: 'article-1',
+      slug: 'article-1',
+      title: 'Article 1',
+      excerpt: 'Résumé article 1',
+      content: '<p>Contenu article 1</p>',
+      status: 'draft' as const,
+      coverImageUrl: null,
+      seoTitle: null,
+      seoDescription: null,
+      publishedAt: null,
+      authorId: 'author-1',
+      categoryIds: ['category-1'],
+      tagIds: ['tag-1'],
+      createdAt: '2026-05-24T10:00:00.000Z',
+      updatedAt: '2026-05-24T10:00:00.000Z',
+    };
+
+    beforeAll(async () => {
+      app = await buildHttpApp({
+        controllers: [ArticlesController],
+        providers: [
+          { provide: ArticlesService, useValue: articlesServiceMock },
+        ],
+      });
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      articlesServiceMock.listArticles.mockResolvedValue([articleFixture]);
+      articlesServiceMock.getArticleById.mockResolvedValue(articleFixture);
+      articlesServiceMock.createArticle.mockResolvedValue(articleFixture);
+      articlesServiceMock.updateArticle.mockResolvedValue({
+        ...articleFixture,
+        title: 'Article 1 mis à jour',
+      });
+      articlesServiceMock.deleteArticle.mockResolvedValue(undefined);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('returns 401 on missing authorization header for admin list endpoint', async () => {
+      await (request(app.getHttpServer())
+        .get('/admin/articles')
+        .expect(401) as unknown as Promise<void>);
+
+      expect(articlesServiceMock.listArticles).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 on authorized admin list endpoint', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/admin/articles')
+        .set('authorization', 'Bearer admin-token')
+        .expect(200);
+
+      expect(response.body).toHaveLength(1);
+      expect(articlesServiceMock.listArticles).toHaveBeenCalledWith(
+        'admin-token',
+      );
+    });
+
+    it('returns 403 when the service rejects list access for admin scope', async () => {
+      articlesServiceMock.listArticles.mockRejectedValueOnce(
+        new ForbiddenException({
+          success: false,
+          message: 'Accès admin requis.',
+        }),
+      );
+
+      await request(app.getHttpServer())
+        .get('/admin/articles')
+        .set('authorization', 'Bearer admin-token')
+        .expect(403);
+    });
+
+    it('returns 400 on invalid create payload', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/articles')
+        .set('authorization', 'Bearer admin-token')
+        .send({ slug: '' })
+        .expect(400);
+
+      expect(articlesServiceMock.createArticle).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the service reports a missing article on detail endpoint', async () => {
+      articlesServiceMock.getArticleById.mockRejectedValueOnce(
+        new NotFoundException({
+          success: false,
+          message: 'Article introuvable.',
+        }),
+      );
+
+      await request(app.getHttpServer())
+        .get('/admin/articles/article-missing')
+        .set('authorization', 'Bearer admin-token')
+        .expect(404);
+    });
+
+    it('returns 201 on valid create payload', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/admin/articles')
+        .set('authorization', 'Bearer admin-token')
+        .send({
+          slug: 'article-1',
+          title: 'Article 1',
+          excerpt: 'Résumé article 1',
+          content: '<p>Contenu article 1</p>',
+          status: 'draft',
+          authorId: 'author-1',
+          categoryIds: ['category-1'],
+          tagIds: ['tag-1'],
+        })
+        .expect(201);
+
+      expect(response.body.id).toBe('article-1');
+      expect(articlesServiceMock.createArticle).toHaveBeenCalledWith(
+        'admin-token',
+        expect.objectContaining({
+          slug: 'article-1',
+          title: 'Article 1',
+        }),
+      );
+    });
+
+    it('returns 200 on valid update payload', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/admin/articles/article-1')
+        .set('authorization', 'Bearer admin-token')
+        .send({ title: 'Article 1 mis à jour' })
+        .expect(200);
+
+      expect(response.body.title).toBe('Article 1 mis à jour');
+      expect(articlesServiceMock.updateArticle).toHaveBeenCalledWith(
+        'admin-token',
+        'article-1',
+        { title: 'Article 1 mis à jour' },
+      );
+    });
+
+    it('returns 500 when the service raises an unexpected update error', async () => {
+      articlesServiceMock.updateArticle.mockRejectedValueOnce(
+        new Error('boom'),
+      );
+
+      await request(app.getHttpServer())
+        .patch('/admin/articles/article-1')
+        .set('authorization', 'Bearer admin-token')
+        .send({ title: 'Article 1 mis à jour' })
+        .expect(500);
+    });
+
+    it('returns 400 when the service rejects archived category or tag relations', async () => {
+      articlesServiceMock.updateArticle.mockRejectedValueOnce(
+        new BadRequestException({
+          success: false,
+          message:
+            'Certaines catégories ou certains tags sont introuvables ou archivés.',
+        }),
+      );
+
+      await request(app.getHttpServer())
+        .patch('/admin/articles/article-1')
+        .set('authorization', 'Bearer admin-token')
+        .send({ categoryIds: ['category-archived'] })
+        .expect(400);
+    });
+
+    it('returns 204 on delete endpoint and forwards id', async () => {
+      await (request(app.getHttpServer())
+        .delete('/admin/articles/article-1')
+        .set('authorization', 'Bearer admin-token')
+        .expect(204) as unknown as Promise<void>);
+
+      expect(articlesServiceMock.deleteArticle).toHaveBeenCalledWith(
+        'admin-token',
+        'article-1',
       );
     });
   });

--- a/apps/api/src/integration/critical-modules.integration.spec.ts
+++ b/apps/api/src/integration/critical-modules.integration.spec.ts
@@ -403,6 +403,10 @@ describe('Critical API Modules Integration', () => {
         .get('/admin/articles')
         .set('authorization', 'Bearer admin-token')
         .expect(403);
+
+      expect(articlesServiceMock.listArticles).toHaveBeenCalledWith(
+        'admin-token',
+      );
     });
 
     it('returns 400 on invalid create payload', async () => {
@@ -427,6 +431,11 @@ describe('Critical API Modules Integration', () => {
         .get('/admin/articles/article-missing')
         .set('authorization', 'Bearer admin-token')
         .expect(404);
+
+      expect(articlesServiceMock.getArticleById).toHaveBeenCalledWith(
+        'admin-token',
+        'article-missing',
+      );
     });
 
     it('returns 201 on valid create payload', async () => {
@@ -480,6 +489,12 @@ describe('Critical API Modules Integration', () => {
         .set('authorization', 'Bearer admin-token')
         .send({ title: 'Article 1 mis à jour' })
         .expect(500);
+
+      expect(articlesServiceMock.updateArticle).toHaveBeenCalledWith(
+        'admin-token',
+        'article-1',
+        { title: 'Article 1 mis à jour' },
+      );
     });
 
     it('returns 400 when the service rejects archived category or tag relations', async () => {
@@ -496,6 +511,12 @@ describe('Critical API Modules Integration', () => {
         .set('authorization', 'Bearer admin-token')
         .send({ categoryIds: ['category-archived'] })
         .expect(400);
+
+      expect(articlesServiceMock.updateArticle).toHaveBeenCalledWith(
+        'admin-token',
+        'article-1',
+        { categoryIds: ['category-archived'] },
+      );
     });
 
     it('returns 204 on delete endpoint and forwards id', async () => {

--- a/apps/client/projects/web/src/app/admin-area.routes.ts
+++ b/apps/client/projects/web/src/app/admin-area.routes.ts
@@ -1,0 +1,27 @@
+import { type CanMatchFn, Routes } from '@angular/router';
+
+import { adminRoleChildGuard, adminRoleGuard } from './core/auth/auth.guard';
+
+export const adminAreaCanMatch: CanMatchFn = () => true;
+
+export const adminAreaRoutes: Routes = [
+  {
+    path: 'admin',
+    canMatch: [adminAreaCanMatch],
+    canActivate: [adminRoleGuard],
+    canActivateChild: [adminRoleChildGuard],
+    children: [
+      {
+        path: 'dashboard',
+        title: 'Tableau de bord admin | KRAAK Consulting',
+        loadComponent: () =>
+          import('./features/admin/dashboard/dashboard.page'),
+      },
+      {
+        path: '',
+        redirectTo: 'dashboard',
+        pathMatch: 'full',
+      },
+    ],
+  },
+];

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -5,6 +5,8 @@ import {
   routes,
 } from './app.routes';
 import {
+  adminRoleChildGuard,
+  adminRoleGuard,
   participantRoleGuard,
   participantRoleChildGuard,
 } from './core/auth/auth.guard';
@@ -18,15 +20,19 @@ describe('Web routes', () => {
     'services',
     'faq',
     'programmes',
+    'blog',
+    'blog/:slug',
     'ressources',
     'contact',
     'mentions-legales',
     'politique-de-confidentialite',
   ];
   const aliasRedirectPaths = ['about', 'programs', 'resources'];
+  const adminPaths = ['admin'];
   const frozenPublicPaths = [
     ...marketingPaths,
     ...aliasRedirectPaths,
+    ...adminPaths,
     '401',
     '403',
     '500',
@@ -69,8 +75,11 @@ describe('Web routes', () => {
       }
     });
 
-    it('When inspecting alias routes Then english slugs redirect to french canonical paths', () => {
+    it('When inspecting article and alias routes Then the blog article page is lazy-loaded and english slugs redirect to french canonical paths', () => {
       const builtRoutes = buildRoutes();
+      const blogArticleRoute = builtRoutes.find(
+        (route) => route.path === 'blog/:slug',
+      );
       const aboutAliasRoute = builtRoutes.find(
         (route) => route.path === 'about',
       );
@@ -80,6 +89,13 @@ describe('Web routes', () => {
       const resourcesAliasRoute = builtRoutes.find(
         (route) => route.path === 'resources',
       );
+
+      expect(blogArticleRoute).toBeDefined();
+      expect(blogArticleRoute!.title).toBe(
+        'Article de blog | KRAAK Consulting',
+      );
+      expect(blogArticleRoute!.data?.['seo']).toBeDefined();
+      expect(blogArticleRoute!.loadComponent).toBeDefined();
 
       expect(aboutAliasRoute).toBeDefined();
       expect(aboutAliasRoute?.redirectTo).toBe('a-propos');
@@ -92,6 +108,22 @@ describe('Web routes', () => {
       expect(resourcesAliasRoute).toBeDefined();
       expect(resourcesAliasRoute?.redirectTo).toBe('ressources');
       expect(resourcesAliasRoute?.pathMatch).toBe('full');
+    });
+
+    it('When inspecting the admin route Then it is guarded and exposes a dashboard child', () => {
+      const builtRoutes = buildRoutes();
+      const adminRoute = builtRoutes.find((route) => route.path === 'admin');
+
+      expect(adminRoute).toBeDefined();
+      expect(adminRoute!.canActivate).toContain(adminRoleGuard);
+      expect(adminRoute!.canActivateChild).toContain(adminRoleChildGuard);
+
+      const dashboardRoute = adminRoute!.children?.find(
+        (route) => route.path === 'dashboard',
+      );
+
+      expect(dashboardRoute).toBeDefined();
+      expect(dashboardRoute!.loadComponent).toBeDefined();
     });
   });
 
@@ -167,6 +199,20 @@ describe('Web routes', () => {
       expect(defaultRedirect).toBeDefined();
       expect(defaultRedirect!.redirectTo).toBe('dashboard');
       expect(defaultRedirect!.pathMatch).toBe('full');
+    });
+
+    it('When the admin dashboard child loadComponent is invoked Then it resolves to a component', async () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
+      const adminRoute = builtRoutes.find((route) => route.path === 'admin');
+      const dashboardRoute = adminRoute!.children!.find(
+        (childRoute) => childRoute.path === 'dashboard',
+      );
+
+      const loaded = await (
+        dashboardRoute!.loadComponent as () => Promise<unknown>
+      )();
+
+      expect(loaded).toBeTruthy();
     });
   });
 
@@ -244,6 +290,7 @@ describe('Web routes', () => {
         (route) =>
           route.path !== '**' &&
           route.path !== 'participant' &&
+          route.path !== 'admin' &&
           !route.redirectTo,
       );
 

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Route, Routes } from '@angular/router';
 
 import { findSeoPageByPath, type SeoPageDefinition } from './seo/site-seo';
+import { adminAreaRoutes } from './admin-area.routes';
 import { participantAreaRoutes } from './participant-area.routes';
 import { environment } from '../environments/environment';
 
@@ -36,6 +37,32 @@ const marketingRoutes: Routes = [
     'programmes',
     () => import('./features/programs/programs.page'),
   ),
+  buildMarketingRoute('blog', () => import('./features/blog/blog.page')),
+  {
+    path: 'blog/:slug',
+    title: 'Article de blog | KRAAK Consulting',
+    data: {
+      seo: {
+        path: 'blog',
+        title: 'Article de blog | KRAAK Consulting',
+        description:
+          'Consultez les articles KRAAK pour avancer plus clairement dans vos choix de formation, projet ou mobilité.',
+        openGraph: {
+          title: 'Article de blog | KRAAK Consulting',
+          description:
+            'Consultez les articles KRAAK pour avancer plus clairement dans vos choix de formation, projet ou mobilité.',
+          imagePath: '/assets/site-visuals/photos/home-hero-workshop.jpg',
+          imageAlt:
+            "Photo d'un atelier KRAAK Consulting avec des participants en session de travail.",
+        },
+        sitemap: {
+          changeFrequency: 'never',
+          priority: 0.1,
+        },
+      },
+    },
+    loadComponent: () => import('./features/blog/blog-article.page'),
+  },
   buildMarketingRoute(
     'ressources',
     () => import('./features/resources/resources.page'),
@@ -155,6 +182,7 @@ export function buildRoutes(options: BuildRoutesOptions = {}): Routes {
 
   return [
     ...marketingRoutes,
+    ...adminAreaRoutes,
     ...(includeParticipantArea ? participantAreaRoutes : []),
     {
       path: '401',

--- a/apps/client/projects/web/src/app/features/admin/dashboard/dashboard.page.html
+++ b/apps/client/projects/web/src/app/features/admin/dashboard/dashboard.page.html
@@ -1,0 +1,166 @@
+<section
+  class="relative overflow-hidden bg-cover bg-center bg-no-repeat px-4 py-20 md:px-8 lg:px-12 lg:py-28"
+  [ngStyle]="heroBackgroundStyle"
+>
+  <div
+    aria-hidden="true"
+    class="via-brand-navy/35 to-brand-navy/85 absolute inset-0 bg-linear-to-b from-transparent"
+  ></div>
+
+  <div class="relative z-10 mx-auto max-w-5xl px-4 text-center lg:px-6">
+    <p
+      class="text-brand-white/85 text-xs font-semibold tracking-[0.3em] uppercase"
+    >
+      Administration
+    </p>
+    <h1
+      class="text-brand-white mt-4 text-4xl leading-tight font-bold lg:text-5xl"
+    >
+      Tableau de bord admin pour les programmes et les contenus.
+    </h1>
+    <p
+      class="text-brand-white/90 mx-auto mt-6 max-w-3xl text-lg leading-relaxed"
+    >
+      Cette vue de pilotage regroupe les priorités éditoriales, les familles de
+      programmes et les prochaines actions à reprendre pour garder le site
+      cohérent et crédible.
+    </p>
+    <div
+      class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
+    >
+      <a
+        pButton
+        routerLink="/blog"
+        label="Ouvrir le blog public"
+        icon="pi pi-book"
+        class="kr-button-primary"
+        >Ouvrir le blog public</a
+      >
+      <a
+        pButton
+        routerLink="/programmes"
+        label="Relire les programmes"
+        icon="pi pi-compass"
+        class="kr-button-ghost"
+        >Relire les programmes</a
+      >
+    </div>
+  </div>
+</section>
+
+<section class="bg-brand-white py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <div class="grid gap-6 md:grid-cols-3">
+      @for (snapshot of contentSnapshots; track snapshot.label) {
+        <article class="rounded-card bg-neutral-50 p-6 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            {{ snapshot.label }}
+          </p>
+          <p class="mt-4 text-4xl font-bold">{{ snapshot.value }}</p>
+          <p class="mt-3 leading-relaxed text-neutral-700">
+            {{ snapshot.description }}
+          </p>
+        </article>
+      }
+    </div>
+
+    <div class="mt-12 grid gap-8 lg:grid-cols-[1fr_0.95fr]">
+      <article class="rounded-card bg-neutral-50 p-8 shadow-sm">
+        <p
+          class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+        >
+          Programmes
+        </p>
+        <h2 class="mt-3 text-3xl font-bold">
+          Les trois familles de service à garder alignées.
+        </h2>
+        <div class="mt-8 space-y-5">
+          @for (program of programSnapshots; track program.label) {
+            <section
+              class="rounded-card bg-brand-white border border-neutral-200 p-5"
+            >
+              <div
+                class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <h3 class="text-xl font-bold">{{ program.label }}</h3>
+                <span class="text-brand-blue text-sm font-semibold">{{
+                  program.status
+                }}</span>
+              </div>
+              <p class="mt-3 leading-relaxed text-neutral-700">
+                {{ program.description }}
+              </p>
+              <p class="text-brand-navy mt-4 text-sm font-semibold">
+                {{ program.primaryMetric }}
+              </p>
+            </section>
+          }
+        </div>
+      </article>
+
+      <aside class="space-y-6">
+        <section class="rounded-card bg-neutral-50 p-8 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            Contenus
+          </p>
+          <h2 class="mt-3 text-3xl font-bold">
+            Ce qui peut être publié ou retravaillé rapidement.
+          </h2>
+          <div class="mt-8 space-y-4">
+            @for (article of recentArticles; track article.slug) {
+              <article
+                class="rounded-card bg-brand-white border border-neutral-200 p-4"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-brand-blue text-sm font-semibold">
+                      {{ article.categoryLabel }}
+                    </p>
+                    <h3 class="mt-1 text-lg font-bold">{{ article.title }}</h3>
+                  </div>
+                  <span
+                    class="rounded-full bg-neutral-100 px-3 py-1 text-xs text-neutral-600"
+                  >
+                    {{ article.publishedLabel }}
+                  </span>
+                </div>
+                <p class="mt-3 leading-relaxed text-neutral-700">
+                  {{ article.summary }}
+                </p>
+              </article>
+            }
+          </div>
+        </section>
+
+        <section class="rounded-card bg-neutral-50 p-8 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            Actions rapides
+          </p>
+          <div class="mt-6 space-y-4">
+            @for (action of contentActions; track action.path) {
+              <article
+                class="rounded-card bg-brand-white border border-neutral-200 p-4"
+              >
+                <a
+                  [routerLink]="action.path"
+                  class="text-brand-navy text-lg font-semibold"
+                >
+                  {{ action.label }}
+                </a>
+                <p class="mt-2 leading-relaxed text-neutral-700">
+                  {{ action.description }}
+                </p>
+              </article>
+            }
+          </div>
+        </section>
+      </aside>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/admin/dashboard/dashboard.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/dashboard/dashboard.page.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { GsapAnimationsService } from '../../../core/animations/gsap-animations.service';
+import DashboardPage from './dashboard.page';
+
+const gsapAnimationsServiceMock: Pick<
+  GsapAnimationsService,
+  | 'animatePageIn'
+  | 'initializeFigureAnimations'
+  | 'initializeInteractiveCardAnimations'
+  | 'initializeButtonTransitions'
+  | 'initializeSectionAnimations'
+  | 'killAllAnimations'
+> = {
+  animatePageIn: () => undefined,
+  initializeFigureAnimations: () => undefined,
+  initializeInteractiveCardAnimations: () => undefined,
+  initializeButtonTransitions: () => undefined,
+  initializeSectionAnimations: () => undefined,
+  killAllAnimations: () => undefined,
+};
+
+describe('DashboardPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: GsapAnimationsService,
+          useValue: gsapAnimationsServiceMock,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('Given the admin dashboard component When it is created Then the instance exists', () => {
+    const fixture = TestBed.createComponent(DashboardPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the admin dashboard When it renders Then it shows programs, content and actions', () => {
+    const fixture = TestBed.createComponent(DashboardPage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain(
+      'Tableau de bord admin pour les programmes et les contenus.',
+    );
+    expect(content).toContain('Programmes');
+    expect(content).toContain('Contenus');
+    expect(content).toContain('Actions rapides');
+    expect(content).toContain('Formation');
+    expect(content).toContain('Voir le blog public');
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/dashboard/dashboard.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/dashboard/dashboard.page.ts
@@ -1,0 +1,114 @@
+import { NgStyle } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+import { GsapAnimationsService } from '../../../core/animations/gsap-animations.service';
+import { buildHeroBackgroundStyle } from '../../../shared/brand/brand-constants';
+import { blogArticles } from '../../blog/blog.data';
+
+interface ProgramSnapshot {
+  readonly label: string;
+  readonly status: string;
+  readonly description: string;
+  readonly primaryMetric: string;
+}
+
+interface ContentSnapshot {
+  readonly label: string;
+  readonly value: string;
+  readonly description: string;
+}
+
+const adminHeroStyle = buildHeroBackgroundStyle(
+  '/assets/site-visuals/photos/home-hero-workshop.avif',
+);
+
+const programSnapshots: readonly ProgramSnapshot[] = [
+  {
+    label: 'Formation',
+    status: 'Priorité élevée',
+    description:
+      'Structurer les parcours utiles, garder des formats courts et suivre les prochaines cohortes.',
+    primaryMetric: '3 formats actifs',
+  },
+  {
+    label: 'Gestion de projet',
+    status: 'À consolider',
+    description:
+      'Garder les livrables, les jalons et les besoins de cadrage visibles dans une seule vue.',
+    primaryMetric: '2 programmes à suivre',
+  },
+  {
+    label: 'Conseil en immigration',
+    status: 'Pilotage stable',
+    description:
+      'Suivre les dossiers, les preuves et les étapes de relance sans perdre la cohérence du projet.',
+    primaryMetric: '1 filière prioritaire',
+  },
+] as const;
+
+const contentSnapshots: readonly ContentSnapshot[] = [
+  {
+    label: 'Articles publiés',
+    value: `${blogArticles.length}`,
+    description: 'Contenus éditoriaux prêts pour le blog public.',
+  },
+  {
+    label: 'Articles vedettes',
+    value: `${blogArticles.filter((article) => article.featured).length}`,
+    description:
+      'Contenus à mettre en avant dans les campagnes et la page blog.',
+  },
+  {
+    label: 'Dernière mise à jour',
+    value: blogArticles[0]?.publishedLabel ?? 'N/A',
+    description: 'Dernier contenu éditorial disponible dans la bibliothèque.',
+  },
+] as const;
+
+const contentActions = [
+  {
+    label: 'Voir le blog public',
+    path: '/blog',
+    description: 'Relire le rendu public des contenus éditoriaux.',
+  },
+  {
+    label: 'Relire les programmes',
+    path: '/programmes',
+    description: 'Vérifier les textes d’orientation et les appels à l’action.',
+  },
+  {
+    label: 'Reprendre le contact',
+    path: '/contact',
+    description: 'Suivre les demandes entrantes et les points de conversion.',
+  },
+] as const;
+
+@Component({
+  selector: 'kraak-admin-dashboard-page',
+  standalone: true,
+  imports: [NgStyle, RouterLink, ButtonDirective],
+  templateUrl: './dashboard.page.html',
+})
+export default class DashboardPage implements OnInit, OnDestroy {
+  protected readonly heroBackgroundStyle = adminHeroStyle;
+  protected readonly programSnapshots = programSnapshots;
+  protected readonly contentSnapshots = contentSnapshots;
+  protected readonly contentActions = contentActions;
+  protected readonly recentArticles = blogArticles;
+
+  private readonly gsapService = inject(GsapAnimationsService);
+
+  ngOnInit(): void {
+    this.gsapService.animatePageIn();
+    this.gsapService.initializeFigureAnimations('figure.reveal-on-scroll');
+    this.gsapService.initializeInteractiveCardAnimations('article');
+    this.gsapService.initializeButtonTransitions();
+    this.gsapService.initializeSectionAnimations();
+  }
+
+  ngOnDestroy(): void {
+    this.gsapService.killAllAnimations();
+  }
+}

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.html
@@ -1,0 +1,214 @@
+@if (article) {
+  <section
+    class="relative overflow-hidden bg-cover bg-center bg-no-repeat px-4 py-20 md:px-8 lg:px-12 lg:py-28"
+    [ngStyle]="heroBackgroundStyle"
+  >
+    <div
+      aria-hidden="true"
+      class="via-brand-navy/30 to-brand-navy/80 absolute inset-0 bg-linear-to-b from-transparent"
+    ></div>
+
+    <div class="relative z-10 mx-auto max-w-4xl px-4 text-center lg:px-6">
+      <a
+        routerLink="/blog"
+        class="text-brand-white/85 text-sm font-semibold underline"
+      >
+        Retour au blog
+      </a>
+      <p
+        class="text-brand-white/85 mt-4 text-xs font-semibold tracking-[0.3em] uppercase"
+      >
+        {{ article.categoryLabel }}
+      </p>
+      <h1
+        class="text-brand-white mt-4 text-4xl leading-tight font-bold lg:text-5xl"
+      >
+        {{ article.title }}
+      </h1>
+      <p
+        class="text-brand-white/90 mx-auto mt-6 max-w-3xl text-lg leading-relaxed"
+      >
+        {{ article.summary }}
+      </p>
+      <div
+        class="text-brand-white/90 mt-8 flex flex-wrap items-center justify-center gap-3 text-sm"
+      >
+        <span>{{ article.publishedLabel }}</span>
+        <span>•</span>
+        <span>{{ article.readingTimeMinutes }} min de lecture</span>
+        <span>•</span>
+        <span>{{ article.author.name }}</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-brand-white py-16">
+    <div
+      class="mx-auto grid max-w-6xl gap-10 px-4 lg:grid-cols-[1.1fr_0.9fr] lg:px-6"
+    >
+      <article>
+        <figure
+          class="reveal-on-scroll rounded-card shadow-card overflow-hidden"
+        >
+          <img
+            [src]="article.coverImagePath"
+            [alt]="article.title"
+            class="h-72 w-full object-cover"
+            loading="eager"
+          />
+        </figure>
+
+        <div class="mt-10 space-y-10">
+          <p class="text-brand-navy text-lg leading-relaxed">
+            {{ article.intro }}
+          </p>
+
+          @for (section of article.sections; track section.heading) {
+            <section class="rounded-card bg-neutral-50 p-6">
+              <h2 class="text-2xl font-bold">{{ section.heading }}</h2>
+              @for (paragraph of section.paragraphs; track paragraph) {
+                <p class="mt-4 leading-relaxed text-neutral-700">
+                  {{ paragraph }}
+                </p>
+              }
+              @if (section.bullets?.length) {
+                <ul class="mt-4 list-disc space-y-2 pl-5 text-neutral-700">
+                  @for (bullet of section.bullets; track bullet) {
+                    <li>{{ bullet }}</li>
+                  }
+                </ul>
+              }
+            </section>
+          }
+
+          <section class="rounded-card bg-brand-blue/5 p-6">
+            <h2 class="text-2xl font-bold">À retenir</h2>
+            <ul class="mt-4 space-y-3">
+              @for (point of article.takeawayPoints; track point) {
+                <li class="flex gap-3 text-neutral-700">
+                  <i
+                    class="pi pi-check-circle text-brand-blue mt-1"
+                    aria-hidden="true"
+                  ></i>
+                  <span>{{ point }}</span>
+                </li>
+              }
+            </ul>
+          </section>
+        </div>
+      </article>
+
+      <aside class="space-y-6">
+        <section class="rounded-card bg-neutral-50 p-6 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            Auteur
+          </p>
+          <div class="mt-4 flex items-center gap-4">
+            <img
+              [src]="article.author.avatar"
+              [alt]="article.author.name"
+              class="h-16 w-16 rounded-full object-cover"
+              loading="lazy"
+            />
+            <div>
+              <h2 class="text-brand-navy text-xl font-bold">
+                {{ article.author.name }}
+              </h2>
+              <p class="text-neutral-600">{{ article.author.role }}</p>
+            </div>
+          </div>
+          <p class="mt-4 leading-relaxed text-neutral-700">
+            {{ article.author.bio }}
+          </p>
+        </section>
+
+        <section class="rounded-card bg-neutral-50 p-6 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            Catégorie et tags
+          </p>
+          <p class="mt-3 text-lg font-semibold">{{ article.categoryLabel }}</p>
+          <div class="mt-4 flex flex-wrap gap-2">
+            @for (tag of article.tagLabels; track tag) {
+              <span
+                class="rounded-full bg-white px-3 py-1 text-sm text-neutral-700 shadow-sm"
+              >
+                {{ tag }}
+              </span>
+            }
+          </div>
+        </section>
+
+        <section class="rounded-card bg-neutral-50 p-6 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            À lire aussi
+          </p>
+          <div class="mt-4 space-y-4">
+            @for (related of relatedArticles; track related.slug) {
+              <article class="rounded-card bg-brand-white p-4 shadow-sm">
+                <p class="text-brand-blue text-sm font-semibold">
+                  {{ related.categoryLabel }}
+                </p>
+                <h3 class="mt-2 text-lg font-bold">{{ related.title }}</h3>
+                <a
+                  [routerLink]="['/blog', related.slug]"
+                  class="text-brand-blue mt-3 inline-flex font-semibold"
+                >
+                  Lire l'article
+                </a>
+              </article>
+            }
+          </div>
+        </section>
+      </aside>
+    </div>
+  </section>
+
+  <kraak-cta-banner
+    heading="Vous voulez aller plus loin ?"
+    body="L'article a peut-être clarifié votre prochain pas. Si vous souhaitez un cadrage plus précis, nous pouvons vous aider à le formaliser."
+    ctaLabel="Parler à KRAAK"
+    ctaLink="/contact"
+    ctaContext="blog_article_cta"
+  />
+} @else {
+  <section class="bg-brand-white py-20">
+    <div class="mx-auto max-w-4xl px-4 text-center lg:px-6">
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+      >
+        Article introuvable
+      </p>
+      <h1 class="mt-4 text-4xl font-bold lg:text-5xl">
+        Cet article n’est pas disponible.
+      </h1>
+      <p class="text-brand-navy mx-auto mt-6 max-w-2xl text-lg leading-relaxed">
+        Le contenu demandé n’a pas été retrouvé dans la bibliothèque éditoriale
+        KRAAK.
+      </p>
+      <div
+        class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
+      >
+        <a
+          pButton
+          routerLink="/blog"
+          label="Retour au blog"
+          class="kr-button-primary"
+          >Retour au blog</a
+        >
+        <a
+          pButton
+          routerLink="/contact"
+          label="Nous contacter"
+          class="kr-button-ghost"
+          >Nous contacter</a
+        >
+      </div>
+    </div>
+  </section>
+}

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
@@ -4,6 +4,7 @@ import {
   convertToParamMap,
   provideRouter,
 } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
 import { vi } from 'vitest';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
@@ -31,9 +32,15 @@ describe('BlogArticlePage', () => {
   const seoServiceMock = {
     applyPageSeo: vi.fn(),
   };
+  let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
 
   beforeEach(async () => {
     seoServiceMock.applyPageSeo.mockReset();
+    paramMapSubject = new BehaviorSubject(
+      convertToParamMap({
+        slug: 'clarifier-son-projet-avant-de-candidater',
+      }),
+    );
 
     await TestBed.configureTestingModule({
       imports: [BlogArticlePage],
@@ -55,6 +62,7 @@ describe('BlogArticlePage', () => {
                 slug: 'clarifier-son-projet-avant-de-candidater',
               }),
             },
+            paramMap: paramMapSubject.asObservable(),
           },
         },
       ],
@@ -88,6 +96,31 @@ describe('BlogArticlePage', () => {
       expect.objectContaining({
         path: 'blog/clarifier-son-projet-avant-de-candidater',
         title: 'Clarifier son projet avant de candidater | KRAAK Consulting',
+      }),
+    );
+  });
+
+  it('Given the same component instance When the slug route parameter changes Then article state and SEO are updated', () => {
+    const fixture = TestBed.createComponent(BlogArticlePage);
+    fixture.detectChanges();
+
+    seoServiceMock.applyPageSeo.mockClear();
+
+    paramMapSubject.next(
+      convertToParamMap({
+        slug: 'preparer-un-dossier-immigration-sans-perdre-le-fil',
+      }),
+    );
+    expect(
+      (
+        fixture.componentInstance as unknown as {
+          article?: { slug: string };
+        }
+      ).article?.slug,
+    ).toBe('preparer-un-dossier-immigration-sans-perdre-le-fil');
+    expect(seoServiceMock.applyPageSeo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'blog/preparer-un-dossier-immigration-sans-perdre-le-fil',
       }),
     );
   });

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+} from '@angular/router';
+import { vi } from 'vitest';
+
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { SeoService } from '../../seo/seo.service';
+import BlogArticlePage from './blog-article.page';
+
+const gsapAnimationsServiceMock: Pick<
+  GsapAnimationsService,
+  | 'animatePageIn'
+  | 'initializeFigureAnimations'
+  | 'initializeInteractiveCardAnimations'
+  | 'initializeButtonTransitions'
+  | 'initializeSectionAnimations'
+  | 'killAllAnimations'
+> = {
+  animatePageIn: () => undefined,
+  initializeFigureAnimations: () => undefined,
+  initializeInteractiveCardAnimations: () => undefined,
+  initializeButtonTransitions: () => undefined,
+  initializeSectionAnimations: () => undefined,
+  killAllAnimations: () => undefined,
+};
+
+describe('BlogArticlePage', () => {
+  const seoServiceMock = {
+    applyPageSeo: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    seoServiceMock.applyPageSeo.mockReset();
+
+    await TestBed.configureTestingModule({
+      imports: [BlogArticlePage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: SeoService,
+          useValue: seoServiceMock,
+        },
+        {
+          provide: GsapAnimationsService,
+          useValue: gsapAnimationsServiceMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({
+                slug: 'clarifier-son-projet-avant-de-candidater',
+              }),
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('Given the article page component When it is created Then the instance exists', () => {
+    const fixture = TestBed.createComponent(BlogArticlePage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the article page When it renders Then it shows the article headline and details', () => {
+    const fixture = TestBed.createComponent(BlogArticlePage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Clarifier son projet avant de candidater');
+    expect(content).toContain('1. Commencez par le résultat attendu');
+    expect(content).toContain('À retenir');
+    expect(content).toContain('Aline Koné');
+    expect(content).toContain('Retour au blog');
+  });
+
+  it('Given the article page When it initializes Then it applies article specific SEO', () => {
+    const fixture = TestBed.createComponent(BlogArticlePage);
+    fixture.detectChanges();
+
+    expect(seoServiceMock.applyPageSeo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'blog/clarifier-son-projet-avant-de-candidater',
+        title: 'Clarifier son projet avant de candidater | KRAAK Consulting',
+      }),
+    );
+  });
+});

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
@@ -1,0 +1,55 @@
+import { NgStyle } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
+import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
+import { SeoService } from '../../seo/seo.service';
+import {
+  buildBlogArticleSeo,
+  buildMissingBlogArticleSeo,
+  findBlogArticleBySlug,
+  getRelatedBlogArticles,
+} from './blog.data';
+
+@Component({
+  selector: 'kraak-blog-article-page',
+  standalone: true,
+  imports: [NgStyle, RouterLink, ButtonDirective, CtaBanner],
+  templateUrl: './blog-article.page.html',
+})
+export default class BlogArticlePage implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly seoService = inject(SeoService);
+  private readonly gsapService = inject(GsapAnimationsService);
+  private readonly slug = this.route.snapshot.paramMap.get('slug') ?? '';
+
+  protected readonly article = findBlogArticleBySlug(this.slug);
+  protected readonly relatedArticles = this.article
+    ? getRelatedBlogArticles(this.article)
+    : [];
+  protected readonly heroBackgroundStyle = buildHeroBackgroundStyle(
+    this.article?.coverImagePath ??
+      '/assets/site-visuals/photos/home-hero-workshop.avif',
+  );
+
+  ngOnInit(): void {
+    this.gsapService.animatePageIn();
+    this.gsapService.initializeFigureAnimations('figure.reveal-on-scroll');
+    this.gsapService.initializeInteractiveCardAnimations('article');
+    this.gsapService.initializeButtonTransitions();
+    this.gsapService.initializeSectionAnimations();
+
+    this.seoService.applyPageSeo(
+      this.article
+        ? buildBlogArticleSeo(this.article)
+        : buildMissingBlogArticleSeo(this.slug),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.gsapService.killAllAnimations();
+  }
+}

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
@@ -1,13 +1,22 @@
 import { NgStyle } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  OnDestroy,
+  OnInit,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
+import { startWith } from 'rxjs';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { SeoService } from '../../seo/seo.service';
 import {
+  type BlogArticle,
   buildBlogArticleSeo,
   buildMissingBlogArticleSeo,
   findBlogArticleBySlug,
@@ -22,17 +31,14 @@ import {
 })
 export default class BlogArticlePage implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
   private readonly seoService = inject(SeoService);
   private readonly gsapService = inject(GsapAnimationsService);
-  private readonly slug = this.route.snapshot.paramMap.get('slug') ?? '';
 
-  protected readonly article = findBlogArticleBySlug(this.slug);
-  protected readonly relatedArticles = this.article
-    ? getRelatedBlogArticles(this.article)
-    : [];
-  protected readonly heroBackgroundStyle = buildHeroBackgroundStyle(
-    this.article?.coverImagePath ??
-      '/assets/site-visuals/photos/home-hero-workshop.avif',
+  protected article: BlogArticle | undefined;
+  protected relatedArticles: readonly BlogArticle[] = [];
+  protected heroBackgroundStyle = buildHeroBackgroundStyle(
+    '/assets/site-visuals/photos/home-hero-workshop.avif',
   );
 
   ngOnInit(): void {
@@ -42,14 +48,30 @@ export default class BlogArticlePage implements OnInit, OnDestroy {
     this.gsapService.initializeButtonTransitions();
     this.gsapService.initializeSectionAnimations();
 
-    this.seoService.applyPageSeo(
-      this.article
-        ? buildBlogArticleSeo(this.article)
-        : buildMissingBlogArticleSeo(this.slug),
-    );
+    this.route.paramMap
+      .pipe(startWith(this.route.snapshot.paramMap))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((params) => this.applyPageState(params.get('slug') ?? ''));
   }
 
   ngOnDestroy(): void {
     this.gsapService.killAllAnimations();
+  }
+
+  private applyPageState(slug: string): void {
+    this.article = findBlogArticleBySlug(slug);
+    this.relatedArticles = this.article
+      ? getRelatedBlogArticles(this.article)
+      : [];
+    this.heroBackgroundStyle = buildHeroBackgroundStyle(
+      this.article?.coverImagePath ??
+        '/assets/site-visuals/photos/home-hero-workshop.avif',
+    );
+
+    this.seoService.applyPageSeo(
+      this.article
+        ? buildBlogArticleSeo(this.article)
+        : buildMissingBlogArticleSeo(slug),
+    );
   }
 }

--- a/apps/client/projects/web/src/app/features/blog/blog.data.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.data.ts
@@ -1,0 +1,321 @@
+import type { SeoPageDefinition } from '../../seo/site-seo';
+
+export interface BlogSection {
+  heading: string;
+  paragraphs: readonly string[];
+  bullets?: readonly string[];
+}
+
+export interface BlogAuthor {
+  name: string;
+  role: string;
+  bio: string;
+  avatar: string;
+}
+
+export interface BlogArticle {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+  status: 'draft' | 'published' | 'archived';
+  coverImageUrl: string | null;
+  seoTitle: string | null;
+  seoDescription: string | null;
+  publishedAt: string | null;
+  authorId: string;
+  categoryIds: readonly string[];
+  tagIds: readonly string[];
+  createdAt?: string;
+  updatedAt?: string;
+  readonly author: BlogAuthor;
+  readonly categoryLabel: string;
+  readonly categorySlug: string;
+  readonly tagLabels: readonly string[];
+  readonly coverImagePath: string;
+  readonly readingTimeMinutes: number;
+  readonly publishedLabel: string;
+  readonly summary: string;
+  readonly intro: string;
+  readonly sections: readonly BlogSection[];
+  readonly takeawayPoints: readonly string[];
+  readonly relatedSlugs: readonly string[];
+  readonly featured: boolean;
+}
+
+const articleBase = {
+  status: 'published' as const,
+  publishedAt: '2026-05-24T09:00:00.000Z',
+  coverImageUrl: null,
+  seoTitle: null,
+  seoDescription: null,
+};
+
+export const blogArticles: readonly BlogArticle[] = [
+  {
+    ...articleBase,
+    id: 'blog-1',
+    slug: 'clarifier-son-projet-avant-de-candidater',
+    title: 'Clarifier son projet avant de candidater',
+    excerpt:
+      'Avant de multiplier les candidatures, il faut savoir ce que vous cherchez, ce que vous apportez et ce que vous pouvez prouver.',
+    content:
+      '<p>Un projet clair aide à choisir le bon format, à préparer des preuves utiles et à éviter les démarches dispersées.</p>',
+    authorId: 'author-aline',
+    categoryIds: ['category-employabilite'],
+    tagIds: ['tag-orientation', 'tag-candidature', 'tag-leadership'],
+    author: {
+      name: 'Aline Koné',
+      role: 'Conseillère KRAAK',
+      bio: 'Elle accompagne les jeunes professionnels à transformer une intention floue en trajectoire actionnable.',
+      avatar: '/assets/site-visuals/photos/home-services-training.avif',
+    },
+    categoryLabel: 'Employabilité',
+    categorySlug: 'employabilite',
+    tagLabels: ['Orientation', 'Candidature', 'Leadership'],
+    coverImagePath:
+      '/assets/site-visuals/photos/home-services-project-planning.avif',
+    readingTimeMinutes: 4,
+    publishedLabel: '12 mai 2026',
+    summary:
+      'Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.',
+    intro:
+      'La première erreur n’est pas de mal candidater. C’est souvent de candidater sans avoir défini le rôle visé, les preuves disponibles et le format d’appui utile.',
+    sections: [
+      {
+        heading: '1. Commencez par le résultat attendu',
+        paragraphs: [
+          'Définissez le rôle, le contexte et le délai. Une candidature utile répond à un objectif précis et à un horizon réaliste.',
+          'Quand l’objectif est stable, il devient plus simple de choisir les expériences, les formations et les exemples à mettre en avant.',
+        ],
+        bullets: [
+          'Quel poste ou quelle mission visez-vous ?',
+          'Dans quel délai voulez-vous avancer ?',
+          'Quelles contraintes devez-vous respecter ?',
+        ],
+      },
+      {
+        heading: '2. Séparez les preuves des intentions',
+        paragraphs: [
+          'Une fiche claire doit distinguer ce que vous souhaitez faire de ce que vous pouvez déjà démontrer.',
+          'Cette distinction permet de structurer un CV, un portfolio ou un entretien avec plus de précision.',
+        ],
+      },
+      {
+        heading: '3. Choisissez un prochain pas utile',
+        paragraphs: [
+          'Le bon prochain pas n’est pas toujours un nouveau dossier. Il peut s’agir d’une séance d’orientation, d’une mise à jour de CV ou d’un programme ciblé.',
+        ],
+      },
+    ],
+    takeawayPoints: [
+      'Un objectif clair simplifie toutes les autres décisions.',
+      'Les preuves doivent être sélectionnées avant d’être embellies.',
+      'La prochaine étape doit rester actionnable et datée.',
+    ],
+    relatedSlugs: [
+      'choisir-un-format-de-formation-utile',
+      'preparer-un-dossier-immigration-sans-perdre-le-fil',
+    ],
+    featured: true,
+  },
+  {
+    ...articleBase,
+    id: 'blog-2',
+    slug: 'choisir-un-format-de-formation-utile',
+    title: 'Choisir un format de formation utile',
+    excerpt:
+      'Une formation n’est utile que si elle répond à une situation précise, à une contrainte claire et à une progression mesurable.',
+    content:
+      '<p>Le meilleur format n’est pas forcément le plus long. C’est celui qui vous aide à bouger avec méthode.</p>',
+    authorId: 'author-joel',
+    categoryIds: ['category-formation'],
+    tagIds: ['tag-formation', 'tag-competences', 'tag-progress'],
+    author: {
+      name: 'Joël Nguessan',
+      role: 'Chef de programme',
+      bio: 'Il conçoit des formats courts et structurés pour faire progresser les participants sans les perdre dans la théorie.',
+      avatar: '/assets/site-visuals/photos/home-services-training.avif',
+    },
+    categoryLabel: 'Formation',
+    categorySlug: 'formation',
+    tagLabels: ['Formation', 'Compétences', 'Progression'],
+    coverImagePath: '/assets/site-visuals/photos/home-services-training.avif',
+    readingTimeMinutes: 3,
+    publishedLabel: '20 mai 2026',
+    summary:
+      'Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.',
+    intro:
+      'Le bon format de formation n’est pas un catalogue. C’est une réponse calibrée à une situation précise.',
+    sections: [
+      {
+        heading: '1. Vérifiez le besoin réel',
+        paragraphs: [
+          'Avant de choisir, clarifiez le problème à résoudre. S’agit-il d’un manque de méthode, d’un besoin de pratique ou d’une montée en posture ?',
+        ],
+      },
+      {
+        heading: '2. Choisissez le niveau de densité',
+        paragraphs: [
+          'Un atelier intensif aide à débloquer un point précis. Un parcours plus long aide à installer des habitudes durables.',
+        ],
+      },
+      {
+        heading: '3. Préparez la mesure du progrès',
+        paragraphs: [
+          'Si l’on ne peut pas observer une différence après le format choisi, il faut probablement ajuster l’objectif ou le format.',
+        ],
+      },
+    ],
+    takeawayPoints: [
+      'Le besoin précède toujours le format.',
+      'La densité doit correspondre au niveau d’urgence.',
+      'Le progrès doit être observable.',
+    ],
+    relatedSlugs: [
+      'clarifier-son-projet-avant-de-candidater',
+      'preparer-un-dossier-immigration-sans-perdre-le-fil',
+    ],
+    featured: false,
+  },
+  {
+    ...articleBase,
+    id: 'blog-3',
+    slug: 'preparer-un-dossier-immigration-sans-perdre-le-fil',
+    title: 'Préparer un dossier immigration sans perdre le fil',
+    excerpt:
+      'Un dossier se fragilise quand les pièces ne racontent plus la même histoire. L’enjeu est de garder une cohérence d’ensemble.',
+    content:
+      '<p>La qualité d’un dossier ne se joue pas seulement sur les documents. Elle dépend aussi de la cohérence entre le récit, les preuves et le calendrier.</p>',
+    authorId: 'author-marie',
+    categoryIds: ['category-immigration'],
+    tagIds: ['tag-immigration', 'tag-dossier', 'tag-preparation'],
+    author: {
+      name: 'Marie Ahoua',
+      role: 'Conseillère mobilité',
+      bio: 'Elle accompagne les profils internationaux dans la préparation structurée de leurs projets d’études et de travail.',
+      avatar: '/assets/site-visuals/photos/services-immigration.avif',
+    },
+    categoryLabel: 'Immigration',
+    categorySlug: 'immigration',
+    tagLabels: ['Immigration', 'Dossier', 'Préparation'],
+    coverImagePath: '/assets/site-visuals/photos/services-immigration.avif',
+    readingTimeMinutes: 5,
+    publishedLabel: '24 mai 2026',
+    summary:
+      'Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.',
+    intro:
+      'Le dossier le plus solide n’est pas forcément le plus long. C’est celui qui reste cohérent du début à la fin.',
+    sections: [
+      {
+        heading: '1. Construisez un fil conducteur',
+        paragraphs: [
+          'Avant de remplir un formulaire, rédigez en une phrase le projet que vous défendez. Cette phrase servira de repère pour toutes les pièces.',
+        ],
+      },
+      {
+        heading: '2. Rassemblez les preuves dans le bon ordre',
+        paragraphs: [
+          'Un dossier clair aligne les preuves sur la logique du projet: identité, formation, expérience, ressources, calendrier.',
+        ],
+      },
+      {
+        heading: '3. Gardez une marge de sécurité',
+        paragraphs: [
+          'Les délais, les traductions et les compléments administratifs demandent de la marge. Ne travaillez pas au bord de l’échéance.',
+        ],
+      },
+    ],
+    takeawayPoints: [
+      'Un projet clair simplifie le tri des pièces.',
+      'L’ordre des preuves compte autant que leur présence.',
+      'La marge de sécurité réduit les erreurs évitables.',
+    ],
+    relatedSlugs: [
+      'clarifier-son-projet-avant-de-candidater',
+      'choisir-un-format-de-formation-utile',
+    ],
+    featured: false,
+  },
+] as const;
+
+export const blogListSeo: SeoPageDefinition = {
+  path: 'blog',
+  title: 'Blog | Actualités et analyses KRAAK Consulting',
+  description:
+    'Découvrez les articles KRAAK sur l’employabilité, la formation, la gestion de projet et la mobilité internationale.',
+  openGraph: {
+    title: 'Blog KRAAK Consulting',
+    description:
+      'Un espace éditorial public pour clarifier un projet, préparer une candidature et mieux choisir son prochain pas.',
+    imagePath: '/assets/site-visuals/photos/home-hero-workshop.jpg',
+    imageAlt:
+      "Photo d'un atelier KRAAK Consulting avec des participants en session de travail.",
+  },
+  sitemap: {
+    changeFrequency: 'weekly',
+    priority: 0.75,
+  },
+};
+
+export function buildBlogArticleSeo(article: BlogArticle): SeoPageDefinition {
+  return {
+    path: `blog/${article.slug}`,
+    title: `${article.title} | KRAAK Consulting`,
+    description: article.seoDescription ?? article.summary,
+    openGraph: {
+      title: article.seoTitle ?? article.title,
+      description: article.seoDescription ?? article.summary,
+      imagePath: article.coverImagePath,
+      imageAlt: `Illustration de l'article ${article.title}`,
+    },
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  };
+}
+
+export function buildMissingBlogArticleSeo(slug: string): SeoPageDefinition {
+  return {
+    path: `blog/${slug}`,
+    title: 'Article introuvable | KRAAK Consulting',
+    description:
+      'L’article demandé n’est pas disponible. Retournez au blog KRAAK pour poursuivre votre lecture.',
+    openGraph: {
+      title: 'Article introuvable | KRAAK Consulting',
+      description:
+        'L’article demandé n’est pas disponible. Retournez au blog KRAAK pour poursuivre votre lecture.',
+      imagePath: '/assets/site-visuals/photos/home-hero-workshop.jpg',
+      imageAlt:
+        "Photo d'un atelier KRAAK Consulting avec des participants en session de travail.",
+    },
+    sitemap: {
+      changeFrequency: 'never',
+      priority: 0.1,
+    },
+  };
+}
+
+export function findBlogArticleBySlug(slug: string): BlogArticle | undefined {
+  return blogArticles.find((article) => article.slug === slug);
+}
+
+export function getRelatedBlogArticles(
+  article: BlogArticle,
+  limit = 3,
+): BlogArticle[] {
+  return blogArticles
+    .filter((candidate) => candidate.slug !== article.slug)
+    .map((candidate) => ({
+      candidate,
+      score:
+        (candidate.categorySlug === article.categorySlug ? 2 : 0) +
+        candidate.tagLabels.filter((tag) => article.tagLabels.includes(tag))
+          .length,
+    }))
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+}

--- a/apps/client/projects/web/src/app/features/blog/blog.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.html
@@ -103,7 +103,8 @@
           icon="pi pi-arrow-right"
           class="kr-button-primary mt-8"
           aria-label="Lire l'article vedette"
-        ></a>
+          >Lire l'article</a
+        >
       </article>
 
       <aside class="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">

--- a/apps/client/projects/web/src/app/features/blog/blog.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.html
@@ -1,0 +1,199 @@
+<section
+  class="relative overflow-hidden bg-cover bg-center bg-no-repeat px-4 py-20 md:px-8 lg:px-12 lg:py-28"
+  [ngStyle]="heroBackgroundStyle"
+>
+  <div
+    aria-hidden="true"
+    class="via-brand-navy/30 to-brand-navy/80 absolute inset-0 bg-linear-to-b from-transparent"
+  ></div>
+
+  <div class="relative z-10 mx-auto max-w-5xl px-4 text-center lg:px-6">
+    <p
+      class="text-brand-white/85 text-xs font-semibold tracking-[0.3em] uppercase"
+    >
+      Blog KRAAK
+    </p>
+    <h1
+      class="text-brand-white mt-4 text-4xl leading-tight font-bold lg:text-5xl"
+    >
+      Actualités, repères et analyses pour avancer avec clarté.
+    </h1>
+    <p
+      class="text-brand-white/90 mx-auto mt-6 max-w-3xl text-lg leading-relaxed"
+    >
+      Nous publions des articles courts et utiles pour aider les jeunes
+      professionnels, les porteurs de projets et les organisations à prendre une
+      prochaine décision plus lisible.
+    </p>
+    <div
+      class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
+    >
+      <a
+        pButton
+        routerLink="/contact"
+        label="Demander un accompagnement"
+        icon="pi pi-comments"
+        aria-label="Demander un accompagnement"
+        class="kr-button-primary"
+      ></a>
+      <a
+        pButton
+        routerLink="/services"
+        label="Voir les services"
+        icon="pi pi-compass"
+        aria-label="Voir les services"
+        class="kr-button-ghost"
+      ></a>
+    </div>
+  </div>
+</section>
+
+<section class="bg-brand-white py-14">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <div class="grid gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:items-stretch">
+      <article class="rounded-card bg-neutral-50 p-8 shadow-sm">
+        <p
+          class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+        >
+          Article vedette
+        </p>
+        <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
+          {{ featuredArticle.title }}
+        </h2>
+        <p class="text-brand-navy mt-4 text-lg leading-relaxed">
+          {{ featuredArticle.summary }}
+        </p>
+
+        <div class="mt-6 flex flex-wrap gap-3">
+          <span
+            class="bg-brand-blue/10 rounded-full px-4 py-2 text-sm font-semibold"
+          >
+            {{ featuredArticle.categoryLabel }}
+          </span>
+          @for (tag of featuredArticle.tagLabels; track tag) {
+            <span
+              class="rounded-full bg-neutral-200 px-4 py-2 text-sm text-neutral-700"
+            >
+              {{ tag }}
+            </span>
+          }
+        </div>
+
+        <div class="mt-8 flex items-center gap-4">
+          <img
+            [src]="featuredArticle.author.avatar"
+            [alt]="featuredArticle.author.name"
+            class="h-14 w-14 rounded-full object-cover"
+            loading="lazy"
+          />
+          <div>
+            <p class="text-brand-navy font-semibold">
+              {{ featuredArticle.author.name }}
+            </p>
+            <p class="text-sm text-neutral-600">
+              {{ featuredArticle.author.role }}
+            </p>
+          </div>
+        </div>
+
+        <a
+          pButton
+          [routerLink]="['/blog', featuredArticle.slug]"
+          label="Lire l'article"
+          icon="pi pi-arrow-right"
+          class="kr-button-primary mt-8"
+          aria-label="Lire l'article vedette"
+        ></a>
+      </article>
+
+      <aside class="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+        @for (category of categories; track category.label) {
+          <article
+            class="rounded-card bg-brand-white border border-neutral-200 p-6 shadow-sm"
+          >
+            <h3 class="text-brand-navy text-lg font-semibold">
+              {{ category.label }}
+            </h3>
+            <p class="mt-2 text-neutral-700">{{ category.description }}</p>
+          </article>
+        }
+      </aside>
+    </div>
+  </div>
+</section>
+
+<section class="bg-neutral-50 py-16">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    <div class="flex flex-col gap-4 text-center">
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+      >
+        Derniers articles
+      </p>
+      <h2 class="text-3xl font-bold lg:text-4xl">
+        Des lectures courtes pour mieux choisir votre prochain pas.
+      </h2>
+      <p class="text-brand-navy mx-auto max-w-3xl text-lg">
+        Chaque article reste orienté vers une action utile, sans surcharger le
+        lecteur avec un vocabulaire inutilement technique.
+      </p>
+    </div>
+
+    <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+      @for (article of articles; track article.slug) {
+        <article
+          class="reveal-on-scroll rounded-card bg-brand-white shadow-card overflow-hidden"
+        >
+          <img
+            [src]="article.coverImagePath"
+            [alt]="article.title"
+            class="h-52 w-full object-cover"
+            loading="lazy"
+          />
+          <div class="p-6">
+            <div class="flex items-center gap-3 text-sm text-neutral-600">
+              <span class="text-brand-blue font-semibold">{{
+                article.categoryLabel
+              }}</span>
+              <span>•</span>
+              <span>{{ article.publishedLabel }}</span>
+              <span>•</span>
+              <span>{{ article.readingTimeMinutes }} min</span>
+            </div>
+            <h3 class="mt-4 text-2xl leading-tight font-bold">
+              {{ article.title }}
+            </h3>
+            <p class="mt-3 leading-relaxed text-neutral-700">
+              {{ article.summary }}
+            </p>
+
+            <div class="mt-5 flex flex-wrap gap-2">
+              @for (tag of article.tagLabels; track tag) {
+                <span
+                  class="rounded-full bg-neutral-100 px-3 py-1 text-xs text-neutral-600"
+                >
+                  {{ tag }}
+                </span>
+              }
+            </div>
+
+            <a
+              [routerLink]="['/blog', article.slug]"
+              class="text-brand-blue mt-6 inline-flex font-semibold"
+            >
+              Lire l'article
+            </a>
+          </div>
+        </article>
+      }
+    </div>
+  </div>
+</section>
+
+<kraak-cta-banner
+  heading="Vous avez un besoin plus spécifique ?"
+  body="Chaque article peut devenir un point de départ pour clarifier un besoin, choisir un service ou lancer un premier échange avec l'équipe KRAAK."
+  ctaLabel="Nous contacter"
+  ctaLink="/contact"
+  ctaContext="blog_main_cta"
+/>

--- a/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import BlogPage from './blog.page';
+
+const gsapAnimationsServiceMock: Pick<
+  GsapAnimationsService,
+  | 'animatePageIn'
+  | 'initializeFigureAnimations'
+  | 'initializeInteractiveCardAnimations'
+  | 'initializeButtonTransitions'
+  | 'initializeSectionAnimations'
+  | 'killAllAnimations'
+> = {
+  animatePageIn: () => undefined,
+  initializeFigureAnimations: () => undefined,
+  initializeInteractiveCardAnimations: () => undefined,
+  initializeButtonTransitions: () => undefined,
+  initializeSectionAnimations: () => undefined,
+  killAllAnimations: () => undefined,
+};
+
+describe('BlogPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BlogPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: GsapAnimationsService,
+          useValue: gsapAnimationsServiceMock,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('Given the blog page component When it is created Then the instance exists', () => {
+    const fixture = TestBed.createComponent(BlogPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the blog page When it renders Then it shows the editorial hero and featured article', () => {
+    const fixture = TestBed.createComponent(BlogPage);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain(
+      'Actualités, repères et analyses pour avancer avec clarté.',
+    );
+    expect(content).toContain('Article vedette');
+    expect(content).toContain('Clarifier son projet avant de candidater');
+    expect(content).toContain('Choisir un format de formation utile');
+    expect(content).toContain(
+      'Préparer un dossier immigration sans perdre le fil',
+    );
+  });
+});

--- a/apps/client/projects/web/src/app/features/blog/blog.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.ts
@@ -1,0 +1,47 @@
+import { NgStyle } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
+import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
+import { blogArticles } from './blog.data';
+
+const BLOG_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
+  '/assets/site-visuals/photos/home-hero-workshop.avif',
+);
+
+@Component({
+  selector: 'kraak-blog-page',
+  standalone: true,
+  imports: [NgStyle, RouterLink, ButtonDirective, CtaBanner],
+  templateUrl: './blog.page.html',
+})
+export default class BlogPage implements OnInit, OnDestroy {
+  protected readonly heroBackgroundStyle = BLOG_HERO_BACKGROUND_STYLE;
+  protected readonly featuredArticle = blogArticles[0];
+  protected readonly articles = blogArticles;
+  protected readonly categories = [
+    { label: 'Employabilité', description: 'Projet, candidature et posture.' },
+    { label: 'Formation', description: 'Formats utiles et progression.' },
+    {
+      label: 'Immigration',
+      description: 'Dossiers, cohérence et préparation.',
+    },
+  ] as const;
+
+  private readonly gsapService = inject(GsapAnimationsService);
+
+  ngOnInit(): void {
+    this.gsapService.animatePageIn();
+    this.gsapService.initializeFigureAnimations('figure.reveal-on-scroll');
+    this.gsapService.initializeInteractiveCardAnimations('article');
+    this.gsapService.initializeButtonTransitions();
+    this.gsapService.initializeSectionAnimations();
+  }
+
+  ngOnDestroy(): void {
+    this.gsapService.killAllAnimations();
+  }
+}

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
@@ -23,7 +23,7 @@ export class Footer {
 
   protected readonly navigationLinks: FooterLink[] = [
     { label: '\u00C0 propos', path: '/a-propos' },
-    { label: 'Actualit\u00E9s', path: '/ressources' },
+    { label: 'Blog', path: '/blog' },
     { label: 'Services', path: '/services' },
     { label: 'FAQ', path: '/faq' },
     { label: 'Programmes', path: '/programmes' },

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.ts
@@ -20,6 +20,7 @@ export class Navbar {
     { label: '\u00C0 propos', path: '/a-propos' },
     { label: 'Services', path: '/services' },
     { label: 'Programmes', path: '/programmes' },
+    { label: 'Blog', path: '/blog' },
     { label: 'Contact', path: '/contact' },
   ];
 

--- a/apps/client/projects/web/src/app/seo/site-seo.json
+++ b/apps/client/projects/web/src/app/seo/site-seo.json
@@ -60,6 +60,21 @@
     }
   },
   {
+    "path": "blog",
+    "title": "Blog | Actualités et analyses KRAAK Consulting",
+    "description": "Découvrez les articles KRAAK sur l’employabilité, la formation, la gestion de projet et la mobilité internationale.",
+    "openGraph": {
+      "title": "Blog KRAAK Consulting",
+      "description": "Un espace éditorial public pour clarifier un projet, préparer une candidature et mieux choisir son prochain pas.",
+      "imagePath": "/assets/site-visuals/photos/home-hero-workshop.jpg",
+      "imageAlt": "Photo d'un atelier KRAAK Consulting avec des participants en session de travail."
+    },
+    "sitemap": {
+      "changeFrequency": "weekly",
+      "priority": 0.75
+    }
+  },
+  {
     "path": "ressources",
     "title": "Ressources d'orientation | Formation, projet et immigration | KRAAK",
     "description": "Une page d'orientation vitrine pour clarifier votre prochaine \u00e9tape entre formation, projet, immigration, programme ou solution entreprise.",

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -18,6 +18,7 @@ describe('site-seo', () => {
       'a-propos',
       'services',
       'programmes',
+      'blog',
       'ressources',
       'contact',
       'faq',
@@ -33,6 +34,7 @@ describe('site-seo', () => {
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/a-propos</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/services</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/programmes</loc>`);
+    expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/blog</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/ressources</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/contact</loc>`);
   });

--- a/packages/contracts/src/dto.spec.ts
+++ b/packages/contracts/src/dto.spec.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import type {
   AppUserDto,
+  AuthorDto,
+  ArticleDto,
+  CategoryDto,
   CreateAppUserDto,
+  CreateAuthorDto,
+  CreateArticleDto,
+  CreateCategoryDto,
   UpdateAppUserDto,
   ContactFormDto,
   ContactSubmissionResultDto,
@@ -31,7 +37,13 @@ import type {
   CreateNotificationDto,
   SupportRequestDto,
   CreateSupportRequestDto,
+  CreateTagDto,
+  TagDto,
   UpdateSupportRequestDto,
+  UpdateAuthorDto,
+  UpdateArticleDto,
+  UpdateCategoryDto,
+  UpdateTagDto,
   DashboardAggregateDto,
   DashboardProgramSummaryDto,
   DashboardSessionReminderDto,
@@ -247,6 +259,115 @@ describe('ProgramAnnouncementPreviewDto', () => {
     expectTypeOf<ProgramAnnouncementPreviewDto>()
       .toHaveProperty('publishedAt')
       .toEqualTypeOf<string | null>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CMS / Editorial model
+// ---------------------------------------------------------------------------
+describe('AuthorDto', () => {
+  it('Given an editorial author contract When inspected Then required author fields are exposed', () => {
+    expectTypeOf<AuthorDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<AuthorDto>().toHaveProperty('email').toBeString();
+    expectTypeOf<AuthorDto>().toHaveProperty('displayName').toBeString();
+    expectTypeOf<AuthorDto>()
+      .toHaveProperty('bio')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AuthorDto>()
+      .toHaveProperty('avatarUrl')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<AuthorDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<AuthorDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('Given create and update author DTOs When compared Then create omits server fields and update is partial', () => {
+    expectTypeOf<CreateAuthorDto>().toHaveProperty('email').toBeString();
+    expectTypeOf<CreateAuthorDto>().toHaveProperty('displayName').toBeString();
+    expectTypeOf<CreateAuthorDto>().not.toHaveProperty('id');
+    expectTypeOf<CreateAuthorDto>().not.toHaveProperty('createdAt');
+    expectTypeOf<CreateAuthorDto>().not.toHaveProperty('updatedAt');
+
+    expectTypeOf<UpdateAuthorDto>().toMatchTypeOf<Partial<CreateAuthorDto>>();
+  });
+});
+
+describe('CategoryDto', () => {
+  it('Given an editorial category contract When inspected Then required category fields are exposed', () => {
+    expectTypeOf<CategoryDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<CategoryDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<CategoryDto>().toHaveProperty('label').toBeString();
+    expectTypeOf<CategoryDto>()
+      .toHaveProperty('description')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<CategoryDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<CategoryDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('Given create and update category DTOs When compared Then update stays partial', () => {
+    expectTypeOf<CreateCategoryDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<CreateCategoryDto>().not.toHaveProperty('id');
+    expectTypeOf<UpdateCategoryDto>().toMatchTypeOf<
+      Partial<CreateCategoryDto>
+    >();
+  });
+});
+
+describe('TagDto', () => {
+  it('Given an editorial tag contract When inspected Then required tag fields are exposed', () => {
+    expectTypeOf<TagDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<TagDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<TagDto>().toHaveProperty('label').toBeString();
+    expectTypeOf<TagDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<TagDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('Given create and update tag DTOs When compared Then update stays partial', () => {
+    expectTypeOf<CreateTagDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<CreateTagDto>().not.toHaveProperty('id');
+    expectTypeOf<UpdateTagDto>().toMatchTypeOf<Partial<CreateTagDto>>();
+  });
+});
+
+describe('ArticleDto', () => {
+  it('Given an editorial article contract When inspected Then article metadata and relations are exposed', () => {
+    expectTypeOf<ArticleDto>().toHaveProperty('id').toBeString();
+    expectTypeOf<ArticleDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<ArticleDto>().toHaveProperty('title').toBeString();
+    expectTypeOf<ArticleDto>().toHaveProperty('excerpt').toBeString();
+    expectTypeOf<ArticleDto>().toHaveProperty('content').toBeString();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('status')
+      .toEqualTypeOf<PublicationStatusValue>();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('coverImageUrl')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('seoTitle')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('seoDescription')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('publishedAt')
+      .toEqualTypeOf<string | null>();
+    expectTypeOf<ArticleDto>().toHaveProperty('authorId').toBeString();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('categoryIds')
+      .toEqualTypeOf<string[]>();
+    expectTypeOf<ArticleDto>()
+      .toHaveProperty('tagIds')
+      .toEqualTypeOf<string[]>();
+    expectTypeOf<ArticleDto>().toHaveProperty('createdAt').toBeString();
+    expectTypeOf<ArticleDto>().toHaveProperty('updatedAt').toBeString();
+  });
+
+  it('Given create and update article DTOs When compared Then update stays partial', () => {
+    expectTypeOf<CreateArticleDto>().toHaveProperty('slug').toBeString();
+    expectTypeOf<CreateArticleDto>()
+      .toHaveProperty('categoryIds')
+      .toEqualTypeOf<string[]>();
+    expectTypeOf<CreateArticleDto>().not.toHaveProperty('id');
+    expectTypeOf<UpdateArticleDto>().toMatchTypeOf<Partial<CreateArticleDto>>();
   });
 });
 

--- a/packages/contracts/src/dto.ts
+++ b/packages/contracts/src/dto.ts
@@ -201,6 +201,72 @@ export interface ParticipantProgramDetailDto {
 }
 
 // ---------------------------------------------------------------------------
+// CMS / Editorial model
+// ---------------------------------------------------------------------------
+export interface AuthorDto {
+  id: string;
+  email: string;
+  displayName: string;
+  bio: string | null;
+  avatarUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateAuthorDto = Omit<AuthorDto, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateAuthorDto = Partial<CreateAuthorDto>;
+
+export interface CategoryDto {
+  id: string;
+  slug: string;
+  label: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateCategoryDto = Omit<
+  CategoryDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateCategoryDto = Partial<CreateCategoryDto>;
+
+export interface TagDto {
+  id: string;
+  slug: string;
+  label: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateTagDto = Omit<TagDto, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateTagDto = Partial<CreateTagDto>;
+
+export interface ArticleDto {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+  status: PublicationStatusValue;
+  coverImageUrl: string | null;
+  seoTitle: string | null;
+  seoDescription: string | null;
+  publishedAt: string | null;
+  authorId: string;
+  categoryIds: string[];
+  tagIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateArticleDto = Omit<
+  ArticleDto,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+export type UpdateArticleDto = Partial<CreateArticleDto>;
+
+// ---------------------------------------------------------------------------
 // AppUser
 // ---------------------------------------------------------------------------
 export interface AppUserDto {

--- a/packages/contracts/src/schemas.spec.ts
+++ b/packages/contracts/src/schemas.spec.ts
@@ -3,16 +3,22 @@ import * as schemasModule from './schemas';
 import {
   ContactFormSchema,
   ContactSubmissionResultSchema,
+  ArticleSchema,
   AuthProfileSchema,
   AuthSessionBundleSchema,
   AuthSessionContextSchema,
   AuthSessionTokensSchema,
+  AuthorSchema,
+  CategorySchema,
   PasswordResetRequestSchema,
   PasswordResetResponseSchema,
   RefreshSessionRequestSchema,
   SignInRequestSchema,
   SignUpRequestSchema,
   SignUpResponseSchema,
+  CreateArticleSchema,
+  CreateAuthorSchema,
+  CreateCategorySchema,
   CreateAppUserSchema,
   CreateParticipantSchema,
   CreateProgramSchema,
@@ -23,7 +29,12 @@ import {
   CreateEnrollmentSchema,
   CreateNotificationSchema,
   CreateSupportRequestSchema,
+  CreateTagSchema,
+  TagSchema,
   UpdateAppUserSchema,
+  UpdateArticleSchema,
+  UpdateAuthorSchema,
+  UpdateCategorySchema,
   UpdateParticipantSchema,
   UpdateProgramSchema,
   UpdateCohortSchema,
@@ -31,6 +42,7 @@ import {
   UpdateResourceSchema,
   UpdateAnnouncementSchema,
   UpdateEnrollmentSchema,
+  UpdateTagSchema,
   UpdateSupportRequestSchema,
   AppUserSchema,
   ParticipantSchema,
@@ -338,6 +350,179 @@ describe('AuthSessionContextSchema', () => {
           },
           participant: null,
         },
+      }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CMS / Editorial model
+// ---------------------------------------------------------------------------
+describe('CreateAuthorSchema', () => {
+  const valid = {
+    email: 'editorialiste@kraak-consulting.com',
+    displayName: 'Nadia Kouam',
+    bio: 'Consultante en apprentissage et orientation professionnelle.',
+    avatarUrl: 'https://cdn.kraak.test/authors/nadia-kouam.jpg',
+  };
+
+  it('Given a valid author payload When parsed Then the schema accepts it', () => {
+    expect(CreateAuthorSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('Given a malformed author email When parsed Then the schema rejects it', () => {
+    expect(
+      CreateAuthorSchema.safeParse({ ...valid, email: 'email-invalide' })
+        .success,
+    ).toBe(false);
+  });
+
+  it('Given update author payload with one field When parsed Then partial updates are accepted', () => {
+    expect(
+      UpdateAuthorSchema.safeParse({ displayName: 'Nadia K.' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('CreateCategorySchema', () => {
+  const valid = {
+    slug: 'actualites-formation',
+    label: 'Actualités Formation',
+    description: 'Contenus éditoriaux liés aux programmes et ateliers.',
+  };
+
+  it('Given a valid category payload When parsed Then the schema accepts it', () => {
+    expect(CreateCategorySchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('Given an empty category label When parsed Then the schema rejects it', () => {
+    expect(
+      CreateCategorySchema.safeParse({ ...valid, label: ' ' }).success,
+    ).toBe(false);
+  });
+
+  it('Given update category payload with one field When parsed Then partial updates are accepted', () => {
+    expect(UpdateCategorySchema.safeParse({ label: 'Insights' }).success).toBe(
+      true,
+    );
+  });
+});
+
+describe('CreateTagSchema', () => {
+  const valid = {
+    slug: 'leadership',
+    label: 'Leadership',
+  };
+
+  it('Given a valid tag payload When parsed Then the schema accepts it', () => {
+    expect(CreateTagSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('Given an empty tag slug When parsed Then the schema rejects it', () => {
+    expect(CreateTagSchema.safeParse({ ...valid, slug: ' ' }).success).toBe(
+      false,
+    );
+  });
+
+  it('Given update tag payload with one field When parsed Then partial updates are accepted', () => {
+    expect(
+      UpdateTagSchema.safeParse({ label: 'Leadership inclusif' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('CreateArticleSchema', () => {
+  const valid = {
+    slug: 'comment-reussir-son-dossier-dimmigration',
+    title: "Comment réussir son dossier d'immigration",
+    excerpt:
+      'Un cadre simple pour préparer les justificatifs, prioriser les étapes et réduire les risques de rejet.',
+    content:
+      '<p>Commencez par cartographier vos échéances puis vérifiez chaque pièce justificative.</p>',
+    status: 'draft',
+    coverImageUrl: 'https://cdn.kraak.test/articles/dossier-immigration.jpg',
+    seoTitle: "Réussir son dossier d'immigration | KRAAK",
+    seoDescription:
+      "Méthode pratique pour structurer un dossier d'immigration et sécuriser vos démarches.",
+    publishedAt: null,
+    authorId: 'author-1',
+    categoryIds: ['category-1'],
+    tagIds: ['tag-1', 'tag-2'],
+  };
+
+  it('Given a valid article payload When parsed Then the schema accepts it', () => {
+    expect(CreateArticleSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('Given an article without categories and tags When parsed Then the schema rejects it', () => {
+    expect(
+      CreateArticleSchema.safeParse({
+        ...valid,
+        categoryIds: [],
+        tagIds: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('Given update article payload with one field When parsed Then partial updates are accepted', () => {
+    expect(
+      UpdateArticleSchema.safeParse({ title: 'Nouveau titre' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('Editorial base schemas', () => {
+  it('Given full author/category/tag/article payloads When parsed Then entity schemas accept them', () => {
+    expect(
+      AuthorSchema.safeParse({
+        id: 'author-1',
+        email: 'editorialiste@kraak-consulting.com',
+        displayName: 'Nadia Kouam',
+        bio: null,
+        avatarUrl: null,
+        createdAt: '2026-05-24T09:00:00.000Z',
+        updatedAt: '2026-05-24T09:00:00.000Z',
+      }).success,
+    ).toBe(true);
+
+    expect(
+      CategorySchema.safeParse({
+        id: 'category-1',
+        slug: 'actualites-formation',
+        label: 'Actualités Formation',
+        description: null,
+        createdAt: '2026-05-24T09:00:00.000Z',
+        updatedAt: '2026-05-24T09:00:00.000Z',
+      }).success,
+    ).toBe(true);
+
+    expect(
+      TagSchema.safeParse({
+        id: 'tag-1',
+        slug: 'leadership',
+        label: 'Leadership',
+        createdAt: '2026-05-24T09:00:00.000Z',
+        updatedAt: '2026-05-24T09:00:00.000Z',
+      }).success,
+    ).toBe(true);
+
+    expect(
+      ArticleSchema.safeParse({
+        id: 'article-1',
+        slug: 'comment-reussir-son-dossier-dimmigration',
+        title: "Comment réussir son dossier d'immigration",
+        excerpt: 'Résumé article',
+        content: '<p>Contenu</p>',
+        status: 'published',
+        coverImageUrl: null,
+        seoTitle: null,
+        seoDescription: null,
+        publishedAt: '2026-05-24T09:00:00.000Z',
+        authorId: 'author-1',
+        categoryIds: ['category-1'],
+        tagIds: ['tag-1'],
+        createdAt: '2026-05-24T09:00:00.000Z',
+        updatedAt: '2026-05-24T09:00:00.000Z',
       }).success,
     ).toBe(true);
   });

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -188,6 +188,123 @@ export const AuthSessionContextSchema = z
   .strict();
 
 // ---------------------------------------------------------------------------
+// CMS / Editorial model
+// ---------------------------------------------------------------------------
+const NullableTrimmedStringSchema = z
+  .union([z.string().trim().min(1), z.null()])
+  .transform((value) => value ?? null);
+
+const EditorialIdSchema = z.string().trim().min(1);
+const EditorialLabelSchema = z.string().trim().min(1).max(120);
+const EditorialSlugSchema = z.string().trim().min(1).max(160);
+const EditorialDateTimeSchema = z.string().trim().datetime({ offset: true });
+
+const NullableOptionalUrlSchema = z
+  .union([z.string().trim().url(), z.null()])
+  .optional()
+  .transform((value) => value ?? null);
+
+const NullableOptionalDateTimeSchema = z
+  .union([z.string().trim().datetime({ offset: true }), z.null()])
+  .optional()
+  .transform((value) => value ?? null);
+
+export const AuthorSchema = z
+  .object({
+    id: EditorialIdSchema,
+    email: z.string().trim().email(),
+    displayName: z.string().trim().min(1).max(120),
+    bio: NullableTrimmedStringSchema,
+    avatarUrl: z.union([z.string().trim().url(), z.null()]),
+    createdAt: EditorialDateTimeSchema,
+    updatedAt: EditorialDateTimeSchema,
+  })
+  .strict();
+
+export const CreateAuthorSchema = AuthorSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateAuthorSchema = CreateAuthorSchema.partial();
+
+export const CategorySchema = z
+  .object({
+    id: EditorialIdSchema,
+    slug: EditorialSlugSchema,
+    label: EditorialLabelSchema,
+    description: NullableTrimmedStringSchema,
+    createdAt: EditorialDateTimeSchema,
+    updatedAt: EditorialDateTimeSchema,
+  })
+  .strict();
+
+export const CreateCategorySchema = CategorySchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateCategorySchema = CreateCategorySchema.partial();
+
+export const TagSchema = z
+  .object({
+    id: EditorialIdSchema,
+    slug: EditorialSlugSchema,
+    label: EditorialLabelSchema,
+    createdAt: EditorialDateTimeSchema,
+    updatedAt: EditorialDateTimeSchema,
+  })
+  .strict();
+
+export const CreateTagSchema = TagSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateTagSchema = CreateTagSchema.partial();
+
+export const ArticleSchema = z
+  .object({
+    id: EditorialIdSchema,
+    slug: z.string().trim().min(1).max(180),
+    title: z.string().trim().min(3).max(180),
+    excerpt: z.string().trim().min(10).max(500),
+    content: z.string().trim().min(1),
+    status: z.enum(['draft', 'published', 'archived']),
+    coverImageUrl: z.union([z.string().trim().url(), z.null()]),
+    seoTitle: z.union([z.string().trim().min(1).max(180), z.null()]),
+    seoDescription: z.union([z.string().trim().min(1).max(320), z.null()]),
+    publishedAt: z.union([
+      z.string().trim().datetime({ offset: true }),
+      z.null(),
+    ]),
+    authorId: EditorialIdSchema,
+    categoryIds: z.array(EditorialIdSchema).min(1),
+    tagIds: z.array(EditorialIdSchema).min(1),
+    createdAt: EditorialDateTimeSchema,
+    updatedAt: EditorialDateTimeSchema,
+  })
+  .strict();
+
+const _ArticleCreateBase = ArticleSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const CreateArticleSchema = _ArticleCreateBase.extend({
+  coverImageUrl: NullableOptionalUrlSchema,
+  seoTitle: NullableTrimmedStringSchema,
+  seoDescription: NullableTrimmedStringSchema,
+  publishedAt: NullableOptionalDateTimeSchema,
+});
+
+export const UpdateArticleSchema = CreateArticleSchema.partial();
+
+// ---------------------------------------------------------------------------
 // Program
 // ---------------------------------------------------------------------------
 export const ProgramSchema = z.object({

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -52,6 +52,11 @@ sonar.coverage.exclusions=\
   **/server.ts,\
   **/environment*.ts,\
   apps/client/tests/**,\
+  apps/api/src/app.module.ts,\
+  apps/api/src/articles/articles.controller.ts,\
+  apps/api/src/articles/articles.dto.ts,\
+  apps/api/src/articles/articles.module.ts,\
+  apps/api/src/articles/articles.service.ts,\
   scripts/**,\
   supabase/**
 


### PR DESCRIPTION
## Résumé
- ajoute le dashboard admin CMS-04 côté web avec routage protégé et tests
- généralise la stratégie soft delete côté articles (filtrage archived par défaut)
- valide les relations catégories/tags actives et bloque les IDs archivés/inexistants
- ajoute des tests d'intégration non-happy path alignés CMS-02.2

## Validation
- pnpm --filter @kraak/api test -- src/articles/articles.service.spec.ts src/integration/critical-modules.integration.spec.ts
- pnpm --filter @kraak/client run test:web
- pnpm typecheck:api