### PR TITLE
fix(api): extract update helpers and fix implicit any in articles service

### DIFF
--- a/apps/api/src/articles/articles.service.spec.ts
+++ b/apps/api/src/articles/articles.service.spec.ts
@@ -11,6 +11,7 @@ import { ArticlesService } from './articles.service';
 
 function createSingleRowQuery(result: { data: unknown; error: unknown }) {
   return {
+    insert: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     eq: jest.fn().mockReturnThis(),
     neq: jest.fn().mockReturnThis(),
@@ -362,8 +363,6 @@ describe('ArticlesService', () => {
       data: null,
       error: { message: 'insert error' },
     });
-
-    articleInsertQuery['insert'] = jest.fn().mockReturnThis();
 
     adminClient.from.mockImplementation((tableName: string) => {
       if (tableName === 'app_user') {

--- a/apps/api/src/articles/articles.service.ts
+++ b/apps/api/src/articles/articles.service.ts
@@ -151,6 +151,67 @@ export class ArticlesService {
     return this.mapArticleRow(data as ArticleRow, relations);
   }
 
+  private buildUpdatePayload(
+    payload: UpdateArticleDto,
+  ): Record<string, unknown> {
+    const updatePayload: Record<string, unknown> = {};
+
+    if (payload.slug !== undefined) {
+      updatePayload['slug'] = payload.slug;
+    }
+    if (payload.title !== undefined) {
+      updatePayload['title'] = payload.title;
+    }
+    if (payload.excerpt !== undefined) {
+      updatePayload['excerpt'] = payload.excerpt;
+    }
+    if (payload.content !== undefined) {
+      updatePayload['content'] = payload.content;
+    }
+    if (payload.status !== undefined) {
+      updatePayload['status'] = payload.status;
+    }
+    if (payload.coverImageUrl !== undefined) {
+      updatePayload['cover_image_url'] = payload.coverImageUrl;
+    }
+    if (payload.seoTitle !== undefined) {
+      updatePayload['seo_title'] = payload.seoTitle;
+    }
+    if (payload.seoDescription !== undefined) {
+      updatePayload['seo_description'] = payload.seoDescription;
+    }
+    if (payload.publishedAt !== undefined) {
+      updatePayload['published_at'] = payload.publishedAt;
+    }
+    if (payload.authorId !== undefined) {
+      updatePayload['author_id'] = payload.authorId;
+    }
+
+    return updatePayload;
+  }
+
+  private handleUpdateError(error: unknown): void {
+    const errorCode =
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      typeof error.code === 'string'
+        ? error.code
+        : null;
+
+    if (errorCode !== null && notFoundSupabaseErrorCodes.has(errorCode)) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+
+    throw new InternalServerErrorException({
+      success: false,
+      message: "Impossible de mettre à jour l'article.",
+    });
+  }
+
   async updateArticle(
     accessToken: string,
     articleId: string,
@@ -159,48 +220,7 @@ export class ArticlesService {
     await this.assertAdminAccess(accessToken);
 
     const adminClient = this.supabaseService.getClient();
-
-    const updatePayload: Record<string, unknown> = {};
-
-    if (payload.slug !== undefined) {
-      updatePayload['slug'] = payload.slug;
-    }
-
-    if (payload.title !== undefined) {
-      updatePayload['title'] = payload.title;
-    }
-
-    if (payload.excerpt !== undefined) {
-      updatePayload['excerpt'] = payload.excerpt;
-    }
-
-    if (payload.content !== undefined) {
-      updatePayload['content'] = payload.content;
-    }
-
-    if (payload.status !== undefined) {
-      updatePayload['status'] = payload.status;
-    }
-
-    if (payload.coverImageUrl !== undefined) {
-      updatePayload['cover_image_url'] = payload.coverImageUrl;
-    }
-
-    if (payload.seoTitle !== undefined) {
-      updatePayload['seo_title'] = payload.seoTitle;
-    }
-
-    if (payload.seoDescription !== undefined) {
-      updatePayload['seo_description'] = payload.seoDescription;
-    }
-
-    if (payload.publishedAt !== undefined) {
-      updatePayload['published_at'] = payload.publishedAt;
-    }
-
-    if (payload.authorId !== undefined) {
-      updatePayload['author_id'] = payload.authorId;
-    }
+    const updatePayload = this.buildUpdatePayload(payload);
 
     const { data, error } = await adminClient
       .from('article')
@@ -211,25 +231,7 @@ export class ArticlesService {
       .single();
 
     if (error) {
-      const errorCode =
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        typeof error.code === 'string'
-          ? error.code
-          : null;
-
-      if (errorCode !== null && notFoundSupabaseErrorCodes.has(errorCode)) {
-        throw new NotFoundException({
-          success: false,
-          message: 'Article introuvable.',
-        });
-      }
-
-      throw new InternalServerErrorException({
-        success: false,
-        message: "Impossible de mettre à jour l'article.",
-      });
+      this.handleUpdateError(error);
     }
 
     if (!data) {

--- a/packages/contracts/src/db.types.ts
+++ b/packages/contracts/src/db.types.ts
@@ -142,6 +142,188 @@ export type Database = {
         };
         Relationships: [];
       };
+      article: {
+        Row: {
+          author_id: string;
+          content: string;
+          cover_image_url: string | null;
+          created_at: string;
+          excerpt: string;
+          id: string;
+          published_at: string | null;
+          seo_description: string | null;
+          seo_title: string | null;
+          slug: string;
+          status: Database['public']['Enums']['publication_status'];
+          title: string;
+          updated_at: string;
+        };
+        Insert: {
+          author_id: string;
+          content: string;
+          cover_image_url?: string | null;
+          created_at?: string;
+          excerpt: string;
+          id?: string;
+          published_at?: string | null;
+          seo_description?: string | null;
+          seo_title?: string | null;
+          slug: string;
+          status?: Database['public']['Enums']['publication_status'];
+          title: string;
+          updated_at?: string;
+        };
+        Update: {
+          author_id?: string;
+          content?: string;
+          cover_image_url?: string | null;
+          created_at?: string;
+          excerpt?: string;
+          id?: string;
+          published_at?: string | null;
+          seo_description?: string | null;
+          seo_title?: string | null;
+          slug?: string;
+          status?: Database['public']['Enums']['publication_status'];
+          title?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'article_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'author';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      article_category: {
+        Row: {
+          article_id: string;
+          category_id: string;
+          created_at: string;
+        };
+        Insert: {
+          article_id: string;
+          category_id: string;
+          created_at?: string;
+        };
+        Update: {
+          article_id?: string;
+          category_id?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'article_category_article_id_fkey';
+            columns: ['article_id'];
+            isOneToOne: false;
+            referencedRelation: 'article';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'article_category_category_id_fkey';
+            columns: ['category_id'];
+            isOneToOne: false;
+            referencedRelation: 'category';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      article_tag: {
+        Row: {
+          article_id: string;
+          created_at: string;
+          tag_id: string;
+        };
+        Insert: {
+          article_id: string;
+          created_at?: string;
+          tag_id: string;
+        };
+        Update: {
+          article_id?: string;
+          created_at?: string;
+          tag_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'article_tag_article_id_fkey';
+            columns: ['article_id'];
+            isOneToOne: false;
+            referencedRelation: 'article';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'article_tag_tag_id_fkey';
+            columns: ['tag_id'];
+            isOneToOne: false;
+            referencedRelation: 'tag';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      author: {
+        Row: {
+          avatar_url: string | null;
+          bio: string | null;
+          created_at: string;
+          display_name: string;
+          email: string;
+          id: string;
+          updated_at: string;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          display_name: string;
+          email: string;
+          id?: string;
+          updated_at?: string;
+        };
+        Update: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          display_name?: string;
+          email?: string;
+          id?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      category: {
+        Row: {
+          created_at: string;
+          description: string | null;
+          id: string;
+          label: string;
+          slug: string;
+          status: Database['public']['Enums']['publication_status'];
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          label: string;
+          slug: string;
+          status?: Database['public']['Enums']['publication_status'];
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          label?: string;
+          slug?: string;
+          status?: Database['public']['Enums']['publication_status'];
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       cohort: {
         Row: {
           capacity: number | null;
@@ -560,6 +742,33 @@ export type Database = {
             referencedColumns: ['id'];
           },
         ];
+      };
+      tag: {
+        Row: {
+          created_at: string;
+          id: string;
+          label: string;
+          slug: string;
+          status: Database['public']['Enums']['publication_status'];
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          label: string;
+          slug: string;
+          status?: Database['public']['Enums']['publication_status'];
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          label?: string;
+          slug?: string;
+          status?: Database['public']['Enums']['publication_status'];
+          updated_at?: string;
+        };
+        Relationships: [];
       };
     };
     Views: {

--- a/supabase/migrations/20260524103000_add_editorial_content_model.sql
+++ b/supabase/migrations/20260524103000_add_editorial_content_model.sql
@@ -1,0 +1,98 @@
+-- ============================================================
+-- Migration : modèle éditorial admin (CMS)
+-- Entités  : author, category, tag, article
+--            + tables de liaison article_category, article_tag
+-- ============================================================
+
+CREATE TABLE author (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  email text NOT NULL,
+  display_name text NOT NULL,
+  bio text,
+  avatar_url text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE category (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug text NOT NULL,
+  label text NOT NULL,
+  description text,
+  status publication_status NOT NULL DEFAULT 'draft',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE tag (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug text NOT NULL,
+  label text NOT NULL,
+  status publication_status NOT NULL DEFAULT 'draft',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE article (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug text NOT NULL,
+  title text NOT NULL,
+  excerpt text NOT NULL,
+  content text NOT NULL,
+  cover_image_url text,
+  seo_title text,
+  seo_description text,
+  published_at timestamptz,
+  status publication_status NOT NULL DEFAULT 'draft',
+  author_id uuid NOT NULL REFERENCES author(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT article_published_at_consistency CHECK (
+    (status = 'draft' AND published_at IS NULL)
+    OR (status IN ('published', 'archived') AND published_at IS NOT NULL)
+  )
+);
+
+CREATE TABLE article_category (
+  article_id uuid NOT NULL REFERENCES article(id) ON DELETE CASCADE,
+  category_id uuid NOT NULL REFERENCES category(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (article_id, category_id)
+);
+
+CREATE TABLE article_tag (
+  article_id uuid NOT NULL REFERENCES article(id) ON DELETE CASCADE,
+  tag_id uuid NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (article_id, tag_id)
+);
+
+CREATE UNIQUE INDEX idx_author_email_unique ON author (email);
+CREATE UNIQUE INDEX idx_category_slug_unique ON category (slug);
+CREATE UNIQUE INDEX idx_tag_slug_unique ON tag (slug);
+CREATE UNIQUE INDEX idx_article_slug_unique ON article (slug);
+
+CREATE INDEX idx_article_status ON article (status);
+CREATE INDEX idx_article_published_at ON article (published_at DESC);
+CREATE INDEX idx_article_author_id ON article (author_id);
+CREATE INDEX idx_category_status ON category (status);
+CREATE INDEX idx_tag_status ON tag (status);
+CREATE INDEX idx_article_category_category_id ON article_category (category_id);
+CREATE INDEX idx_article_tag_tag_id ON article_tag (tag_id);
+
+CREATE TRIGGER trg_author_updated_at
+BEFORE UPDATE ON author
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at();
+
+CREATE TRIGGER trg_category_updated_at
+BEFORE UPDATE ON category
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at();
+
+CREATE TRIGGER trg_tag_updated_at
+BEFORE UPDATE ON tag
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at();
+
+CREATE TRIGGER trg_article_updated_at
+BEFORE UPDATE ON article
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at();


### PR DESCRIPTION
## Changements

- Extraction de `buildUpdatePayload` et `handleUpdateError` comme méthodes privées de `ArticlesService`
- Correction ESLint `no-explicit-any` : `error: any` -> `error: unknown` (narrowing existant compatible)
- Ajout de `insert: jest.fn().mockReturnThis()` dans `createSingleRowQuery` pour corriger TS7053
- Ajout de la migration Supabase `20260524103000_add_editorial_content_model.sql` pour le modèle éditorial CMS (`author`, `category`, `tag`, `article`, `article_category`, `article_tag`)
- Ajout des contraintes de cohérence publication et des index/contraintes d'unicité sur les slugs
- Mise à jour de `packages/contracts/src/db.types.ts` avec les nouvelles tables éditoriales

## Type
- fix / refactor interne + feat data model CMS

## Tracking
- Relates to #352
- Parent epic: #332
