### PR TITLE
feat(api): add CMS admin/public article endpoints

### DIFF
--- a/apps/api/src/articles/articles-public.controller.spec.ts
+++ b/apps/api/src/articles/articles-public.controller.spec.ts
@@ -1,0 +1,79 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ArticlesPublicController } from './articles-public.controller';
+import { ArticlesService } from './articles.service';
+
+describe('ArticlesPublicController', () => {
+  let controller: ArticlesPublicController;
+
+  const articlesService = {
+    listPublicArticles: jest.fn(),
+    getPublicArticleBySlug: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    articlesService.listPublicArticles.mockResolvedValue([]);
+    articlesService.getPublicArticleBySlug.mockResolvedValue({
+      id: 'article-1',
+      slug: 'article-1',
+      title: 'Article 1',
+      excerpt: 'Resume article 1',
+      content: '<p>Contenu article 1</p>',
+      status: 'published',
+      coverImageUrl: null,
+      seoTitle: null,
+      seoDescription: null,
+      publishedAt: '2026-05-24T10:00:00.000Z',
+      authorId: 'author-1',
+      categoryIds: ['category-1'],
+      tagIds: ['tag-1'],
+      createdAt: '2026-05-24T10:00:00.000Z',
+      updatedAt: '2026-05-24T10:00:00.000Z',
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ArticlesPublicController],
+      providers: [
+        {
+          provide: ArticlesService,
+          useValue: articlesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ArticlesPublicController>(ArticlesPublicController);
+  });
+
+  it('Given des articles publics disponibles, When listPublishedArticles est appele, Then la liste publiee est renvoyee', async () => {
+    await expect(controller.listPublishedArticles()).resolves.toEqual([]);
+    expect(articlesService.listPublicArticles).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given un slug valide, When getArticleBySlug est appele, Then le detail public est renvoye', async () => {
+    await expect(
+      controller.getArticleBySlug('article-1'),
+    ).resolves.toMatchObject({
+      slug: 'article-1',
+      status: 'published',
+    });
+
+    expect(articlesService.getPublicArticleBySlug).toHaveBeenCalledWith(
+      'article-1',
+    );
+  });
+
+  it('Given un slug inconnu, When getArticleBySlug est appele, Then une NotFoundException est renvoyee', async () => {
+    articlesService.getPublicArticleBySlug.mockRejectedValueOnce(
+      new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      }),
+    );
+
+    await expect(controller.getArticleBySlug('missing')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+});

--- a/apps/api/src/articles/articles-public.controller.ts
+++ b/apps/api/src/articles/articles-public.controller.ts
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  Get,
-  HttpStatus,
-  NotFoundException,
-  Param,
-} from '@nestjs/common';
+import { Controller, Get, HttpStatus, Param } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { ArticleDto } from '@kraak/contracts';
 import { ArticlesService } from './articles.service';
@@ -77,14 +71,6 @@ export class ArticlesPublicController {
     description: 'Article introuvable.',
   })
   async getArticleBySlug(@Param('slug') slug: string): Promise<ArticleDto> {
-    try {
-      return await this.articlesService.getPublicArticleBySlug(slug);
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw error;
-      }
-
-      throw error;
-    }
+    return this.articlesService.getPublicArticleBySlug(slug);
   }
 }

--- a/apps/api/src/articles/articles-public.controller.ts
+++ b/apps/api/src/articles/articles-public.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  NotFoundException,
+  Param,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { ArticleDto } from '@kraak/contracts';
+import { ArticlesService } from './articles.service';
+
+const publicationStatusEnum = ['draft', 'published', 'archived'];
+
+const articleSchema = {
+  type: 'object',
+  required: [
+    'id',
+    'slug',
+    'title',
+    'excerpt',
+    'content',
+    'status',
+    'coverImageUrl',
+    'seoTitle',
+    'seoDescription',
+    'publishedAt',
+    'authorId',
+    'categoryIds',
+    'tagIds',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    slug: { type: 'string' },
+    title: { type: 'string' },
+    excerpt: { type: 'string' },
+    content: { type: 'string' },
+    status: { type: 'string', enum: publicationStatusEnum },
+    coverImageUrl: { type: 'string', nullable: true },
+    seoTitle: { type: 'string', nullable: true },
+    seoDescription: { type: 'string', nullable: true },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+    authorId: { type: 'string' },
+    categoryIds: { type: 'array', items: { type: 'string' } },
+    tagIds: { type: 'array', items: { type: 'string' } },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+@ApiTags('Public Articles')
+@Controller('articles')
+export class ArticlesPublicController {
+  constructor(private readonly articlesService: ArticlesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Lister les articles publics publies' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Liste publique des articles publies.',
+    schema: { type: 'array', items: articleSchema },
+  })
+  async listPublishedArticles(): Promise<ArticleDto[]> {
+    return this.articlesService.listPublicArticles();
+  }
+
+  @Get(':slug')
+  @ApiOperation({ summary: 'Afficher le detail public d un article' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Article public charge avec succes.',
+    schema: articleSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Article introuvable.',
+  })
+  async getArticleBySlug(@Param('slug') slug: string): Promise<ArticleDto> {
+    try {
+      return await this.articlesService.getPublicArticleBySlug(slug);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+  }
+}

--- a/apps/api/src/articles/articles-public.controller.ts
+++ b/apps/api/src/articles/articles-public.controller.ts
@@ -84,10 +84,7 @@ export class ArticlesPublicController {
         throw error;
       }
 
-      throw new NotFoundException({
-        success: false,
-        message: 'Article introuvable.',
-      });
+      throw error;
     }
   }
 }

--- a/apps/api/src/articles/articles.controller.spec.ts
+++ b/apps/api/src/articles/articles.controller.spec.ts
@@ -18,6 +18,16 @@ describe('ArticlesController', () => {
     getArticleById: jest.fn(),
     createArticle: jest.fn(),
     updateArticle: jest.fn(),
+    publishArticle: jest.fn(),
+    uploadCoverImage: jest.fn(),
+    listCategories: jest.fn(),
+    createCategory: jest.fn(),
+    updateCategory: jest.fn(),
+    deleteCategory: jest.fn(),
+    listTags: jest.fn(),
+    createTag: jest.fn(),
+    updateTag: jest.fn(),
+    deleteTag: jest.fn(),
     deleteArticle: jest.fn(),
   };
 
@@ -48,6 +58,36 @@ describe('ArticlesController', () => {
     articlesService.updateArticle.mockResolvedValue(
       articlesService.getArticleById(),
     );
+    articlesService.publishArticle.mockResolvedValue(
+      articlesService.getArticleById(),
+    );
+    articlesService.uploadCoverImage.mockResolvedValue({
+      url: 'https://cdn.kraak.test/articles/cover.jpg',
+      path: 'articles/cover.jpg',
+    });
+    articlesService.listCategories.mockResolvedValue([]);
+    articlesService.createCategory.mockResolvedValue({
+      id: 'category-1',
+      slug: 'categorie-1',
+      label: 'Categorie 1',
+      description: null,
+      createdAt: '2026-05-24T10:00:00.000Z',
+      updatedAt: '2026-05-24T10:00:00.000Z',
+    });
+    articlesService.updateCategory.mockResolvedValue(
+      articlesService.createCategory(),
+    );
+    articlesService.deleteCategory.mockResolvedValue(undefined);
+    articlesService.listTags.mockResolvedValue([]);
+    articlesService.createTag.mockResolvedValue({
+      id: 'tag-1',
+      slug: 'tag-1',
+      label: 'Tag 1',
+      createdAt: '2026-05-24T10:00:00.000Z',
+      updatedAt: '2026-05-24T10:00:00.000Z',
+    });
+    articlesService.updateTag.mockResolvedValue(articlesService.createTag());
+    articlesService.deleteTag.mockResolvedValue(undefined);
     articlesService.deleteArticle.mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
@@ -80,11 +120,61 @@ describe('ArticlesController', () => {
       RequestMethod.POST,
     );
     expect(Reflect.getMetadata(METHOD_METADATA, controller.updateArticle)).toBe(
-      RequestMethod.PATCH,
+      RequestMethod.PUT,
     );
     expect(Reflect.getMetadata(METHOD_METADATA, controller.deleteArticle)).toBe(
       RequestMethod.DELETE,
     );
+  });
+
+  it('Given un token admin valide, When publishArticle est appele, Then le service de publication est invoque', async () => {
+    await controller.publishArticle('article-1', 'Bearer access-token');
+
+    expect(articlesService.publishArticle).toHaveBeenCalledWith(
+      'access-token',
+      'article-1',
+    );
+  });
+
+  it('Given un token admin valide, When uploadCoverImage est appele, Then le service upload est invoque', async () => {
+    await controller.uploadCoverImage(
+      {
+        buffer: Buffer.from('image'),
+        originalname: 'cover.jpg',
+        mimetype: 'image/jpeg',
+        size: 120,
+      } as Express.Multer.File,
+      'Bearer access-token',
+    );
+
+    expect(articlesService.uploadCoverImage).toHaveBeenCalled();
+  });
+
+  it('Given une categorie invalide, When createCategory est appele, Then une BadRequestException est renvoyee', async () => {
+    await expect(
+      controller.createCategory(
+        {
+          slug: '',
+        },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('Given un tag valide, When createTag est appele, Then le service createTag est invoque', async () => {
+    await controller.createTag(
+      {
+        slug: 'tag-1',
+        label: 'Tag 1',
+      },
+      'Bearer access-token',
+    );
+
+    expect(articlesService.createTag).toHaveBeenCalledWith('access-token', {
+      slug: 'tag-1',
+      label: 'Tag 1',
+      description: null,
+    });
   });
 
   it('Given un header Authorization valide, When listArticles est appelé, Then le token est transmis au service', async () => {

--- a/apps/api/src/articles/articles.controller.spec.ts
+++ b/apps/api/src/articles/articles.controller.spec.ts
@@ -150,6 +150,27 @@ describe('ArticlesController', () => {
     expect(articlesService.uploadCoverImage).toHaveBeenCalled();
   });
 
+  it('Given une erreur ForbiddenException du service upload, When uploadCoverImage est appele, Then l erreur est propagee', async () => {
+    articlesService.uploadCoverImage.mockRejectedValueOnce(
+      new ForbiddenException({
+        success: false,
+        message: 'Accès admin requis.',
+      }),
+    );
+
+    await expect(
+      controller.uploadCoverImage(
+        {
+          buffer: Buffer.from('image'),
+          originalname: 'cover.jpg',
+          mimetype: 'image/jpeg',
+          size: 120,
+        },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('Given une categorie invalide, When createCategory est appele, Then une BadRequestException est renvoyee', async () => {
     await expect(
       controller.createCategory(
@@ -173,8 +194,20 @@ describe('ArticlesController', () => {
     expect(articlesService.createTag).toHaveBeenCalledWith('access-token', {
       slug: 'tag-1',
       label: 'Tag 1',
-      description: null,
     });
+  });
+
+  it('Given un payload tag avec description, When createTag est appele, Then une BadRequestException est renvoyee', async () => {
+    await expect(
+      controller.createTag(
+        {
+          slug: 'tag-1',
+          label: 'Tag 1',
+          description: 'Description interdite',
+        },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
   });
 
   it('Given un header Authorization valide, When listArticles est appelé, Then le token est transmis au service', async () => {

--- a/apps/api/src/articles/articles.controller.spec.ts
+++ b/apps/api/src/articles/articles.controller.spec.ts
@@ -143,7 +143,7 @@ describe('ArticlesController', () => {
         originalname: 'cover.jpg',
         mimetype: 'image/jpeg',
         size: 120,
-      } as Express.Multer.File,
+      },
       'Bearer access-token',
     );
 

--- a/apps/api/src/articles/articles.controller.ts
+++ b/apps/api/src/articles/articles.controller.ts
@@ -442,6 +442,11 @@ export class ArticlesController {
         throw error;
       }
 
+      console.error("Échec de l'envoi de l'image de couverture article", {
+        context: 'articles.uploadCoverImage',
+        message: error instanceof Error ? error.message : 'Erreur inconnue',
+      });
+
       throw new InternalServerErrorException({
         success: false,
         message: "Impossible d'envoyer l'image de couverture.",

--- a/apps/api/src/articles/articles.controller.ts
+++ b/apps/api/src/articles/articles.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Get,
   Headers,
+  HttpException,
   HttpCode,
   HttpStatus,
   InternalServerErrorException,
@@ -132,7 +133,7 @@ const apiErrorSchema = {
   },
 };
 
-const taxonomySchema = {
+const categoryResponseSchema = {
   type: 'object',
   required: ['id', 'slug', 'label', 'createdAt', 'updatedAt'],
   properties: {
@@ -142,6 +143,54 @@ const taxonomySchema = {
     description: { type: 'string', nullable: true },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const categoryCreateBodySchema = {
+  type: 'object',
+  required: ['slug', 'label'],
+  properties: {
+    slug: { type: 'string' },
+    label: { type: 'string' },
+    description: { type: 'string', nullable: true },
+  },
+};
+
+const categoryUpdateBodySchema = {
+  type: 'object',
+  properties: {
+    slug: { type: 'string' },
+    label: { type: 'string' },
+    description: { type: 'string', nullable: true },
+  },
+};
+
+const tagResponseSchema = {
+  type: 'object',
+  required: ['id', 'slug', 'label', 'createdAt', 'updatedAt'],
+  properties: {
+    id: { type: 'string' },
+    slug: { type: 'string' },
+    label: { type: 'string' },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const tagCreateBodySchema = {
+  type: 'object',
+  required: ['slug', 'label'],
+  properties: {
+    slug: { type: 'string' },
+    label: { type: 'string' },
+  },
+};
+
+const tagUpdateBodySchema = {
+  type: 'object',
+  properties: {
+    slug: { type: 'string' },
+    label: { type: 'string' },
   },
 };
 
@@ -206,35 +255,6 @@ export class ArticlesController {
     }
 
     return this.articlesService.listArticles(accessToken.data);
-  }
-
-  @Get(':id')
-  @ApiBearerAuth('access-token')
-  @ApiOperation({ summary: 'Récupérer un article par son identifiant' })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: 'Article chargé avec succès.',
-    schema: articleSchema,
-  })
-  @ApiResponse({
-    status: HttpStatus.NOT_FOUND,
-    description: 'Article introuvable.',
-    schema: apiErrorSchema,
-  })
-  async getArticleById(
-    @Param('id') id: string,
-    @Headers('authorization') authorizationHeader?: string,
-  ): Promise<ArticleDto> {
-    const accessToken = extractAccessToken(authorizationHeader);
-
-    if (!accessToken.valid) {
-      throw new UnauthorizedException({
-        success: false,
-        message: accessToken.error,
-      });
-    }
-
-    return this.articlesService.getArticleById(accessToken.data, id);
   }
 
   @Post()
@@ -418,7 +438,7 @@ export class ArticlesController {
         file,
       );
     } catch (error) {
-      if (error instanceof BadRequestException) {
+      if (error instanceof HttpException) {
         throw error;
       }
 
@@ -435,7 +455,7 @@ export class ArticlesController {
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Categories chargees avec succes.',
-    schema: { type: 'array', items: taxonomySchema },
+    schema: { type: 'array', items: categoryResponseSchema },
   })
   async listCategories(
     @Headers('authorization') authorizationHeader?: string,
@@ -455,7 +475,12 @@ export class ArticlesController {
   @Post('categories')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Creer une categorie' })
-  @ApiBody({ schema: taxonomySchema })
+  @ApiBody({ schema: categoryCreateBodySchema })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Categorie creee avec succes.',
+    schema: categoryResponseSchema,
+  })
   async createCategory(
     @Body() body: unknown,
     @Headers('authorization') authorizationHeader?: string,
@@ -487,7 +512,12 @@ export class ArticlesController {
   @Patch('categories/:id')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Mettre a jour une categorie' })
-  @ApiBody({ schema: taxonomySchema })
+  @ApiBody({ schema: categoryUpdateBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Categorie mise a jour avec succes.',
+    schema: categoryResponseSchema,
+  })
   async updateCategory(
     @Param('id') id: string,
     @Body() body: unknown,
@@ -544,7 +574,7 @@ export class ArticlesController {
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Tags charges avec succes.',
-    schema: { type: 'array', items: taxonomySchema },
+    schema: { type: 'array', items: tagResponseSchema },
   })
   async listTags(
     @Headers('authorization') authorizationHeader?: string,
@@ -564,7 +594,12 @@ export class ArticlesController {
   @Post('tags')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Creer un tag' })
-  @ApiBody({ schema: taxonomySchema })
+  @ApiBody({ schema: tagCreateBodySchema })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Tag cree avec succes.',
+    schema: tagResponseSchema,
+  })
   async createTag(
     @Body() body: unknown,
     @Headers('authorization') authorizationHeader?: string,
@@ -593,7 +628,12 @@ export class ArticlesController {
   @Patch('tags/:id')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Mettre a jour un tag' })
-  @ApiBody({ schema: taxonomySchema })
+  @ApiBody({ schema: tagUpdateBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Tag mis a jour avec succes.',
+    schema: tagResponseSchema,
+  })
   async updateTag(
     @Param('id') id: string,
     @Body() body: unknown,
@@ -638,6 +678,35 @@ export class ArticlesController {
     }
 
     await this.articlesService.deleteTag(accessToken.data, id);
+  }
+
+  @Get(':id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Récupérer un article par son identifiant' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Article chargé avec succès.',
+    schema: articleSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Article introuvable.',
+    schema: apiErrorSchema,
+  })
+  async getArticleById(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.articlesService.getArticleById(accessToken.data, id);
   }
 
   @Delete(':id')

--- a/apps/api/src/articles/articles.controller.ts
+++ b/apps/api/src/articles/articles.controller.ts
@@ -150,6 +150,31 @@ const taxonomySchema = {
 export class ArticlesController {
   constructor(private readonly articlesService: ArticlesService) {}
 
+  private isCoverFile(value: unknown): value is {
+    originalname: string;
+    mimetype: string;
+    size: number;
+    buffer: Buffer;
+  } {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+
+    const candidate = value as {
+      originalname?: unknown;
+      mimetype?: unknown;
+      size?: unknown;
+      buffer?: unknown;
+    };
+
+    return (
+      typeof candidate.originalname === 'string' &&
+      typeof candidate.mimetype === 'string' &&
+      typeof candidate.size === 'number' &&
+      Buffer.isBuffer(candidate.buffer)
+    );
+  }
+
   @Get()
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Lister tous les articles administrables' })
@@ -368,7 +393,7 @@ export class ArticlesController {
   })
   @UseInterceptors(FileInterceptor('file'))
   async uploadCoverImage(
-    @UploadedFile() file: Express.Multer.File | undefined,
+    @UploadedFile() file: unknown,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<{ url: string; path: string }> {
     const accessToken = extractAccessToken(authorizationHeader);
@@ -380,7 +405,7 @@ export class ArticlesController {
       });
     }
 
-    if (!file?.buffer) {
+    if (this.isCoverFile(file) === false) {
       throw new BadRequestException({
         success: false,
         message: 'Le fichier image est requis.',

--- a/apps/api/src/articles/articles.controller.ts
+++ b/apps/api/src/articles/articles.controller.ts
@@ -7,22 +7,32 @@ import {
   Headers,
   HttpCode,
   HttpStatus,
+  InternalServerErrorException,
   Param,
   Patch,
   Post,
+  Put,
   UnauthorizedException,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiConsumes,
   ApiOperation,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import type { ArticleDto } from '@kraak/contracts';
+import type { ArticleDto, CategoryDto, TagDto } from '@kraak/contracts';
 import { extractAccessToken } from '../auth/auth.dto';
 import {
+  validateCreateCategoryPayload,
+  validateCreateTagPayload,
   validateCreateArticlePayload,
+  validateUpdateCategoryPayload,
+  validateUpdateTagPayload,
   validateUpdateArticlePayload,
 } from './articles.dto';
 import { ArticlesService } from './articles.service';
@@ -119,6 +129,19 @@ const apiErrorSchema = {
     success: { type: 'boolean', example: false },
     message: { type: 'string' },
     errors: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+const taxonomySchema = {
+  type: 'object',
+  required: ['id', 'slug', 'label', 'createdAt', 'updatedAt'],
+  properties: {
+    id: { type: 'string' },
+    slug: { type: 'string' },
+    label: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
   },
 };
 
@@ -229,7 +252,7 @@ export class ArticlesController {
     return this.articlesService.createArticle(accessToken.data, validated.data);
   }
 
-  @Patch(':id')
+  @Put(':id')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Mettre à jour un article' })
   @ApiBody({ schema: updateArticleBodySchema })
@@ -272,6 +295,324 @@ export class ArticlesController {
       id,
       validated.data,
     );
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Mettre à jour un article (compatibilite PATCH)' })
+  @ApiBody({ schema: updateArticleBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Article mis a jour avec succes.',
+    schema: articleSchema,
+  })
+  async patchArticle(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto> {
+    return this.updateArticle(id, body, authorizationHeader);
+  }
+
+  @Patch(':id/publish')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Publier un article' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Article publie avec succes.',
+    schema: articleSchema,
+  })
+  async publishArticle(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ArticleDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.articlesService.publishArticle(accessToken.data, id);
+  }
+
+  @Post('cover-image')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: "Envoyer une image de couverture d'article" })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Image de couverture envoyee.',
+    schema: {
+      type: 'object',
+      required: ['url', 'path'],
+      properties: {
+        url: { type: 'string' },
+        path: { type: 'string' },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadCoverImage(
+    @UploadedFile() file: Express.Multer.File | undefined,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<{ url: string; path: string }> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    if (!file?.buffer) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Le fichier image est requis.',
+      });
+    }
+
+    try {
+      return await this.articlesService.uploadCoverImage(
+        accessToken.data,
+        file,
+      );
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible d'envoyer l'image de couverture.",
+      });
+    }
+  }
+
+  @Get('categories')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Lister les categories' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Categories chargees avec succes.',
+    schema: { type: 'array', items: taxonomySchema },
+  })
+  async listCategories(
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<CategoryDto[]> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.articlesService.listCategories(accessToken.data);
+  }
+
+  @Post('categories')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Creer une categorie' })
+  @ApiBody({ schema: taxonomySchema })
+  async createCategory(
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<CategoryDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const validated = validateCreateCategoryPayload(body);
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.articlesService.createCategory(
+      accessToken.data,
+      validated.data,
+    );
+  }
+
+  @Patch('categories/:id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Mettre a jour une categorie' })
+  @ApiBody({ schema: taxonomySchema })
+  async updateCategory(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<CategoryDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const validated = validateUpdateCategoryPayload(body);
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.articlesService.updateCategory(
+      accessToken.data,
+      id,
+      validated.data,
+    );
+  }
+
+  @Delete('categories/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Archiver une categorie' })
+  async deleteCategory(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<void> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    await this.articlesService.deleteCategory(accessToken.data, id);
+  }
+
+  @Get('tags')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Lister les tags' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Tags charges avec succes.',
+    schema: { type: 'array', items: taxonomySchema },
+  })
+  async listTags(
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<TagDto[]> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    return this.articlesService.listTags(accessToken.data);
+  }
+
+  @Post('tags')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Creer un tag' })
+  @ApiBody({ schema: taxonomySchema })
+  async createTag(
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<TagDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const validated = validateCreateTagPayload(body);
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.articlesService.createTag(accessToken.data, validated.data);
+  }
+
+  @Patch('tags/:id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Mettre a jour un tag' })
+  @ApiBody({ schema: taxonomySchema })
+  async updateTag(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<TagDto> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const validated = validateUpdateTagPayload(body);
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.articlesService.updateTag(accessToken.data, id, validated.data);
+  }
+
+  @Delete('tags/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Archiver un tag' })
+  async deleteTag(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<void> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    await this.articlesService.deleteTag(accessToken.data, id);
   }
 
   @Delete(':id')

--- a/apps/api/src/articles/articles.dto.spec.ts
+++ b/apps/api/src/articles/articles.dto.spec.ts
@@ -1,5 +1,9 @@
 import {
+  validateCreateCategoryPayload,
+  validateCreateTagPayload,
   validateCreateArticlePayload,
+  validateUpdateCategoryPayload,
+  validateUpdateTagPayload,
   validateUpdateArticlePayload,
 } from './articles.dto';
 
@@ -177,6 +181,59 @@ describe('Articles DTO validation', () => {
         'Le champ coverImageUrl est invalide.',
         'Le champ publishedAt est invalide.',
       ],
+    });
+  });
+
+  it('Given un payload categorie valide, When validateCreateCategoryPayload est appele, Then les champs normalises sont renvoyes', () => {
+    const result = validateCreateCategoryPayload({
+      slug: '  immigration  ',
+      label: '  Immigration  ',
+      description: '  Description categorie  ',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        slug: 'immigration',
+        label: 'Immigration',
+        description: 'Description categorie',
+      },
+    });
+  });
+
+  it('Given un payload tag invalide, When validateCreateTagPayload est appele, Then les erreurs explicites sont renvoyees', () => {
+    const result = validateCreateTagPayload({
+      slug: '',
+      label: '',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Le champ slug est requis.', 'Le champ label est requis.'],
+    });
+  });
+
+  it('Given un payload categorie update vide, When validateUpdateCategoryPayload est appele, Then une erreur est renvoyee', () => {
+    const result = validateUpdateCategoryPayload({});
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Au moins un champ doit etre fourni pour la mise a jour.'],
+    });
+  });
+
+  it('Given un payload tag update valide, When validateUpdateTagPayload est appele, Then les champs sont normalises', () => {
+    const result = validateUpdateTagPayload({
+      slug: '  integrations  ',
+      label: '  Integrations  ',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        slug: 'integrations',
+        label: 'Integrations',
+      },
     });
   });
 });

--- a/apps/api/src/articles/articles.dto.spec.ts
+++ b/apps/api/src/articles/articles.dto.spec.ts
@@ -218,7 +218,7 @@ describe('Articles DTO validation', () => {
 
     expect(result).toEqual({
       valid: false,
-      errors: ['Au moins un champ doit etre fourni pour la mise a jour.'],
+      errors: ['Au moins un champ doit être fourni pour la mise à jour.'],
     });
   });
 
@@ -234,6 +234,30 @@ describe('Articles DTO validation', () => {
         slug: 'integrations',
         label: 'Integrations',
       },
+    });
+  });
+
+  it('Given un payload tag avec description, When validateCreateTagPayload est appele, Then une erreur explicite est renvoyee', () => {
+    const result = validateCreateTagPayload({
+      slug: 'tag-1',
+      label: 'Tag 1',
+      description: 'Description interdite',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Le champ description n’est pas autorisé pour un tag.'],
+    });
+  });
+
+  it('Given un payload tag update avec description, When validateUpdateTagPayload est appele, Then une erreur explicite est renvoyee', () => {
+    const result = validateUpdateTagPayload({
+      description: 'Description interdite',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Le champ description n’est pas autorisé pour un tag.'],
     });
   });
 });

--- a/apps/api/src/articles/articles.dto.ts
+++ b/apps/api/src/articles/articles.dto.ts
@@ -1,4 +1,11 @@
-import type { CreateArticleDto, UpdateArticleDto } from '@kraak/contracts';
+import type {
+  CreateArticleDto,
+  CreateCategoryDto,
+  CreateTagDto,
+  UpdateArticleDto,
+  UpdateCategoryDto,
+  UpdateTagDto,
+} from '@kraak/contracts';
 import {
   isObjectPayload,
   readTrimmedString,
@@ -312,4 +319,121 @@ export function validateUpdateArticlePayload(
     valid: true,
     data: updates,
   };
+}
+
+type TaxonomyCreatePayload = CreateCategoryDto | CreateTagDto;
+type TaxonomyUpdatePayload = UpdateCategoryDto | UpdateTagDto;
+
+function validateTaxonomyCreatePayload(
+  body: unknown,
+): ValidationResult<TaxonomyCreatePayload> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requete invalide.'],
+    };
+  }
+
+  const slug = readTrimmedString(body['slug']);
+  const label = readTrimmedString(body['label']);
+  const description =
+    'description' in body ? readNullableString(body['description']) : null;
+  const errors: string[] = [];
+
+  if (slug.length === 0) {
+    errors.push('Le champ slug est requis.');
+  }
+
+  if (label.length === 0) {
+    errors.push('Le champ label est requis.');
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data: { slug, label, description } as TaxonomyCreatePayload,
+  };
+}
+
+function validateTaxonomyUpdatePayload(
+  body: unknown,
+): ValidationResult<TaxonomyUpdatePayload> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requete invalide.'],
+    };
+  }
+
+  const updates: Record<string, string | null> = {};
+  const errors: string[] = [];
+
+  if ('slug' in body) {
+    const slug = readTrimmedString(body['slug']);
+    if (slug.length === 0) {
+      errors.push('Le champ slug est requis.');
+    } else {
+      updates['slug'] = slug;
+    }
+  }
+
+  if ('label' in body) {
+    const label = readTrimmedString(body['label']);
+    if (label.length === 0) {
+      errors.push('Le champ label est requis.');
+    } else {
+      updates['label'] = label;
+    }
+  }
+
+  if ('description' in body) {
+    updates['description'] = readNullableString(body['description']);
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return {
+      valid: false,
+      errors: ['Au moins un champ doit etre fourni pour la mise a jour.'],
+    };
+  }
+
+  return {
+    valid: true,
+    data: updates as TaxonomyUpdatePayload,
+  };
+}
+
+export function validateCreateCategoryPayload(
+  body: unknown,
+): ValidationResult<CreateCategoryDto> {
+  return validateTaxonomyCreatePayload(
+    body,
+  ) as ValidationResult<CreateCategoryDto>;
+}
+
+export function validateUpdateCategoryPayload(
+  body: unknown,
+): ValidationResult<UpdateCategoryDto> {
+  return validateTaxonomyUpdatePayload(
+    body,
+  ) as ValidationResult<UpdateCategoryDto>;
+}
+
+export function validateCreateTagPayload(
+  body: unknown,
+): ValidationResult<CreateTagDto> {
+  return validateTaxonomyCreatePayload(body) as ValidationResult<CreateTagDto>;
+}
+
+export function validateUpdateTagPayload(
+  body: unknown,
+): ValidationResult<UpdateTagDto> {
+  return validateTaxonomyUpdatePayload(body) as ValidationResult<UpdateTagDto>;
 }

--- a/apps/api/src/articles/articles.dto.ts
+++ b/apps/api/src/articles/articles.dto.ts
@@ -326,18 +326,18 @@ type TaxonomyUpdatePayload = UpdateCategoryDto | UpdateTagDto;
 
 function validateTaxonomyCreatePayload(
   body: unknown,
+  options: { allowDescription: boolean },
 ): ValidationResult<TaxonomyCreatePayload> {
   if (!isObjectPayload(body)) {
     return {
       valid: false,
-      errors: ['Corps de requete invalide.'],
+      errors: ['Corps de requête invalide.'],
     };
   }
 
   const slug = readTrimmedString(body['slug']);
   const label = readTrimmedString(body['label']);
-  const description =
-    'description' in body ? readNullableString(body['description']) : null;
+  const payload: Partial<CreateCategoryDto> = { slug, label };
   const errors: string[] = [];
 
   if (slug.length === 0) {
@@ -352,19 +352,31 @@ function validateTaxonomyCreatePayload(
     return { valid: false, errors };
   }
 
+  if (options.allowDescription) {
+    payload.description =
+      'description' in body ? readNullableString(body['description']) : null;
+  } else if ('description' in body) {
+    errors.push('Le champ description n’est pas autorisé pour un tag.');
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
   return {
     valid: true,
-    data: { slug, label, description } as TaxonomyCreatePayload,
+    data: payload as TaxonomyCreatePayload,
   };
 }
 
 function validateTaxonomyUpdatePayload(
   body: unknown,
+  options: { allowDescription: boolean },
 ): ValidationResult<TaxonomyUpdatePayload> {
   if (!isObjectPayload(body)) {
     return {
       valid: false,
-      errors: ['Corps de requete invalide.'],
+      errors: ['Corps de requête invalide.'],
     };
   }
 
@@ -389,8 +401,10 @@ function validateTaxonomyUpdatePayload(
     }
   }
 
-  if ('description' in body) {
+  if (options.allowDescription && 'description' in body) {
     updates['description'] = readNullableString(body['description']);
+  } else if (!options.allowDescription && 'description' in body) {
+    errors.push('Le champ description n’est pas autorisé pour un tag.');
   }
 
   if (errors.length > 0) {
@@ -400,7 +414,7 @@ function validateTaxonomyUpdatePayload(
   if (Object.keys(updates).length === 0) {
     return {
       valid: false,
-      errors: ['Au moins un champ doit etre fourni pour la mise a jour.'],
+      errors: ['Au moins un champ doit être fourni pour la mise à jour.'],
     };
   }
 
@@ -413,27 +427,31 @@ function validateTaxonomyUpdatePayload(
 export function validateCreateCategoryPayload(
   body: unknown,
 ): ValidationResult<CreateCategoryDto> {
-  return validateTaxonomyCreatePayload(
-    body,
-  ) as ValidationResult<CreateCategoryDto>;
+  return validateTaxonomyCreatePayload(body, {
+    allowDescription: true,
+  }) as ValidationResult<CreateCategoryDto>;
 }
 
 export function validateUpdateCategoryPayload(
   body: unknown,
 ): ValidationResult<UpdateCategoryDto> {
-  return validateTaxonomyUpdatePayload(
-    body,
-  ) as ValidationResult<UpdateCategoryDto>;
+  return validateTaxonomyUpdatePayload(body, {
+    allowDescription: true,
+  }) as ValidationResult<UpdateCategoryDto>;
 }
 
 export function validateCreateTagPayload(
   body: unknown,
 ): ValidationResult<CreateTagDto> {
-  return validateTaxonomyCreatePayload(body) as ValidationResult<CreateTagDto>;
+  return validateTaxonomyCreatePayload(body, {
+    allowDescription: false,
+  }) as ValidationResult<CreateTagDto>;
 }
 
 export function validateUpdateTagPayload(
   body: unknown,
 ): ValidationResult<UpdateTagDto> {
-  return validateTaxonomyUpdatePayload(body) as ValidationResult<UpdateTagDto>;
+  return validateTaxonomyUpdatePayload(body, {
+    allowDescription: false,
+  }) as ValidationResult<UpdateTagDto>;
 }

--- a/apps/api/src/articles/articles.dto.ts
+++ b/apps/api/src/articles/articles.dto.ts
@@ -348,10 +348,6 @@ function validateTaxonomyCreatePayload(
     errors.push('Le champ label est requis.');
   }
 
-  if (errors.length > 0) {
-    return { valid: false, errors };
-  }
-
   if (options.allowDescription) {
     payload.description =
       'description' in body ? readNullableString(body['description']) : null;

--- a/apps/api/src/articles/articles.module.ts
+++ b/apps/api/src/articles/articles.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ArticlesController } from './articles.controller';
+import { ArticlesPublicController } from './articles-public.controller';
 import { ArticlesService } from './articles.service';
 
 @Module({
-  controllers: [ArticlesController],
+  controllers: [ArticlesController, ArticlesPublicController],
   providers: [ArticlesService],
 })
 export class ArticlesModule {}

--- a/apps/api/src/articles/articles.service.spec.ts
+++ b/apps/api/src/articles/articles.service.spec.ts
@@ -672,6 +672,90 @@ describe('ArticlesService', () => {
     expect(articleQuery.eq).toHaveBeenCalledWith('status', 'published');
   });
 
+  it('Given un article public existant, When getPublicArticleBySlug est appele, Then le detail public est renvoye', async () => {
+    const articleQuery = createSingleRowQuery({
+      data: {
+        id: 'article-public-1',
+        slug: 'article-public-1',
+        title: 'Article public',
+        excerpt: 'Resume public',
+        content: '<p>Contenu public</p>',
+        status: 'published',
+        cover_image_url: null,
+        seo_title: null,
+        seo_description: null,
+        published_at: '2026-05-24T10:00:00.000Z',
+        author_id: 'author-1',
+        created_at: '2026-05-24T09:00:00.000Z',
+        updated_at: '2026-05-24T10:00:00.000Z',
+      },
+      error: null,
+    });
+    const articleCategoryQuery = createListQuery({
+      data: [{ article_id: 'article-public-1', category_id: 'category-1' }],
+      error: null,
+    });
+    const articleTagQuery = createListQuery({
+      data: [{ article_id: 'article-public-1', tag_id: 'tag-1' }],
+      error: null,
+    });
+    const categoryQuery = createListQuery({
+      data: [{ id: 'category-1' }],
+      error: null,
+    });
+    const tagQuery = createListQuery({
+      data: [{ id: 'tag-1' }],
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'article') {
+        return articleQuery;
+      }
+      if (tableName === 'article_category') {
+        return articleCategoryQuery;
+      }
+      if (tableName === 'article_tag') {
+        return articleTagQuery;
+      }
+      if (tableName === 'category') {
+        return categoryQuery;
+      }
+      if (tableName === 'tag') {
+        return tagQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getPublicArticleBySlug('article-public-1'),
+    ).resolves.toMatchObject({
+      id: 'article-public-1',
+      categoryIds: ['category-1'],
+      tagIds: ['tag-1'],
+    });
+  });
+
+  it('Given une erreur Supabase non not found, When getPublicArticleBySlug est appele, Then une InternalServerErrorException est renvoyee', async () => {
+    const articleQuery = createSingleRowQuery({
+      data: null,
+      error: { code: '08006', message: 'connection error' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'article') {
+        return articleQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.getPublicArticleBySlug('article-public-1'),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
   it('Given un article admin existant, When publishArticle est appele, Then son statut passe a published', async () => {
     const appUserQuery = createSingleRowQuery({
       data: { id: 'user-1', role: 'admin' },
@@ -726,6 +810,196 @@ describe('ArticlesService', () => {
     await expect(
       service.publishArticle('access-token', 'article-1'),
     ).resolves.toMatchObject({ status: 'published' });
+  });
+
+  it('Given une erreur Supabase non not found lors de publishArticle, When publishArticle est appele, Then une InternalServerErrorException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const publishQuery = createUpdateQuery({
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'article') {
+        return publishQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.publishArticle('access-token', 'article-1'),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it('Given une categorie inexistante lors de updateCategory, When updateCategory est appele, Then une NotFoundException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const categoryUpdateQuery = createUpdateQuery({
+      data: null,
+      error: { code: 'PGRST116', message: 'no rows' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'category') {
+        return categoryUpdateQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.updateCategory('access-token', 'missing-category', {
+        slug: 'categorie',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('Given une erreur technique lors de updateCategory, When updateCategory est appele, Then une InternalServerErrorException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const categoryUpdateQuery = createUpdateQuery({
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'category') {
+        return categoryUpdateQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.updateCategory('access-token', 'category-1', {
+        slug: 'categorie',
+      }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it('Given une categorie absente, When deleteCategory est appele, Then une NotFoundException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const existingCategoryQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'category') {
+        return existingCategoryQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteCategory('access-token', 'missing-category'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('Given un tag inexistant lors de updateTag, When updateTag est appele, Then une NotFoundException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const tagUpdateQuery = createUpdateQuery({
+      data: null,
+      error: { code: 'PGRST116', message: 'no rows' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'tag') {
+        return tagUpdateQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.updateTag('access-token', 'missing-tag', {
+        slug: 'tag-slug',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('Given une erreur technique lors de updateTag, When updateTag est appele, Then une InternalServerErrorException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const tagUpdateQuery = createUpdateQuery({
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'tag') {
+        return tagUpdateQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.updateTag('access-token', 'tag-1', {
+        slug: 'tag-slug',
+      }),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it('Given un tag absent, When deleteTag est appele, Then une NotFoundException est renvoyee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const existingTagQuery = createSingleRowQuery({
+      data: null,
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'tag') {
+        return existingTagQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.deleteTag('access-token', 'missing-tag'),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('Given un fichier image valide, When uploadCoverImage est appele, Then une URL publique est retournee', async () => {

--- a/apps/api/src/articles/articles.service.spec.ts
+++ b/apps/api/src/articles/articles.service.spec.ts
@@ -54,6 +54,14 @@ describe('ArticlesService', () => {
 
   const adminClient = {
     from: jest.fn(),
+    storage: {
+      from: jest.fn(() => ({
+        upload: jest.fn().mockResolvedValue({ error: null }),
+        getPublicUrl: jest.fn((path: string) => ({
+          data: { publicUrl: `https://cdn.kraak.test/${path}` },
+        })),
+      })),
+    },
   };
 
   const supabaseService = {
@@ -612,5 +620,135 @@ describe('ArticlesService', () => {
     await expect(
       service.deleteArticle('access-token', 'article-1'),
     ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it('Given des articles publies, When listPublicArticles est appele, Then seuls les articles publies sont retournes', async () => {
+    const articleQuery = createListQuery({
+      data: [
+        {
+          id: 'article-public-1',
+          slug: 'article-public-1',
+          title: 'Article public',
+          excerpt: 'Resume public',
+          content: '<p>Contenu public</p>',
+          status: 'published',
+          cover_image_url: null,
+          seo_title: null,
+          seo_description: null,
+          published_at: '2026-05-24T10:00:00.000Z',
+          author_id: 'author-1',
+          created_at: '2026-05-24T09:00:00.000Z',
+          updated_at: '2026-05-24T10:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const articleCategoryQuery = createListQuery({ data: [], error: null });
+    const articleTagQuery = createListQuery({ data: [], error: null });
+    const categoryQuery = createListQuery({ data: [], error: null });
+    const tagQuery = createListQuery({ data: [], error: null });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'article') {
+        return articleQuery;
+      }
+      if (tableName === 'article_category') {
+        return articleCategoryQuery;
+      }
+      if (tableName === 'article_tag') {
+        return articleTagQuery;
+      }
+      if (tableName === 'category') {
+        return categoryQuery;
+      }
+      if (tableName === 'tag') {
+        return tagQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(service.listPublicArticles()).resolves.toHaveLength(1);
+    expect(articleQuery.eq).toHaveBeenCalledWith('status', 'published');
+  });
+
+  it('Given un article admin existant, When publishArticle est appele, Then son statut passe a published', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+    const publishQuery = createUpdateQuery({
+      data: {
+        id: 'article-1',
+        slug: 'article-1',
+        title: 'Article 1',
+        excerpt: 'Resume article 1',
+        content: '<p>Contenu 1</p>',
+        status: 'published',
+        cover_image_url: null,
+        seo_title: null,
+        seo_description: null,
+        published_at: '2026-05-24T10:00:00.000Z',
+        author_id: 'author-1',
+        created_at: '2026-05-24T09:00:00.000Z',
+        updated_at: '2026-05-24T10:00:00.000Z',
+      },
+      error: null,
+    });
+    const articleCategoryQuery = createListQuery({ data: [], error: null });
+    const articleTagQuery = createListQuery({ data: [], error: null });
+    const categoryQuery = createListQuery({ data: [], error: null });
+    const tagQuery = createListQuery({ data: [], error: null });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+      if (tableName === 'article') {
+        return publishQuery;
+      }
+      if (tableName === 'article_category') {
+        return articleCategoryQuery;
+      }
+      if (tableName === 'article_tag') {
+        return articleTagQuery;
+      }
+      if (tableName === 'category') {
+        return categoryQuery;
+      }
+      if (tableName === 'tag') {
+        return tagQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.publishArticle('access-token', 'article-1'),
+    ).resolves.toMatchObject({ status: 'published' });
+  });
+
+  it('Given un fichier image valide, When uploadCoverImage est appele, Then une URL publique est retournee', async () => {
+    const appUserQuery = createSingleRowQuery({
+      data: { id: 'user-1', role: 'admin' },
+      error: null,
+    });
+
+    adminClient.from.mockImplementation((tableName: string) => {
+      if (tableName === 'app_user') {
+        return appUserQuery;
+      }
+
+      throw new Error(`Unexpected table ${tableName}`);
+    });
+
+    await expect(
+      service.uploadCoverImage('access-token', {
+        originalname: 'cover.jpg',
+        mimetype: 'image/jpeg',
+        size: 1024,
+        buffer: Buffer.from('image'),
+      }),
+    ).resolves.toMatchObject({ path: expect.stringContaining('articles/') });
   });
 });

--- a/apps/api/src/articles/articles.service.ts
+++ b/apps/api/src/articles/articles.service.ts
@@ -89,6 +89,19 @@ const notFoundSupabaseErrorCodes = new Set(['PGRST116']);
 export class ArticlesService {
   constructor(private readonly supabaseService: SupabaseService) {}
 
+  private readSupabaseErrorCode(error: unknown): string | null {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      typeof error.code === 'string'
+    ) {
+      return error.code;
+    }
+
+    return null;
+  }
+
   async listPublicArticles(): Promise<ArticleDto[]> {
     const adminClient = this.supabaseService.getClient();
     const { data, error } = await adminClient
@@ -122,7 +135,23 @@ export class ArticlesService {
       .eq('status', 'published')
       .single();
 
-    if (error || !data) {
+    if (error) {
+      if (
+        notFoundSupabaseErrorCodes.has(this.readSupabaseErrorCode(error) ?? '')
+      ) {
+        throw new NotFoundException({
+          success: false,
+          message: 'Article introuvable.',
+        });
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de charger l'article demandé.",
+      });
+    }
+
+    if (!data) {
       throw new NotFoundException({
         success: false,
         message: 'Article introuvable.',
@@ -269,13 +298,7 @@ export class ArticlesService {
   }
 
   private handleUpdateError(error: unknown): void {
-    const errorCode =
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      typeof error.code === 'string'
-        ? error.code
-        : null;
+    const errorCode = this.readSupabaseErrorCode(error);
 
     if (errorCode !== null && notFoundSupabaseErrorCodes.has(errorCode)) {
       throw new NotFoundException({
@@ -394,7 +417,23 @@ export class ArticlesService {
       .select(articleSelectFields)
       .single();
 
-    if (error || !data) {
+    if (error) {
+      if (
+        notFoundSupabaseErrorCodes.has(this.readSupabaseErrorCode(error) ?? '')
+      ) {
+        throw new NotFoundException({
+          success: false,
+          message: 'Article introuvable.',
+        });
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible de publier l'article.",
+      });
+    }
+
+    if (!data) {
       throw new NotFoundException({
         success: false,
         message: 'Article introuvable.',
@@ -530,7 +569,23 @@ export class ArticlesService {
       .select(categorySelectFields)
       .single();
 
-    if (error || !data) {
+    if (error) {
+      if (
+        notFoundSupabaseErrorCodes.has(this.readSupabaseErrorCode(error) ?? '')
+      ) {
+        throw new NotFoundException({
+          success: false,
+          message: 'Catégorie introuvable.',
+        });
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de mettre à jour la catégorie.',
+      });
+    }
+
+    if (!data) {
       throw new NotFoundException({
         success: false,
         message: 'Catégorie introuvable.',
@@ -544,6 +599,27 @@ export class ArticlesService {
     await this.assertAdminAccess(accessToken);
 
     const adminClient = this.supabaseService.getClient();
+    const { data: existing, error: existingError } = await adminClient
+      .from('category')
+      .select('id')
+      .eq('id', categoryId)
+      .neq('status', 'archived')
+      .maybeSingle();
+
+    if (existingError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible d’archiver la catégorie.',
+      });
+    }
+
+    if (!existing) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Catégorie introuvable.',
+      });
+    }
+
     const { error } = await adminClient
       .from('category')
       .update({ status: 'archived' })
@@ -622,7 +698,23 @@ export class ArticlesService {
       .select(tagSelectFields)
       .single();
 
-    if (error || !data) {
+    if (error) {
+      if (
+        notFoundSupabaseErrorCodes.has(this.readSupabaseErrorCode(error) ?? '')
+      ) {
+        throw new NotFoundException({
+          success: false,
+          message: 'Tag introuvable.',
+        });
+      }
+
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de mettre à jour le tag.',
+      });
+    }
+
+    if (!data) {
       throw new NotFoundException({
         success: false,
         message: 'Tag introuvable.',
@@ -636,6 +728,27 @@ export class ArticlesService {
     await this.assertAdminAccess(accessToken);
 
     const adminClient = this.supabaseService.getClient();
+    const { data: existing, error: existingError } = await adminClient
+      .from('tag')
+      .select('id')
+      .eq('id', tagId)
+      .neq('status', 'archived')
+      .maybeSingle();
+
+    if (existingError) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible d’archiver le tag.',
+      });
+    }
+
+    if (!existing) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Tag introuvable.',
+      });
+    }
+
     const { error } = await adminClient
       .from('tag')
       .update({ status: 'archived' })

--- a/apps/api/src/articles/articles.service.ts
+++ b/apps/api/src/articles/articles.service.ts
@@ -8,10 +8,21 @@ import {
 } from '@nestjs/common';
 import type {
   ArticleDto,
+  CategoryDto,
   CreateArticleDto,
+  CreateCategoryDto,
+  CreateTagDto,
+  TagDto,
   UpdateArticleDto,
+  UpdateCategoryDto,
+  UpdateTagDto,
 } from '@kraak/contracts';
 import { SupabaseService } from '../supabase/supabase.service';
+
+type UploadedCoverImage = {
+  url: string;
+  path: string;
+};
 
 type ArticleRow = {
   id: string;
@@ -48,13 +59,80 @@ type TaxonomyIdRow = {
   id: string;
 };
 
+type CategoryRow = {
+  id: string;
+  slug: string;
+  label: string;
+  description: string | null;
+  status: ArticleDto['status'];
+  created_at: string;
+  updated_at: string;
+};
+
+type TagRow = {
+  id: string;
+  slug: string;
+  label: string;
+  status: ArticleDto['status'];
+  created_at: string;
+  updated_at: string;
+};
+
 const articleSelectFields =
   'id, slug, title, excerpt, content, status, cover_image_url, seo_title, seo_description, published_at, author_id, created_at, updated_at';
+const categorySelectFields =
+  'id, slug, label, description, status, created_at, updated_at';
+const tagSelectFields = 'id, slug, label, status, created_at, updated_at';
 const notFoundSupabaseErrorCodes = new Set(['PGRST116']);
 
 @Injectable()
 export class ArticlesService {
   constructor(private readonly supabaseService: SupabaseService) {}
+
+  async listPublicArticles(): Promise<ArticleDto[]> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('article')
+      .select(articleSelectFields)
+      .eq('status', 'published')
+      .order('published_at', { ascending: false })
+      .limit(100);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les articles publiés.',
+      });
+    }
+
+    const rows = (data as ArticleRow[] | null) ?? [];
+    const relations = await this.readArticleRelations(
+      rows.map((row) => row.id),
+    );
+
+    return rows.map((row) => this.mapArticleRow(row, relations));
+  }
+
+  async getPublicArticleBySlug(slug: string): Promise<ArticleDto> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('article')
+      .select(articleSelectFields)
+      .eq('slug', slug)
+      .eq('status', 'published')
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+
+    const articleRow = data as ArticleRow;
+    const relations = await this.readArticleRelations([articleRow.id]);
+    return this.mapArticleRow(articleRow, relations);
+  }
 
   async listArticles(accessToken: string): Promise<ArticleDto[]> {
     await this.assertAdminAccess(accessToken);
@@ -298,6 +376,280 @@ export class ArticlesService {
     }
   }
 
+  async publishArticle(
+    accessToken: string,
+    articleId: string,
+  ): Promise<ArticleDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('article')
+      .update({
+        status: 'published',
+        published_at: new Date().toISOString(),
+      })
+      .eq('id', articleId)
+      .neq('status', 'archived')
+      .select(articleSelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Article introuvable.',
+      });
+    }
+
+    const row = data as ArticleRow;
+    const relations = await this.readArticleRelations([row.id]);
+    return this.mapArticleRow(row, relations);
+  }
+
+  async uploadCoverImage(
+    accessToken: string,
+    file: {
+      originalname: string;
+      mimetype: string;
+      size: number;
+      buffer: Buffer;
+    },
+  ): Promise<UploadedCoverImage> {
+    await this.assertAdminAccess(accessToken);
+
+    if (file.mimetype.startsWith('image/') === false) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Le fichier doit être une image.',
+      });
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      throw new BadRequestException({
+        success: false,
+        message: "L'image de couverture dépasse la limite de 5MB.",
+      });
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const normalizedName = file.originalname.replace(/[^a-zA-Z0-9._-]/g, '-');
+    const uploadPath = `articles/${Date.now()}-${normalizedName}`;
+
+    const { error } = await adminClient.storage
+      .from('article-covers')
+      .upload(uploadPath, file.buffer, {
+        contentType: file.mimetype,
+        upsert: false,
+      });
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: "Impossible d'envoyer l'image de couverture.",
+      });
+    }
+
+    const {
+      data: { publicUrl },
+    } = adminClient.storage.from('article-covers').getPublicUrl(uploadPath);
+
+    return {
+      url: publicUrl,
+      path: uploadPath,
+    };
+  }
+
+  async listCategories(accessToken: string): Promise<CategoryDto[]> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('category')
+      .select(categorySelectFields)
+      .neq('status', 'archived')
+      .order('label', { ascending: true })
+      .limit(200);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les catégories.',
+      });
+    }
+
+    return ((data as CategoryRow[] | null) ?? []).map((row) =>
+      this.mapCategoryRow(row),
+    );
+  }
+
+  async createCategory(
+    accessToken: string,
+    payload: CreateCategoryDto,
+  ): Promise<CategoryDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('category')
+      .insert({
+        slug: payload.slug,
+        label: payload.label,
+        description: payload.description,
+        status: 'draft',
+      })
+      .select(categorySelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de créer la catégorie.',
+      });
+    }
+
+    return this.mapCategoryRow(data as CategoryRow);
+  }
+
+  async updateCategory(
+    accessToken: string,
+    categoryId: string,
+    payload: UpdateCategoryDto,
+  ): Promise<CategoryDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('category')
+      .update({
+        slug: payload.slug,
+        label: payload.label,
+        description: payload.description,
+      })
+      .eq('id', categoryId)
+      .neq('status', 'archived')
+      .select(categorySelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Catégorie introuvable.',
+      });
+    }
+
+    return this.mapCategoryRow(data as CategoryRow);
+  }
+
+  async deleteCategory(accessToken: string, categoryId: string): Promise<void> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { error } = await adminClient
+      .from('category')
+      .update({ status: 'archived' })
+      .eq('id', categoryId)
+      .neq('status', 'archived');
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible d’archiver la catégorie.',
+      });
+    }
+  }
+
+  async listTags(accessToken: string): Promise<TagDto[]> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('tag')
+      .select(tagSelectFields)
+      .neq('status', 'archived')
+      .order('label', { ascending: true })
+      .limit(200);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger les tags.',
+      });
+    }
+
+    return ((data as TagRow[] | null) ?? []).map((row) => this.mapTagRow(row));
+  }
+
+  async createTag(accessToken: string, payload: CreateTagDto): Promise<TagDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('tag')
+      .insert({
+        slug: payload.slug,
+        label: payload.label,
+        status: 'draft',
+      })
+      .select(tagSelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de créer le tag.',
+      });
+    }
+
+    return this.mapTagRow(data as TagRow);
+  }
+
+  async updateTag(
+    accessToken: string,
+    tagId: string,
+    payload: UpdateTagDto,
+  ): Promise<TagDto> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('tag')
+      .update({
+        slug: payload.slug,
+        label: payload.label,
+      })
+      .eq('id', tagId)
+      .neq('status', 'archived')
+      .select(tagSelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Tag introuvable.',
+      });
+    }
+
+    return this.mapTagRow(data as TagRow);
+  }
+
+  async deleteTag(accessToken: string, tagId: string): Promise<void> {
+    await this.assertAdminAccess(accessToken);
+
+    const adminClient = this.supabaseService.getClient();
+    const { error } = await adminClient
+      .from('tag')
+      .update({ status: 'archived' })
+      .eq('id', tagId)
+      .neq('status', 'archived');
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible d’archiver le tag.',
+      });
+    }
+  }
+
   private async assertAdminAccess(accessToken: string): Promise<string> {
     const authClient = this.supabaseService.createAuthClient();
     const { data, error } = await authClient.auth.getUser(accessToken);
@@ -495,6 +847,27 @@ export class ArticlesService {
       authorId: row.author_id,
       categoryIds: relations.categoryByArticleId.get(row.id) ?? [],
       tagIds: relations.tagByArticleId.get(row.id) ?? [],
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapCategoryRow(row: CategoryRow): CategoryDto {
+    return {
+      id: row.id,
+      slug: row.slug,
+      label: row.label,
+      description: row.description,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapTagRow(row: TagRow): TagDto {
+    return {
+      id: row.id,
+      slug: row.slug,
+      label: row.label,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };


### PR DESCRIPTION
## Objectif
Implementer CMS-02 cote API avec endpoints admin/public des articles, publication et gestion taxonomy.

## Changements
- Admin Articles: CRUD complet (POST, PUT/PATCH, DELETE)
- Admin Articles: PATCH /admin/articles/:id/publish
- Admin Articles: upload image de couverture (POST /admin/articles/cover-image)
- Admin Categories/Tags: listing + creation + mise a jour + archivage
- Public Articles: GET /articles et GET /articles/:slug
- Swagger enrichi sur les nouvelles routes
- Tests ajoutes/ajustes sur controller, service, dto et public controller

## Validation
- pnpm --filter @kraak/api lint
- pnpm --filter @kraak/api exec tsc --noEmit -p tsconfig.build.json
- pnpm --filter @kraak/api test -- src/articles/articles.controller.spec.ts src/articles/articles-public.controller.spec.ts src/articles/articles.service.spec.ts src/articles/articles.dto.spec.ts

## Tracking
- Relates to #353
- Parent epic: #332
