### PR TITLE
feat(web): implement public blog listing and article seo

### DIFF
--- a/apps/client/projects/web/public/sitemap.xml
+++ b/apps/client/projects/web/public/sitemap.xml
@@ -21,6 +21,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://kraak-consulting.vercel.app/blog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://kraak-consulting.vercel.app/ressources</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
@@ -44,5 +49,20 @@
     <loc>https://kraak-consulting.vercel.app/politique-de-confidentialite</loc>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>https://kraak-consulting.vercel.app/blog/clarifier-son-projet-avant-de-candidater</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://kraak-consulting.vercel.app/blog/choisir-un-format-de-formation-utile</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://kraak-consulting.vercel.app/blog/preparer-un-dossier-immigration-sans-perdre-le-fil</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.html
@@ -63,38 +63,30 @@
             {{ article.intro }}
           </p>
 
-          @for (section of article.sections; track section.heading) {
-            <section class="rounded-card bg-neutral-50 p-6">
-              <h2 class="text-2xl font-bold">{{ section.heading }}</h2>
-              @for (paragraph of section.paragraphs; track paragraph) {
-                <p class="mt-4 leading-relaxed text-neutral-700">
-                  {{ paragraph }}
-                </p>
-              }
-              @if (section.bullets?.length) {
-                <ul class="mt-4 list-disc space-y-2 pl-5 text-neutral-700">
-                  @for (bullet of section.bullets; track bullet) {
-                    <li>{{ bullet }}</li>
-                  }
-                </ul>
-              }
+          <section class="rounded-card bg-neutral-50 p-6">
+            <h2 class="text-2xl font-bold">Contenu de l'article</h2>
+            <div
+              class="prose prose-neutral mt-4 max-w-none"
+              [innerHTML]="article.content"
+            ></div>
+          </section>
+
+          @if (article.takeawayPoints.length > 0) {
+            <section class="rounded-card bg-brand-blue/5 p-6">
+              <h2 class="text-2xl font-bold">À retenir</h2>
+              <ul class="mt-4 space-y-3">
+                @for (point of article.takeawayPoints; track point) {
+                  <li class="flex gap-3 text-neutral-700">
+                    <i
+                      class="pi pi-check-circle text-brand-blue mt-1"
+                      aria-hidden="true"
+                    ></i>
+                    <span>{{ point }}</span>
+                  </li>
+                }
+              </ul>
             </section>
           }
-
-          <section class="rounded-card bg-brand-blue/5 p-6">
-            <h2 class="text-2xl font-bold">À retenir</h2>
-            <ul class="mt-4 space-y-3">
-              @for (point of article.takeawayPoints; track point) {
-                <li class="flex gap-3 text-neutral-700">
-                  <i
-                    class="pi pi-check-circle text-brand-blue mt-1"
-                    aria-hidden="true"
-                  ></i>
-                  <span>{{ point }}</span>
-                </li>
-              }
-            </ul>
-          </section>
         </div>
       </article>
 
@@ -124,23 +116,27 @@
           </p>
         </section>
 
-        <section class="rounded-card bg-neutral-50 p-6 shadow-sm">
-          <p
-            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
-          >
-            Catégorie et tags
-          </p>
-          <p class="mt-3 text-lg font-semibold">{{ article.categoryLabel }}</p>
-          <div class="mt-4 flex flex-wrap gap-2">
-            @for (tag of article.tagLabels; track tag) {
-              <span
-                class="rounded-full bg-white px-3 py-1 text-sm text-neutral-700 shadow-sm"
-              >
-                {{ tag }}
-              </span>
-            }
-          </div>
-        </section>
+        @if (article.tagLabels.length > 0) {
+          <section class="rounded-card bg-neutral-50 p-6 shadow-sm">
+            <p
+              class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+            >
+              Catégorie et tags
+            </p>
+            <p class="mt-3 text-lg font-semibold">
+              {{ article.categoryLabel }}
+            </p>
+            <div class="mt-4 flex flex-wrap gap-2">
+              @for (tag of article.tagLabels; track tag) {
+                <span
+                  class="rounded-full bg-white px-3 py-1 text-sm text-neutral-700 shadow-sm"
+                >
+                  {{ tag }}
+                </span>
+              }
+            </div>
+          </section>
+        }
 
         <section class="rounded-card bg-neutral-50 p-6 shadow-sm">
           <p

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
@@ -4,11 +4,13 @@ import {
   convertToParamMap,
   provideRouter,
 } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { vi } from 'vitest';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { SeoService } from '../../seo/seo.service';
+import { blogArticles } from './blog.data';
+import { BlogPublicService } from './blog-public.service';
 import BlogArticlePage from './blog-article.page';
 
 const gsapAnimationsServiceMock: Pick<
@@ -32,10 +34,22 @@ describe('BlogArticlePage', () => {
   const seoServiceMock = {
     applyPageSeo: vi.fn(),
   };
+  const blogPublicServiceMock = {
+    listPublishedArticles: vi.fn(() => of([...blogArticles])),
+    getPublishedArticleBySlug: vi.fn((slug: string) =>
+      of(blogArticles.find((article) => article.slug === slug) ?? null),
+    ),
+  };
   let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+
+  afterEach(() => {
+    document.head.querySelector('#kraak-blog-article-jsonld')?.remove();
+  });
 
   beforeEach(async () => {
     seoServiceMock.applyPageSeo.mockReset();
+    blogPublicServiceMock.listPublishedArticles.mockClear();
+    blogPublicServiceMock.getPublishedArticleBySlug.mockClear();
     paramMapSubject = new BehaviorSubject(
       convertToParamMap({
         slug: 'clarifier-son-projet-avant-de-candidater',
@@ -53,6 +67,10 @@ describe('BlogArticlePage', () => {
         {
           provide: GsapAnimationsService,
           useValue: gsapAnimationsServiceMock,
+        },
+        {
+          provide: BlogPublicService,
+          useValue: blogPublicServiceMock,
         },
         {
           provide: ActivatedRoute,
@@ -82,7 +100,7 @@ describe('BlogArticlePage', () => {
     const content = fixture.nativeElement.textContent as string;
 
     expect(content).toContain('Clarifier son projet avant de candidater');
-    expect(content).toContain('1. Commencez par le résultat attendu');
+    expect(content).toContain("Contenu de l'article");
     expect(content).toContain('À retenir');
     expect(content).toContain('Aline Koné');
     expect(content).toContain('Retour au blog');
@@ -98,6 +116,12 @@ describe('BlogArticlePage', () => {
         title: 'Clarifier son projet avant de candidater | KRAAK Consulting',
       }),
     );
+
+    const jsonLdTag = document.head.querySelector<HTMLScriptElement>(
+      '#kraak-blog-article-jsonld',
+    );
+    expect(jsonLdTag).not.toBeNull();
+    expect(jsonLdTag?.textContent).toContain('"@type":"Article"');
   });
 
   it('Given the same component instance When the slug route parameter changes Then article state and SEO are updated', () => {
@@ -123,5 +147,26 @@ describe('BlogArticlePage', () => {
         path: 'blog/preparer-un-dossier-immigration-sans-perdre-le-fil',
       }),
     );
+  });
+
+  it('Given an unknown article slug, When the page loads, Then it applies missing article SEO and removes JSON-LD', () => {
+    const fixture = TestBed.createComponent(BlogArticlePage);
+    fixture.detectChanges();
+
+    paramMapSubject.next(
+      convertToParamMap({
+        slug: 'slug-introuvable',
+      }),
+    );
+
+    expect(seoServiceMock.applyPageSeo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'blog/slug-introuvable',
+        title: 'Article introuvable | KRAAK Consulting',
+      }),
+    );
+    expect(
+      document.head.querySelector('#kraak-blog-article-jsonld'),
+    ).toBeNull();
   });
 });

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
@@ -122,6 +122,29 @@ describe('BlogArticlePage', () => {
     );
     expect(jsonLdTag).not.toBeNull();
     expect(jsonLdTag?.textContent).toContain('"@type":"Article"');
+    expect(
+      blogPublicServiceMock.getPublishedArticleBySlug,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given an API article with absolute cover image URL, When SEO is rendered, Then JSON-LD keeps that absolute URL', () => {
+    blogPublicServiceMock.getPublishedArticleBySlug.mockReturnValueOnce(
+      of({
+        ...blogArticles[0],
+        coverImagePath: 'https://cdn.example.com/cover.jpg',
+      }),
+    );
+
+    const fixture = TestBed.createComponent(BlogArticlePage);
+    fixture.detectChanges();
+
+    const jsonLdTag = document.head.querySelector<HTMLScriptElement>(
+      '#kraak-blog-article-jsonld',
+    );
+
+    expect(jsonLdTag?.textContent).toContain(
+      '"image":["https://cdn.example.com/cover.jpg"]',
+    );
   });
 
   it('Given the article page initial load When route params emit the initial slug Then the article is fetched once', () => {

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.spec.ts
@@ -124,6 +124,15 @@ describe('BlogArticlePage', () => {
     expect(jsonLdTag?.textContent).toContain('"@type":"Article"');
   });
 
+  it('Given the article page initial load When route params emit the initial slug Then the article is fetched once', () => {
+    const fixture = TestBed.createComponent(BlogArticlePage);
+    fixture.detectChanges();
+
+    expect(
+      blogPublicServiceMock.getPublishedArticleBySlug,
+    ).toHaveBeenCalledTimes(1);
+  });
+
   it('Given the same component instance When the slug route parameter changes Then article state and SEO are updated', () => {
     const fixture = TestBed.createComponent(BlogArticlePage);
     fixture.detectChanges();

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
@@ -1,4 +1,4 @@
-import { NgStyle } from '@angular/common';
+import { DOCUMENT, NgStyle } from '@angular/common';
 import {
   Component,
   DestroyRef,
@@ -8,20 +8,25 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Meta } from '@angular/platform-browser';
 import { ButtonDirective } from 'primeng/button';
-import { startWith } from 'rxjs';
+import { map, of, startWith, switchMap } from 'rxjs';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { SeoService } from '../../seo/seo.service';
+import { buildAbsoluteUrl, resolvePublicSiteUrl } from '../../seo/site-seo';
+import { environment } from '../../../environments/environment';
 import {
   type BlogArticle,
   buildBlogArticleSeo,
   buildMissingBlogArticleSeo,
   findBlogArticleBySlug,
+  getFallbackBlogArticles,
   getRelatedBlogArticles,
 } from './blog.data';
+import { BlogPublicService } from './blog-public.service';
 
 @Component({
   selector: 'kraak-blog-article-page',
@@ -32,10 +37,13 @@ import {
 export default class BlogArticlePage implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly document = inject(DOCUMENT);
+  private readonly meta = inject(Meta);
   private readonly seoService = inject(SeoService);
   private readonly gsapService = inject(GsapAnimationsService);
+  private readonly blogPublicService = inject(BlogPublicService);
 
-  protected article: BlogArticle | undefined;
+  protected article: BlogArticle | null = null;
   protected relatedArticles: readonly BlogArticle[] = [];
   protected heroBackgroundStyle = buildHeroBackgroundStyle(
     '/assets/site-visuals/photos/home-hero-workshop.avif',
@@ -50,28 +58,123 @@ export default class BlogArticlePage implements OnInit, OnDestroy {
 
     this.route.paramMap
       .pipe(startWith(this.route.snapshot.paramMap))
+      .pipe(map((params) => params.get('slug') ?? ''))
+      .pipe(
+        switchMap((slug) => {
+          const fallbackArticles = [...getFallbackBlogArticles()];
+          const fallbackArticle = findBlogArticleBySlug(slug, fallbackArticles);
+          this.applyArticleState(
+            slug,
+            fallbackArticle ?? null,
+            fallbackArticles,
+          );
+
+          return this.blogPublicService.getPublishedArticleBySlug(slug).pipe(
+            switchMap((article) => {
+              const articleToRender = article ?? fallbackArticle ?? null;
+
+              if (!articleToRender) {
+                return of({
+                  slug,
+                  article: null,
+                  articlePool: [] as BlogArticle[],
+                });
+              }
+
+              return this.blogPublicService.listPublishedArticles().pipe(
+                map((publishedArticles) => ({
+                  slug,
+                  article: articleToRender,
+                  articlePool: publishedArticles,
+                })),
+              );
+            }),
+          );
+        }),
+      )
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((params) => this.applyPageState(params.get('slug') ?? ''));
+      .subscribe(({ slug, article, articlePool }) => {
+        this.applyArticleState(slug, article, articlePool);
+      });
   }
 
   ngOnDestroy(): void {
+    this.removeStructuredData();
     this.gsapService.killAllAnimations();
   }
 
-  private applyPageState(slug: string): void {
-    this.article = findBlogArticleBySlug(slug);
-    this.relatedArticles = this.article
-      ? getRelatedBlogArticles(this.article)
+  private updateStructuredData(article: BlogArticle): void {
+    const siteUrl = resolvePublicSiteUrl(environment.siteUrl);
+    const canonicalUrl = buildAbsoluteUrl(`blog/${article.slug}`, siteUrl);
+    const imageUrl = buildAbsoluteUrl(article.coverImagePath, siteUrl);
+    const publishedAt =
+      article.publishedAt ?? article.createdAt ?? new Date().toISOString();
+    const updatedAt = article.updatedAt ?? article.createdAt ?? publishedAt;
+
+    const articleStructuredData = {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: article.title,
+      description: article.seoDescription ?? article.summary,
+      image: [imageUrl],
+      datePublished: publishedAt,
+      dateModified: updatedAt,
+      mainEntityOfPage: canonicalUrl,
+      author: {
+        '@type': 'Person',
+        name: article.author.name,
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'KRAAK Consulting',
+      },
+    };
+
+    this.upsertStructuredData(articleStructuredData);
+  }
+
+  private applyArticleState(
+    slug: string,
+    article: BlogArticle | null,
+    articlePool: readonly BlogArticle[],
+  ): void {
+    this.article = article;
+    this.relatedArticles = article
+      ? getRelatedBlogArticles(article, articlePool)
       : [];
     this.heroBackgroundStyle = buildHeroBackgroundStyle(
-      this.article?.coverImagePath ??
+      article?.coverImagePath ??
         '/assets/site-visuals/photos/home-hero-workshop.avif',
     );
 
-    this.seoService.applyPageSeo(
-      this.article
-        ? buildBlogArticleSeo(this.article)
-        : buildMissingBlogArticleSeo(slug),
-    );
+    if (!article) {
+      this.meta.updateTag({ property: 'og:type', content: 'website' });
+      this.removeStructuredData();
+      this.seoService.applyPageSeo(buildMissingBlogArticleSeo(slug));
+      return;
+    }
+
+    this.seoService.applyPageSeo(buildBlogArticleSeo(article));
+    this.meta.updateTag({ property: 'og:type', content: 'article' });
+    this.updateStructuredData(article);
+  }
+
+  private upsertStructuredData(payload: Record<string, unknown>): void {
+    const head = this.document.head;
+    const scriptId = 'kraak-blog-article-jsonld';
+    let jsonLdTag = head.querySelector<HTMLScriptElement>(`#${scriptId}`);
+
+    if (!jsonLdTag) {
+      jsonLdTag = this.document.createElement('script');
+      jsonLdTag.id = scriptId;
+      jsonLdTag.type = 'application/ld+json';
+      head.appendChild(jsonLdTag);
+    }
+
+    jsonLdTag.textContent = JSON.stringify(payload);
+  }
+
+  private removeStructuredData(): void {
+    this.document.head.querySelector('#kraak-blog-article-jsonld')?.remove();
   }
 }

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
@@ -10,7 +10,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Meta } from '@angular/platform-browser';
 import { ButtonDirective } from 'primeng/button';
-import { map, of, startWith, switchMap } from 'rxjs';
+import { map, of, switchMap } from 'rxjs';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
@@ -57,7 +57,6 @@ export default class BlogArticlePage implements OnInit, OnDestroy {
     this.gsapService.initializeSectionAnimations();
 
     this.route.paramMap
-      .pipe(startWith(this.route.snapshot.paramMap))
       .pipe(map((params) => params.get('slug') ?? ''))
       .pipe(
         switchMap((slug) => {
@@ -112,7 +111,10 @@ export default class BlogArticlePage implements OnInit, OnDestroy {
     }
   }
 
-  private resolveArticleImageUrl(imagePathOrUrl: string, siteUrl: string): string {
+  private resolveArticleImageUrl(
+    imagePathOrUrl: string,
+    siteUrl: string,
+  ): string {
     return this.isAbsoluteUrl(imagePathOrUrl)
       ? imagePathOrUrl
       : buildAbsoluteUrl(imagePathOrUrl, siteUrl);

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
@@ -103,10 +103,28 @@ export default class BlogArticlePage implements OnInit, OnDestroy {
     this.gsapService.killAllAnimations();
   }
 
+  private isAbsoluteUrl(value: string): boolean {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  private resolveArticleImageUrl(imagePathOrUrl: string, siteUrl: string): string {
+    return this.isAbsoluteUrl(imagePathOrUrl)
+      ? imagePathOrUrl
+      : buildAbsoluteUrl(imagePathOrUrl, siteUrl);
+  }
+
   private updateStructuredData(article: BlogArticle): void {
     const siteUrl = resolvePublicSiteUrl(environment.siteUrl);
     const canonicalUrl = buildAbsoluteUrl(`blog/${article.slug}`, siteUrl);
-    const imageUrl = buildAbsoluteUrl(article.coverImagePath, siteUrl);
+    const imageUrl = this.resolveArticleImageUrl(
+      article.coverImagePath,
+      siteUrl,
+    );
     const publishedAt =
       article.publishedAt ?? article.createdAt ?? new Date().toISOString();
     const updatedAt = article.updatedAt ?? article.createdAt ?? publishedAt;

--- a/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-article.page.ts
@@ -10,7 +10,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Meta } from '@angular/platform-browser';
 import { ButtonDirective } from 'primeng/button';
-import { map, of, switchMap } from 'rxjs';
+import { distinctUntilChanged, map, of, startWith, switchMap } from 'rxjs';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
@@ -57,7 +57,9 @@ export default class BlogArticlePage implements OnInit, OnDestroy {
     this.gsapService.initializeSectionAnimations();
 
     this.route.paramMap
+      .pipe(startWith(this.route.snapshot.paramMap))
       .pipe(map((params) => params.get('slug') ?? ''))
+      .pipe(distinctUntilChanged())
       .pipe(
         switchMap((slug) => {
           const fallbackArticles = [...getFallbackBlogArticles()];

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
@@ -1,0 +1,96 @@
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+
+import { BlogPublicService } from './blog-public.service';
+
+describe('BlogPublicService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+  });
+
+  it('Given the public articles endpoint, When listing published articles, Then API values are mapped to blog cards', () => {
+    const service = TestBed.inject(BlogPublicService);
+    const httpController = TestBed.inject(HttpTestingController);
+
+    let receivedTitle = '';
+
+    service.listPublishedArticles().subscribe((articles) => {
+      receivedTitle = articles[0]?.title ?? '';
+    });
+
+    const request = httpController.expectOne('http://localhost:3000/articles');
+    expect(request.request.method).toBe('GET');
+    request.flush([
+      {
+        id: 'article-1',
+        slug: 'article-api',
+        title: 'Article API',
+        excerpt: 'Résumé API',
+        content: '<p>Contenu</p>',
+        status: 'published',
+        coverImageUrl: null,
+        seoTitle: null,
+        seoDescription: null,
+        publishedAt: '2026-05-24T09:00:00.000Z',
+        authorId: 'author-1',
+        categoryIds: [],
+        tagIds: [],
+        createdAt: '2026-05-24T09:00:00.000Z',
+        updatedAt: '2026-05-24T09:00:00.000Z',
+      },
+    ]);
+
+    httpController.verify();
+    expect(receivedTitle).toBe('Article API');
+  });
+
+  it('Given an API failure, When listing published articles, Then fallback articles are returned', () => {
+    const service = TestBed.inject(BlogPublicService);
+    const httpController = TestBed.inject(HttpTestingController);
+
+    let receivedCount = 0;
+
+    service.listPublishedArticles().subscribe((articles) => {
+      receivedCount = articles.length;
+    });
+
+    const request = httpController.expectOne('http://localhost:3000/articles');
+    request.flush(
+      { message: 'error' },
+      { status: 500, statusText: 'Server Error' },
+    );
+
+    httpController.verify();
+    expect(receivedCount).toBeGreaterThan(0);
+  });
+
+  it('Given a missing API article, When loading by slug, Then fallback lookup returns null when slug is unknown', () => {
+    const service = TestBed.inject(BlogPublicService);
+    const httpController = TestBed.inject(HttpTestingController);
+
+    let received: unknown = 'uninitialized';
+
+    service
+      .getPublishedArticleBySlug('slug-introuvable')
+      .subscribe((article) => {
+        received = article;
+      });
+
+    const request = httpController.expectOne(
+      'http://localhost:3000/articles/slug-introuvable',
+    );
+    request.flush(
+      { message: 'not found' },
+      { status: 404, statusText: 'Not Found' },
+    );
+
+    httpController.verify();
+    expect(received).toBeNull();
+  });
+});

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
@@ -93,4 +93,26 @@ describe('BlogPublicService', () => {
     httpController.verify();
     expect(received).toBeNull();
   });
+
+  it('Given a malformed encoded slug, When API article lookup fails, Then fallback handling does not throw and returns null', () => {
+    const service = TestBed.inject(BlogPublicService);
+    const httpController = TestBed.inject(HttpTestingController);
+
+    let received: unknown = 'uninitialized';
+
+    service.getPublishedArticleBySlug('%').subscribe((article) => {
+      received = article;
+    });
+
+    const request = httpController.expectOne(
+      'http://localhost:3000/articles/%',
+    );
+    request.flush(
+      { message: 'not found' },
+      { status: 404, statusText: 'Not Found' },
+    );
+
+    httpController.verify();
+    expect(received).toBeNull();
+  });
 });

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
@@ -94,7 +94,7 @@ describe('BlogPublicService', () => {
     expect(received).toBeNull();
   });
 
-  it('Given a malformed encoded slug, When API article lookup fails, Then fallback handling does not throw and returns null', () => {
+  it('Given a malformed encoded slug, When API fails, Then fallback lookup does not throw and returns null', () => {
     const service = TestBed.inject(BlogPublicService);
     const httpController = TestBed.inject(HttpTestingController);
 

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
@@ -53,7 +53,14 @@ export class BlogPublicService {
       map((article) => mapPublicArticleToBlogArticle(article)),
       catchError((error: unknown) => {
         const fallbackArticles = [...getFallbackBlogArticles()];
-        const decodedSlug = decodeURIComponent(normalizedSlug);
+        let decodedSlug = normalizedSlug;
+
+        try {
+          decodedSlug = decodeURIComponent(normalizedSlug);
+        } catch {
+          decodedSlug = normalizedSlug;
+        }
+
         const fallback =
           fallbackArticles.find((article) => article.slug === normalizedSlug) ??
           fallbackArticles.find((article) => article.slug === decodedSlug) ??

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
@@ -18,7 +18,19 @@ export class BlogPublicService {
   private readonly endpoint = `${resolveApiBaseUrl(environment.apiBaseUrl)}/articles`;
 
   private normalizeSlug(slug: string): string {
-    return slug.trim().replace(/^\/+|\/+$/g, '');
+    const trimmedSlug = slug.trim();
+    let start = 0;
+    let end = trimmedSlug.length;
+
+    while (start < end && trimmedSlug.charCodeAt(start) === 47) {
+      start += 1;
+    }
+
+    while (end > start && trimmedSlug.charCodeAt(end - 1) === 47) {
+      end -= 1;
+    }
+
+    return trimmedSlug.slice(start, end);
   }
 
   listPublishedArticles(): Observable<BlogArticle[]> {

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
@@ -57,7 +57,14 @@ export class BlogPublicService {
 
         try {
           decodedSlug = decodeURIComponent(normalizedSlug);
-        } catch {
+        } catch (decodeError: unknown) {
+          console.warn(
+            '[BlogPublicService] decode slug failed, fallback keeps normalized slug',
+            {
+              slug: normalizedSlug,
+              decodeError,
+            },
+          );
           decodedSlug = normalizedSlug;
         }
 

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
@@ -16,17 +16,24 @@ import {
 export class BlogPublicService {
   private readonly http = inject(HttpClient);
   private readonly endpoint = `${resolveApiBaseUrl(environment.apiBaseUrl)}/articles`;
+  private readonly slashCodePoint = '/'.codePointAt(0);
 
   private normalizeSlug(slug: string): string {
     const trimmedSlug = slug.trim();
     let start = 0;
     let end = trimmedSlug.length;
 
-    while (start < end && trimmedSlug.charCodeAt(start) === 47) {
+    while (
+      start < end &&
+      trimmedSlug.codePointAt(start) === this.slashCodePoint
+    ) {
       start += 1;
     }
 
-    while (end > start && trimmedSlug.charCodeAt(end - 1) === 47) {
+    while (
+      end > start &&
+      trimmedSlug.codePointAt(end - 1) === this.slashCodePoint
+    ) {
       end -= 1;
     }
 
@@ -53,21 +60,7 @@ export class BlogPublicService {
       map((article) => mapPublicArticleToBlogArticle(article)),
       catchError((error: unknown) => {
         const fallbackArticles = [...getFallbackBlogArticles()];
-        let decodedSlug = normalizedSlug;
-
-        try {
-          decodedSlug = decodeURIComponent(normalizedSlug);
-        } catch (decodeError: unknown) {
-          console.warn(
-            '[BlogPublicService] decode slug failed, fallback keeps normalized slug',
-            {
-              slug: normalizedSlug,
-              decodeError,
-            },
-          );
-          decodedSlug = normalizedSlug;
-        }
-
+        const decodedSlug = this.decodeSlugSafely(normalizedSlug);
         const fallback =
           fallbackArticles.find((article) => article.slug === normalizedSlug) ??
           fallbackArticles.find((article) => article.slug === decodedSlug) ??
@@ -92,5 +85,13 @@ export class BlogPublicService {
         return of(fallback);
       }),
     );
+  }
+
+  private decodeSlugSafely(slug: string): string {
+    try {
+      return decodeURIComponent(slug);
+    } catch {
+      return slug;
+    }
   }
 }

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.ts
@@ -1,0 +1,70 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import type { ArticleDto } from '@kraak/contracts';
+import { Observable, catchError, map, of } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+import { resolveApiBaseUrl } from '../../core/runtime/runtime-config';
+import {
+  BlogArticle,
+  getFallbackBlogArticles,
+  mapPublicArticleToBlogArticle,
+  mapPublicArticlesToBlogArticles,
+} from './blog.data';
+
+@Injectable({ providedIn: 'root' })
+export class BlogPublicService {
+  private readonly http = inject(HttpClient);
+  private readonly endpoint = `${resolveApiBaseUrl(environment.apiBaseUrl)}/articles`;
+
+  private normalizeSlug(slug: string): string {
+    return slug.trim().replace(/^\/+|\/+$/g, '');
+  }
+
+  listPublishedArticles(): Observable<BlogArticle[]> {
+    return this.http.get<ArticleDto[]>(this.endpoint).pipe(
+      map((articles) => mapPublicArticlesToBlogArticles(articles)),
+      catchError((error: unknown) => {
+        console.error('[BlogPublicService] listPublishedArticles fallback', {
+          error,
+        });
+
+        return of([...getFallbackBlogArticles()]);
+      }),
+    );
+  }
+
+  getPublishedArticleBySlug(slug: string): Observable<BlogArticle | null> {
+    const normalizedSlug = this.normalizeSlug(slug);
+
+    return this.http.get<ArticleDto>(`${this.endpoint}/${normalizedSlug}`).pipe(
+      map((article) => mapPublicArticleToBlogArticle(article)),
+      catchError((error: unknown) => {
+        const fallbackArticles = [...getFallbackBlogArticles()];
+        const decodedSlug = decodeURIComponent(normalizedSlug);
+        const fallback =
+          fallbackArticles.find((article) => article.slug === normalizedSlug) ??
+          fallbackArticles.find((article) => article.slug === decodedSlug) ??
+          fallbackArticles.find(
+            (article) =>
+              normalizedSlug.includes(article.slug) ||
+              article.slug.includes(normalizedSlug),
+          ) ??
+          null;
+
+        console.error(
+          '[BlogPublicService] getPublishedArticleBySlug fallback',
+          {
+            slug: normalizedSlug,
+            decodedSlug,
+            hasFallback: fallback !== null,
+            fallbackCount: fallbackArticles.length,
+            error,
+          },
+        );
+
+        return of(fallback);
+      }),
+    );
+  }
+}

--- a/apps/client/projects/web/src/app/features/blog/blog.data.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.data.ts
@@ -419,7 +419,6 @@ export function mapPublicArticleToBlogArticle(
     categorySlug: fallback?.categorySlug ?? 'actualites',
     tagLabels: fallback?.tagLabels ?? [],
     coverImagePath:
-      article.coverImageUrl ??
       fallback?.coverImagePath ??
       FALLBACK_COVER_IMAGE_PATH,
     readingTimeMinutes:

--- a/apps/client/projects/web/src/app/features/blog/blog.data.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.data.ts
@@ -1,4 +1,5 @@
 import type { SeoPageDefinition } from '../../seo/site-seo';
+import type { ArticleDto } from '@kraak/contracts';
 
 export interface BlogSection {
   heading: string;
@@ -240,6 +241,151 @@ export const blogArticles: readonly BlogArticle[] = [
   },
 ] as const;
 
+const FALLBACK_AUTHOR: BlogAuthor = {
+  name: 'Équipe KRAAK',
+  role: 'Rédaction KRAAK',
+  bio: 'Contenu éditorial KRAAK orienté vers des décisions concrètes et actionnables.',
+  avatar: '/assets/site-visuals/photos/home-services-training.avif',
+};
+
+const FALLBACK_COVER_IMAGE_PATH =
+  '/assets/site-visuals/photos/home-hero-workshop.avif';
+
+const frenchDateFormatter = new Intl.DateTimeFormat('fr-FR', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+function stripHtmlTags(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function estimateReadingTimeMinutes(content: string): number {
+  const plainText = stripHtmlTags(content);
+  const words = plainText.length > 0 ? plainText.split(/\s+/).length : 0;
+
+  return Math.max(1, Math.ceil(words / 200));
+}
+
+function formatPublishedLabel(publishedAt: string | null): string {
+  if (!publishedAt) {
+    return 'Publication à venir';
+  }
+
+  const parsedDate = new Date(publishedAt);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return 'Publication récente';
+  }
+
+  return frenchDateFormatter.format(parsedDate);
+}
+
+function buildIntroFromContent(content: string, fallback?: string): string {
+  if (fallback && fallback.trim().length > 0) {
+    return fallback;
+  }
+
+  const plainText = stripHtmlTags(content);
+
+  if (plainText.length === 0) {
+    return 'Cet article est disponible dans le blog KRAAK.';
+  }
+
+  return plainText.slice(0, 240);
+}
+
+function buildSectionsFromContent(
+  content: string,
+  fallback?: readonly BlogSection[],
+): readonly BlogSection[] {
+  if (fallback && fallback.length > 0) {
+    return fallback;
+  }
+
+  const plainText = stripHtmlTags(content);
+
+  if (plainText.length === 0) {
+    return [
+      {
+        heading: 'Contenu',
+        paragraphs: ['Le contenu de cet article sera bientôt enrichi.'],
+      },
+    ];
+  }
+
+  return [
+    {
+      heading: 'Contenu',
+      paragraphs: [plainText],
+    },
+  ];
+}
+
+export function getFallbackBlogArticles(): readonly BlogArticle[] {
+  return blogArticles;
+}
+
+export function mapPublicArticleToBlogArticle(
+  article: ArticleDto,
+): BlogArticle {
+  const fallback =
+    blogArticles.find((candidate) => candidate.slug === article.slug) ??
+    blogArticles.find((candidate) => candidate.id === article.id);
+
+  return {
+    id: article.id,
+    slug: article.slug,
+    title: article.title,
+    excerpt: article.excerpt,
+    content: article.content,
+    status: article.status,
+    coverImageUrl: article.coverImageUrl,
+    seoTitle: article.seoTitle,
+    seoDescription: article.seoDescription,
+    publishedAt: article.publishedAt,
+    authorId: article.authorId,
+    categoryIds: article.categoryIds,
+    tagIds: article.tagIds,
+    createdAt: article.createdAt,
+    updatedAt: article.updatedAt,
+    author: fallback?.author ?? FALLBACK_AUTHOR,
+    categoryLabel: fallback?.categoryLabel ?? 'Actualités',
+    categorySlug: fallback?.categorySlug ?? 'actualites',
+    tagLabels: fallback?.tagLabels ?? [],
+    coverImagePath:
+      article.coverImageUrl ??
+      fallback?.coverImagePath ??
+      FALLBACK_COVER_IMAGE_PATH,
+    readingTimeMinutes:
+      fallback?.readingTimeMinutes ??
+      estimateReadingTimeMinutes(article.content),
+    publishedLabel: formatPublishedLabel(article.publishedAt),
+    summary: article.excerpt,
+    intro: buildIntroFromContent(article.content, fallback?.intro),
+    sections: buildSectionsFromContent(article.content, fallback?.sections),
+    takeawayPoints: fallback?.takeawayPoints ?? [],
+    relatedSlugs: fallback?.relatedSlugs ?? [],
+    featured: fallback?.featured ?? false,
+  };
+}
+
+export function mapPublicArticlesToBlogArticles(
+  articles: readonly ArticleDto[],
+): BlogArticle[] {
+  return articles
+    .map((article) => mapPublicArticleToBlogArticle(article))
+    .sort((left, right) => {
+      const leftTime = left.publishedAt ? Date.parse(left.publishedAt) : 0;
+      const rightTime = right.publishedAt ? Date.parse(right.publishedAt) : 0;
+
+      return rightTime - leftTime;
+    });
+}
+
 export const blogListSeo: SeoPageDefinition = {
   path: 'blog',
   title: 'Blog | Actualités et analyses KRAAK Consulting',
@@ -298,15 +444,19 @@ export function buildMissingBlogArticleSeo(slug: string): SeoPageDefinition {
   };
 }
 
-export function findBlogArticleBySlug(slug: string): BlogArticle | undefined {
-  return blogArticles.find((article) => article.slug === slug);
+export function findBlogArticleBySlug(
+  slug: string,
+  source: readonly BlogArticle[] = blogArticles,
+): BlogArticle | undefined {
+  return source.find((article) => article.slug === slug);
 }
 
 export function getRelatedBlogArticles(
   article: BlogArticle,
+  source: readonly BlogArticle[] = blogArticles,
   limit = 3,
 ): BlogArticle[] {
-  return blogArticles
+  return source
     .filter((candidate) => candidate.slug !== article.slug)
     .map((candidate) => ({
       candidate,

--- a/apps/client/projects/web/src/app/features/blog/blog.data.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.data.ts
@@ -257,16 +257,78 @@ const frenchDateFormatter = new Intl.DateTimeFormat('fr-FR', {
   year: 'numeric',
 });
 
+function isWhitespaceCharacter(char: string): boolean {
+  return (
+    char === ' ' ||
+    char === '\n' ||
+    char === '\r' ||
+    char === '\t' ||
+    char === '\f' ||
+    char === '\v'
+  );
+}
+
+function collapseWhitespace(value: string): string {
+  let result = '';
+  let previousWasWhitespace = false;
+
+  for (const char of value) {
+    if (isWhitespaceCharacter(char)) {
+      if (!previousWasWhitespace) {
+        result += ' ';
+      }
+
+      previousWasWhitespace = true;
+      continue;
+    }
+
+    previousWasWhitespace = false;
+    result += char;
+  }
+
+  return result.trim();
+}
+
 function stripHtmlTags(value: string): string {
-  return value
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  let textWithoutTags = '';
+  let insideTag = false;
+
+  for (const char of value) {
+    if (char === '<') {
+      insideTag = true;
+      textWithoutTags += ' ';
+      continue;
+    }
+
+    if (char === '>') {
+      insideTag = false;
+      continue;
+    }
+
+    if (!insideTag) {
+      textWithoutTags += char;
+    }
+  }
+
+  return collapseWhitespace(textWithoutTags);
 }
 
 function estimateReadingTimeMinutes(content: string): number {
   const plainText = stripHtmlTags(content);
-  const words = plainText.length > 0 ? plainText.split(/\s+/).length : 0;
+  let words = 0;
+  let insideWord = false;
+
+  for (const char of plainText) {
+    if (isWhitespaceCharacter(char)) {
+      insideWord = false;
+      continue;
+    }
+
+    if (!insideWord) {
+      words += 1;
+      insideWord = true;
+    }
+  }
 
   return Math.max(1, Math.ceil(words / 200));
 }

--- a/apps/client/projects/web/src/app/features/blog/blog.data.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.data.ts
@@ -418,9 +418,7 @@ export function mapPublicArticleToBlogArticle(
     categoryLabel: fallback?.categoryLabel ?? 'Actualités',
     categorySlug: fallback?.categorySlug ?? 'actualites',
     tagLabels: fallback?.tagLabels ?? [],
-    coverImagePath:
-      fallback?.coverImagePath ??
-      FALLBACK_COVER_IMAGE_PATH,
+    coverImagePath: fallback?.coverImagePath ?? FALLBACK_COVER_IMAGE_PATH,
     readingTimeMinutes:
       fallback?.readingTimeMinutes ??
       estimateReadingTimeMinutes(article.content),

--- a/apps/client/projects/web/src/app/features/blog/blog.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.html
@@ -110,10 +110,6 @@
         </p>
       </article>
     }
-
-    @if (errorMessage) {
-      <p class="mt-4 text-center text-sm text-amber-700">{{ errorMessage }}</p>
-    }
   </div>
 </section>
 

--- a/apps/client/projects/web/src/app/features/blog/blog.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.html
@@ -50,76 +50,70 @@
 
 <section class="bg-brand-white py-14">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <div class="grid gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:items-stretch">
-      <article class="rounded-card bg-neutral-50 p-8 shadow-sm">
-        <p
-          class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
-        >
-          Article vedette
-        </p>
-        <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-          {{ featuredArticle.title }}
-        </h2>
-        <p class="text-brand-navy mt-4 text-lg leading-relaxed">
-          {{ featuredArticle.summary }}
-        </p>
-
-        <div class="mt-6 flex flex-wrap gap-3">
-          <span
-            class="bg-brand-blue/10 rounded-full px-4 py-2 text-sm font-semibold"
-          >
-            {{ featuredArticle.categoryLabel }}
-          </span>
-          @for (tag of featuredArticle.tagLabels; track tag) {
-            <span
-              class="rounded-full bg-neutral-200 px-4 py-2 text-sm text-neutral-700"
-            >
-              {{ tag }}
-            </span>
-          }
-        </div>
-
-        <div class="mt-8 flex items-center gap-4">
-          <img
-            [src]="featuredArticle.author.avatar"
-            [alt]="featuredArticle.author.name"
-            class="h-14 w-14 rounded-full object-cover"
-            loading="lazy"
-          />
-          <div>
-            <p class="text-brand-navy font-semibold">
-              {{ featuredArticle.author.name }}
-            </p>
-            <p class="text-sm text-neutral-600">
-              {{ featuredArticle.author.role }}
-            </p>
-          </div>
-        </div>
-
-        <a
-          pButton
-          [routerLink]="['/blog', featuredArticle.slug]"
-          label="Lire l'article"
-          icon="pi pi-arrow-right"
-          class="kr-button-primary mt-8"
-          aria-label="Lire l'article vedette"
-          >Lire l'article</a
-        >
+    @if (isLoading) {
+      <article class="rounded-card bg-neutral-50 p-8 text-center shadow-sm">
+        <p class="text-brand-blue font-semibold">Chargement des articles…</p>
       </article>
+    } @else if (featuredArticle) {
+      <div class="grid gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:items-stretch">
+        <article class="rounded-card bg-neutral-50 p-8 shadow-sm">
+          <p
+            class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
+          >
+            Article vedette
+          </p>
+          <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
+            {{ featuredArticle.title }}
+          </h2>
+          <p class="text-brand-navy mt-4 text-lg leading-relaxed">
+            {{ featuredArticle.summary }}
+          </p>
 
-      <aside class="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
-        @for (category of categories; track category.label) {
+          <div class="mt-6 flex items-center gap-3 text-sm text-neutral-600">
+            <span>{{ featuredArticle.publishedLabel }}</span>
+            <span>•</span>
+            <span>{{ featuredArticle.readingTimeMinutes }} min</span>
+          </div>
+
+          <a
+            pButton
+            [routerLink]="['/blog', featuredArticle.slug]"
+            label="Lire l'article"
+            icon="pi pi-arrow-right"
+            class="kr-button-primary mt-8"
+            aria-label="Lire l'article vedette"
+            >Lire l'article</a
+          >
+        </article>
+
+        <aside class="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
           <article
             class="rounded-card bg-brand-white border border-neutral-200 p-6 shadow-sm"
           >
-            <h3 class="text-brand-navy text-lg font-semibold">
-              {{ category.label }}
-            </h3>
-            <p class="mt-2 text-neutral-700">{{ category.description }}</p>
+            <p class="text-brand-navy text-2xl font-bold">
+              {{ totalArticles }}
+            </p>
+            <p class="mt-2 text-neutral-700">articles publiés disponibles</p>
           </article>
-        }
-      </aside>
-    </div>
+          <article
+            class="rounded-card bg-brand-white border border-neutral-200 p-6 shadow-sm"
+          >
+            <p class="text-brand-navy text-2xl font-bold">{{ totalPages }}</p>
+            <p class="mt-2 text-neutral-700">pages de lecture</p>
+          </article>
+        </aside>
+      </div>
+    } @else {
+      <article class="rounded-card bg-neutral-50 p-8 text-center shadow-sm">
+        <p class="text-brand-blue font-semibold">
+          Aucun article publié pour le moment.
+        </p>
+      </article>
+    }
+
+    @if (errorMessage) {
+      <p class="mt-4 text-center text-sm text-amber-700">{{ errorMessage }}</p>
+    }
   </div>
 </section>
 
@@ -141,7 +135,7 @@
     </div>
 
     <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-      @for (article of articles; track article.slug) {
+      @for (article of pagedArticles; track article.slug) {
         <article
           class="reveal-on-scroll rounded-card bg-brand-white shadow-card overflow-hidden"
         >
@@ -153,10 +147,6 @@
           />
           <div class="p-6">
             <div class="flex items-center gap-3 text-sm text-neutral-600">
-              <span class="text-brand-blue font-semibold">{{
-                article.categoryLabel
-              }}</span>
-              <span>•</span>
               <span>{{ article.publishedLabel }}</span>
               <span>•</span>
               <span>{{ article.readingTimeMinutes }} min</span>
@@ -167,17 +157,6 @@
             <p class="mt-3 leading-relaxed text-neutral-700">
               {{ article.summary }}
             </p>
-
-            <div class="mt-5 flex flex-wrap gap-2">
-              @for (tag of article.tagLabels; track tag) {
-                <span
-                  class="rounded-full bg-neutral-100 px-3 py-1 text-xs text-neutral-600"
-                >
-                  {{ tag }}
-                </span>
-              }
-            </div>
-
             <a
               [routerLink]="['/blog', article.slug]"
               class="text-brand-blue mt-6 inline-flex font-semibold"
@@ -188,6 +167,52 @@
         </article>
       }
     </div>
+
+    @if (!isLoading && totalPages >= 1 && totalArticles > 0) {
+      <nav
+        class="mt-10 flex flex-wrap items-center justify-center gap-2"
+        aria-label="Pagination du blog"
+      >
+        <button
+          type="button"
+          pButton
+          class="kr-button-ghost"
+          label="Précédent"
+          (click)="goToPreviousPage()"
+          [disabled]="currentPage === 1"
+        >
+          Précédent
+        </button>
+
+        @for (pageNumber of pageNumbers; track pageNumber) {
+          <button
+            type="button"
+            pButton
+            [label]="pageNumber.toString()"
+            (click)="goToPage(pageNumber)"
+            [class]="
+              pageNumber === currentPage
+                ? 'kr-button-primary'
+                : 'kr-button-ghost'
+            "
+            [attr.aria-label]="'Aller à la page ' + pageNumber"
+          >
+            {{ pageNumber }}
+          </button>
+        }
+
+        <button
+          type="button"
+          pButton
+          class="kr-button-ghost"
+          label="Suivant"
+          (click)="goToNextPage()"
+          [disabled]="currentPage === totalPages"
+        >
+          Suivant
+        </button>
+      </nav>
+    }
   </div>
 </section>
 

--- a/apps/client/projects/web/src/app/features/blog/blog.page.html
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.html
@@ -50,11 +50,7 @@
 
 <section class="bg-brand-white py-14">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    @if (isLoading) {
-      <article class="rounded-card bg-neutral-50 p-8 text-center shadow-sm">
-        <p class="text-brand-blue font-semibold">Chargement des articles…</p>
-      </article>
-    } @else if (featuredArticle) {
+    @if (featuredArticle) {
       <div class="grid gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:items-stretch">
         <article class="rounded-card bg-neutral-50 p-8 shadow-sm">
           <p
@@ -164,7 +160,7 @@
       }
     </div>
 
-    @if (!isLoading && totalPages >= 1 && totalArticles > 0) {
+    @if (totalPages >= 1 && totalArticles > 0) {
       <nav
         class="mt-10 flex flex-wrap items-center justify-center gap-2"
         aria-label="Pagination du blog"

--- a/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
@@ -51,18 +51,18 @@ describe('BlogPage', () => {
     fixture.destroy();
   });
 
-  it('Given the blog page When the API request is in progress Then it exposes the loading state', () => {
+  it('Given the blog page When the API request is in progress Then it keeps the non-blocking fallback state', () => {
     const fixture = TestBed.createComponent(BlogPage);
     fixture.detectChanges();
 
     expect(
       (fixture.componentInstance as unknown as { isLoading: boolean })
         .isLoading,
-    ).toBe(true);
+    ).toBe(false);
     fixture.destroy();
   });
 
-  it('Given the blog page When it renders before API data is loaded Then it shows the editorial hero and loading state', () => {
+  it('Given the blog page When it renders before API data is loaded Then it shows the editorial hero with fallback content', () => {
     const fixture = TestBed.createComponent(BlogPage);
     fixture.detectChanges();
 
@@ -71,7 +71,8 @@ describe('BlogPage', () => {
     expect(content).toContain(
       'Actualités, repères et analyses pour avancer avec clarté.',
     );
-    expect(content).toContain('Chargement des articles…');
+    expect(content).toContain('Article vedette');
+    expect(content).not.toContain('Chargement des articles…');
 
     fixture.destroy();
   });

--- a/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { blogArticles } from './blog.data';
+import { BlogPublicService } from './blog-public.service';
 import BlogPage from './blog.page';
 
 const gsapAnimationsServiceMock: Pick<
@@ -21,6 +24,11 @@ const gsapAnimationsServiceMock: Pick<
   killAllAnimations: () => undefined,
 };
 
+const blogPublicServiceMock: Pick<BlogPublicService, 'listPublishedArticles'> =
+  {
+    listPublishedArticles: () => of([...blogArticles]),
+  };
+
 describe('BlogPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -30,6 +38,10 @@ describe('BlogPage', () => {
         {
           provide: GsapAnimationsService,
           useValue: gsapAnimationsServiceMock,
+        },
+        {
+          provide: BlogPublicService,
+          useValue: blogPublicServiceMock,
         },
       ],
     }).compileComponents();
@@ -41,8 +53,10 @@ describe('BlogPage', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given the blog page When it renders Then it shows the editorial hero and featured article', () => {
+  it('Given the blog page When it renders Then it shows the editorial hero and featured article', async () => {
     const fixture = TestBed.createComponent(BlogPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
 
     const content = fixture.nativeElement.textContent as string;

--- a/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { of } from 'rxjs';
+import { delay, of } from 'rxjs';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { blogArticles } from './blog.data';
@@ -24,11 +24,6 @@ const gsapAnimationsServiceMock: Pick<
   killAllAnimations: () => undefined,
 };
 
-const blogPublicServiceMock: Pick<BlogPublicService, 'listPublishedArticles'> =
-  {
-    listPublishedArticles: () => of([...blogArticles]),
-  };
-
 describe('BlogPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -41,7 +36,9 @@ describe('BlogPage', () => {
         },
         {
           provide: BlogPublicService,
-          useValue: blogPublicServiceMock,
+          useValue: {
+            listPublishedArticles: () => of([...blogArticles]).pipe(delay(0)),
+          } satisfies Pick<BlogPublicService, 'listPublishedArticles'>,
         },
       ],
     }).compileComponents();
@@ -51,12 +48,22 @@ describe('BlogPage', () => {
     const fixture = TestBed.createComponent(BlogPage);
 
     expect(fixture.componentInstance).toBeTruthy();
+    fixture.destroy();
   });
 
-  it('Given the blog page When it renders Then it shows the editorial hero and featured article', async () => {
+  it('Given the blog page When the API request is in progress Then it exposes the loading state', () => {
     const fixture = TestBed.createComponent(BlogPage);
     fixture.detectChanges();
-    await fixture.whenStable();
+
+    expect(
+      (fixture.componentInstance as unknown as { isLoading: boolean })
+        .isLoading,
+    ).toBe(true);
+    fixture.destroy();
+  });
+
+  it('Given the blog page When it renders before API data is loaded Then it shows the editorial hero and loading state', () => {
+    const fixture = TestBed.createComponent(BlogPage);
     fixture.detectChanges();
 
     const content = fixture.nativeElement.textContent as string;
@@ -64,11 +71,8 @@ describe('BlogPage', () => {
     expect(content).toContain(
       'Actualités, repères et analyses pour avancer avec clarté.',
     );
-    expect(content).toContain('Article vedette');
-    expect(content).toContain('Clarifier son projet avant de candidater');
-    expect(content).toContain('Choisir un format de formation utile');
-    expect(content).toContain(
-      'Préparer un dossier immigration sans perdre le fil',
-    );
+    expect(content).toContain('Chargement des articles…');
+
+    fixture.destroy();
   });
 });

--- a/apps/client/projects/web/src/app/features/blog/blog.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.ts
@@ -34,7 +34,7 @@ export default class BlogPage implements OnInit, OnDestroy {
   protected totalPages = 1;
   protected currentPage = 1;
   protected totalArticles = 0;
-  protected isLoading = true;
+  protected isLoading = false;
   private listArticles: BlogArticle[] = [];
 
   private readonly destroyRef = inject(DestroyRef);
@@ -56,15 +56,15 @@ export default class BlogPage implements OnInit, OnDestroy {
   }
 
   private loadPublishedArticles(): void {
-    this.blogPublicService
-      .listPublishedArticles()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (articles) => {
+    setTimeout(() => {
+      this.blogPublicService
+        .listPublishedArticles()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((articles) => {
           this.isLoading = false;
           this.applyArticles(articles);
-        },
-      });
+        });
+    }, 0);
   }
 
   ngOnDestroy(): void {

--- a/apps/client/projects/web/src/app/features/blog/blog.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.ts
@@ -61,7 +61,6 @@ export default class BlogPage implements OnInit, OnDestroy {
         .listPublishedArticles()
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((articles) => {
-          this.isLoading = false;
           this.applyArticles(articles);
         });
     }, 0);

--- a/apps/client/projects/web/src/app/features/blog/blog.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.ts
@@ -1,12 +1,20 @@
 import { NgStyle } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  OnDestroy,
+  OnInit,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
 
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
-import { blogArticles } from './blog.data';
+import { BlogArticle, getFallbackBlogArticles } from './blog.data';
+import { BlogPublicService } from './blog-public.service';
 
 const BLOG_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/home-hero-workshop.avif',
@@ -20,18 +28,23 @@ const BLOG_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
 })
 export default class BlogPage implements OnInit, OnDestroy {
   protected readonly heroBackgroundStyle = BLOG_HERO_BACKGROUND_STYLE;
-  protected readonly featuredArticle = blogArticles[0];
-  protected readonly articles = blogArticles;
-  protected readonly categories = [
-    { label: 'Employabilité', description: 'Projet, candidature et posture.' },
-    { label: 'Formation', description: 'Formats utiles et progression.' },
-    {
-      label: 'Immigration',
-      description: 'Dossiers, cohérence et préparation.',
-    },
-  ] as const;
+  protected readonly pageSize = 6;
+  protected featuredArticle: BlogArticle | null = null;
+  protected pagedArticles: BlogArticle[] = [];
+  protected totalPages = 1;
+  protected currentPage = 1;
+  protected totalArticles = 0;
+  protected isLoading = false;
+  protected errorMessage = '';
+  private listArticles: BlogArticle[] = [];
 
+  private readonly destroyRef = inject(DestroyRef);
   private readonly gsapService = inject(GsapAnimationsService);
+  private readonly blogPublicService = inject(BlogPublicService);
+
+  constructor() {
+    this.applyArticles([...getFallbackBlogArticles()]);
+  }
 
   ngOnInit(): void {
     this.gsapService.animatePageIn();
@@ -39,9 +52,70 @@ export default class BlogPage implements OnInit, OnDestroy {
     this.gsapService.initializeInteractiveCardAnimations('article');
     this.gsapService.initializeButtonTransitions();
     this.gsapService.initializeSectionAnimations();
+
+    this.blogPublicService
+      .listPublishedArticles()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (articles) => {
+          this.errorMessage = '';
+          this.isLoading = false;
+          this.applyArticles(articles);
+        },
+        error: (error: unknown) => {
+          console.error('[BlogPage] listPublishedArticles failed', { error });
+          this.isLoading = false;
+          this.errorMessage =
+            'Le blog est temporairement indisponible. Merci de réessayer dans un instant.';
+          this.applyArticles([]);
+        },
+      });
   }
 
   ngOnDestroy(): void {
     this.gsapService.killAllAnimations();
+  }
+
+  protected get pageNumbers(): number[] {
+    return Array.from({ length: this.totalPages }, (_, index) => index + 1);
+  }
+
+  protected goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages || page === this.currentPage) {
+      return;
+    }
+
+    this.currentPage = page;
+    this.updatePagedArticles();
+  }
+
+  protected goToPreviousPage(): void {
+    this.goToPage(this.currentPage - 1);
+  }
+
+  protected goToNextPage(): void {
+    this.goToPage(this.currentPage + 1);
+  }
+
+  private applyArticles(articles: BlogArticle[]): void {
+    this.totalArticles = articles.length;
+    this.featuredArticle = articles[0] ?? null;
+
+    this.listArticles = this.featuredArticle ? articles.slice(1) : articles;
+    this.totalPages = Math.max(
+      1,
+      Math.ceil(this.listArticles.length / this.pageSize),
+    );
+    this.currentPage = 1;
+    this.pagedArticles = this.listArticles.slice(0, this.pageSize);
+  }
+
+  private updatePagedArticles(): void {
+    const startIndex = (this.currentPage - 1) * this.pageSize;
+
+    this.pagedArticles = this.listArticles.slice(
+      startIndex,
+      startIndex + this.pageSize,
+    );
   }
 }

--- a/apps/client/projects/web/src/app/features/blog/blog.page.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog.page.ts
@@ -34,8 +34,7 @@ export default class BlogPage implements OnInit, OnDestroy {
   protected totalPages = 1;
   protected currentPage = 1;
   protected totalArticles = 0;
-  protected isLoading = false;
-  protected errorMessage = '';
+  protected isLoading = true;
   private listArticles: BlogArticle[] = [];
 
   private readonly destroyRef = inject(DestroyRef);
@@ -53,21 +52,17 @@ export default class BlogPage implements OnInit, OnDestroy {
     this.gsapService.initializeButtonTransitions();
     this.gsapService.initializeSectionAnimations();
 
+    this.loadPublishedArticles();
+  }
+
+  private loadPublishedArticles(): void {
     this.blogPublicService
       .listPublishedArticles()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (articles) => {
-          this.errorMessage = '';
           this.isLoading = false;
           this.applyArticles(articles);
-        },
-        error: (error: unknown) => {
-          console.error('[BlogPage] listPublishedArticles failed', { error });
-          this.isLoading = false;
-          this.errorMessage =
-            'Le blog est temporairement indisponible. Merci de réessayer dans un instant.';
-          this.applyArticles([]);
         },
       });
   }

--- a/apps/client/projects/web/src/app/seo/blog-sitemap-pages.json
+++ b/apps/client/projects/web/src/app/seo/blog-sitemap-pages.json
@@ -1,0 +1,47 @@
+[
+  {
+    "path": "blog/clarifier-son-projet-avant-de-candidater",
+    "title": "Article de blog | KRAAK Consulting",
+    "description": "Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.",
+    "openGraph": {
+      "title": "Article de blog | KRAAK Consulting",
+      "description": "Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.",
+      "imagePath": "/assets/site-visuals/photos/home-services-project-planning.avif",
+      "imageAlt": "Illustration de l'article Clarifier son projet avant de candidater."
+    },
+    "sitemap": {
+      "changeFrequency": "monthly",
+      "priority": 0.5
+    }
+  },
+  {
+    "path": "blog/choisir-un-format-de-formation-utile",
+    "title": "Article de blog | KRAAK Consulting",
+    "description": "Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.",
+    "openGraph": {
+      "title": "Article de blog | KRAAK Consulting",
+      "description": "Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.",
+      "imagePath": "/assets/site-visuals/photos/home-services-training.avif",
+      "imageAlt": "Illustration de l'article Choisir un format de formation utile."
+    },
+    "sitemap": {
+      "changeFrequency": "monthly",
+      "priority": 0.5
+    }
+  },
+  {
+    "path": "blog/preparer-un-dossier-immigration-sans-perdre-le-fil",
+    "title": "Article de blog | KRAAK Consulting",
+    "description": "Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.",
+    "openGraph": {
+      "title": "Article de blog | KRAAK Consulting",
+      "description": "Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.",
+      "imagePath": "/assets/site-visuals/photos/services-immigration.avif",
+      "imageAlt": "Illustration de l'article Préparer un dossier immigration sans perdre le fil."
+    },
+    "sitemap": {
+      "changeFrequency": "monthly",
+      "priority": 0.5
+    }
+  }
+]

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -35,6 +35,15 @@ describe('site-seo', () => {
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/services</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/programmes</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/blog</loc>`);
+    expect(sitemap).toContain(
+      `<loc>${DEFAULT_SITE_URL}/blog/clarifier-son-projet-avant-de-candidater</loc>`,
+    );
+    expect(sitemap).toContain(
+      `<loc>${DEFAULT_SITE_URL}/blog/choisir-un-format-de-formation-utile</loc>`,
+    );
+    expect(sitemap).toContain(
+      `<loc>${DEFAULT_SITE_URL}/blog/preparer-un-dossier-immigration-sans-perdre-le-fil</loc>`,
+    );
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/ressources</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/contact</loc>`);
   });

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -94,4 +94,10 @@ describe('site-seo', () => {
       `${EXAMPLE_SITE_URL}/contact`,
     );
   });
+
+  it('Given an absolute URL path, when buildAbsoluteUrl is called, then the URL is returned unchanged', () => {
+    expect(
+      buildAbsoluteUrl('https://cdn.example.com/asset.webp', EXAMPLE_SITE_URL),
+    ).toBe('https://cdn.example.com/asset.webp');
+  });
 });

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -37,63 +37,9 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 
 export const seoPages = siteSeoDefinitions as SeoPageDefinition[];
 
-const blogSitemapPages: SeoPageDefinition[] = [
-  {
-    path: 'blog/clarifier-son-projet-avant-de-candidater',
-    title: 'Article de blog | KRAAK Consulting',
-    description:
-      'Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.',
-    openGraph: {
-      title: 'Article de blog | KRAAK Consulting',
-      description:
-        'Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.',
-      imagePath:
-        '/assets/site-visuals/photos/home-services-project-planning.avif',
-      imageAlt:
-        "Illustration de l'article Clarifier son projet avant de candidater.",
-    },
-    sitemap: {
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-  },
-  {
-    path: 'blog/choisir-un-format-de-formation-utile',
-    title: 'Article de blog | KRAAK Consulting',
-    description:
-      'Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.',
-    openGraph: {
-      title: 'Article de blog | KRAAK Consulting',
-      description:
-        'Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.',
-      imagePath: '/assets/site-visuals/photos/home-services-training.avif',
-      imageAlt:
-        "Illustration de l'article Choisir un format de formation utile.",
-    },
-    sitemap: {
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-  },
-  {
-    path: 'blog/preparer-un-dossier-immigration-sans-perdre-le-fil',
-    title: 'Article de blog | KRAAK Consulting',
-    description:
-      'Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.',
-    openGraph: {
-      title: 'Article de blog | KRAAK Consulting',
-      description:
-        'Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.',
-      imagePath: '/assets/site-visuals/photos/services-immigration.avif',
-      imageAlt:
-        "Illustration de l'article Préparer un dossier immigration sans perdre le fil.",
-    },
-    sitemap: {
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-  },
-];
+const blogSitemapPages: SeoPageDefinition[] = seoPages.filter(({ path }) =>
+  path.startsWith('blog/'),
+);
 
 const SLASH_CHAR_CODE = '/'.codePointAt(0);
 

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -1,4 +1,5 @@
 import siteSeoDefinitions from './site-seo.json';
+import blogSitemapDefinitions from './blog-sitemap-pages.json';
 
 export type SitemapChangeFrequency =
   | 'always'
@@ -36,9 +37,7 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 };
 
 export const seoPages = siteSeoDefinitions as SeoPageDefinition[];
-const blogSitemapPages: SeoPageDefinition[] = seoPages.filter(({ path }) =>
-  path.startsWith('blog/'),
-);
+const blogSitemapPages = blogSitemapDefinitions as SeoPageDefinition[];
 
 const SLASH_CHAR_CODE = '/'.codePointAt(0);
 

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -36,7 +36,6 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 };
 
 export const seoPages = siteSeoDefinitions as SeoPageDefinition[];
-
 const blogSitemapPages: SeoPageDefinition[] = seoPages.filter(({ path }) =>
   path.startsWith('blog/'),
 );
@@ -69,6 +68,15 @@ export const resolvePublicSiteUrl = (siteUrl?: string): string => {
 };
 
 export const buildAbsoluteUrl = (path: string, siteUrl: string): string => {
+  try {
+    const absoluteUrl = new URL(path);
+    if (absoluteUrl.protocol === 'http:' || absoluteUrl.protocol === 'https:') {
+      return absoluteUrl.toString();
+    }
+  } catch {
+    // Keep relative path behavior when URL parsing fails.
+  }
+
   const normalizedPath = normalizeRoutePath(path);
   const pathname = normalizedPath.length > 0 ? `/${normalizedPath}` : '/';
 

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -37,6 +37,64 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 
 export const seoPages = siteSeoDefinitions as SeoPageDefinition[];
 
+const blogSitemapPages: SeoPageDefinition[] = [
+  {
+    path: 'blog/clarifier-son-projet-avant-de-candidater',
+    title: 'Article de blog | KRAAK Consulting',
+    description:
+      'Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.',
+    openGraph: {
+      title: 'Article de blog | KRAAK Consulting',
+      description:
+        'Un cadre simple pour clarifier votre objectif, choisir vos preuves et avancer vers une candidature plus crédible.',
+      imagePath:
+        '/assets/site-visuals/photos/home-services-project-planning.avif',
+      imageAlt:
+        "Illustration de l'article Clarifier son projet avant de candidater.",
+    },
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  },
+  {
+    path: 'blog/choisir-un-format-de-formation-utile',
+    title: 'Article de blog | KRAAK Consulting',
+    description:
+      'Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.',
+    openGraph: {
+      title: 'Article de blog | KRAAK Consulting',
+      description:
+        'Trois critères simples pour choisir un format de formation qui respecte votre objectif, votre niveau et votre calendrier.',
+      imagePath: '/assets/site-visuals/photos/home-services-training.avif',
+      imageAlt:
+        "Illustration de l'article Choisir un format de formation utile.",
+    },
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  },
+  {
+    path: 'blog/preparer-un-dossier-immigration-sans-perdre-le-fil',
+    title: 'Article de blog | KRAAK Consulting',
+    description:
+      'Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.',
+    openGraph: {
+      title: 'Article de blog | KRAAK Consulting',
+      description:
+        'Une méthode courte pour garder la cohérence entre votre intention, vos pièces justificatives et votre calendrier.',
+      imagePath: '/assets/site-visuals/photos/services-immigration.avif',
+      imageAlt:
+        "Illustration de l'article Préparer un dossier immigration sans perdre le fil.",
+    },
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  },
+];
+
 const SLASH_CHAR_CODE = '/'.codePointAt(0);
 
 const trimLeadingSlashes = (str: string): string => {
@@ -83,7 +141,7 @@ export const findSeoPageByPath = (
 
 export const buildSitemapXml = (siteUrl: string): string => {
   const normalizedSiteUrl = resolvePublicSiteUrl(siteUrl);
-  const urls = seoPages
+  const urls = [...seoPages, ...blogSitemapPages]
     .map(
       (page) => `  <url>
     <loc>${buildAbsoluteUrl(page.path, normalizedSiteUrl)}</loc>

--- a/apps/client/tests/e2e/blog.spec.ts
+++ b/apps/client/tests/e2e/blog.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Blog public - smoke CMS-03', () => {
+  test('Given la page blog, When elle se charge, Then la liste des articles publies et la pagination sont visibles', async ({
+    page,
+  }) => {
+    await page.goto('/blog', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Actualités, repères et analyses pour avancer avec clarté.',
+      }),
+    ).toBeVisible();
+
+    await expect(page.getByText('Derniers articles')).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: "Lire l'article" }).first(),
+    ).toBeVisible();
+
+    const pagination = page.getByRole('navigation', {
+      name: 'Pagination du blog',
+    });
+    await expect(pagination).toBeVisible();
+  });
+
+  test('Given un article de blog, When il est ouvert, Then les metadonnees SEO et le structured data Article sont presents', async ({
+    page,
+  }) => {
+    await page.goto('/blog/clarifier-son-projet-avant-de-candidater', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Clarifier son projet avant de candidater',
+      }),
+    ).toBeVisible();
+
+    await expect(page).toHaveTitle(/Clarifier son projet avant de candidater/);
+
+    const canonicalHref = await page
+      .locator('link[rel="canonical"]')
+      .getAttribute('href');
+    expect(canonicalHref).toContain(
+      '/blog/clarifier-son-projet-avant-de-candidater',
+    );
+
+    await expect(
+      page.locator('meta[property="og:type"][content="article"]'),
+    ).toHaveCount(1);
+
+    const jsonLd = page.locator('script#kraak-blog-article-jsonld');
+    await expect(jsonLd).toHaveCount(1);
+
+    const jsonLdContent = await jsonLd.textContent();
+    expect(jsonLdContent).toContain('"@type":"Article"');
+  });
+});

--- a/apps/client/tests/e2e/blog.spec.ts
+++ b/apps/client/tests/e2e/blog.spec.ts
@@ -40,12 +40,11 @@ test.describe('Blog public - smoke CMS-03', () => {
 
     await expect(page).toHaveTitle(/Clarifier son projet avant de candidater/);
 
-    const canonicalHref = await page
-      .locator('link[rel="canonical"]')
-      .getAttribute('href');
-    expect(canonicalHref).toContain(
-      '/blog/clarifier-son-projet-avant-de-candidater',
-    );
+    await expect
+      .poll(async () =>
+        page.locator('link[rel="canonical"]').getAttribute('href'),
+      )
+      .toContain('/blog/clarifier-son-projet-avant-de-candidater');
 
     await expect(
       page.locator('meta[property="og:type"][content="article"]'),

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -153,7 +153,11 @@ const main = async () => {
   );
 
   await mkdir(publicDir, { recursive: true });
-  await writeFile(join(publicDir, 'robots.txt'), buildRobotsTxt(siteUrl), 'utf8');
+  await writeFile(
+    join(publicDir, 'robots.txt'),
+    buildRobotsTxt(siteUrl),
+    'utf8',
+  );
   await writeFile(
     join(publicDir, 'sitemap.xml'),
     buildSitemapXml(sitemapPages, siteUrl),

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -20,29 +20,70 @@ const seoSourcePath = join(
 );
 const publicDir = join(repoRoot, 'apps', 'client', 'projects', 'web', 'public');
 const defaultSiteUrl = 'https://kraak-consulting.vercel.app';
-const blogSitemapPages = [
-  {
-    path: 'blog/clarifier-son-projet-avant-de-candidater',
-    sitemap: {
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-  },
-  {
-    path: 'blog/choisir-un-format-de-formation-utile',
-    sitemap: {
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-  },
-  {
-    path: 'blog/preparer-un-dossier-immigration-sans-perdre-le-fil',
-    sitemap: {
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-  },
-];
+
+function extractBlogSitemapPages(seoConfig) {
+  const candidateCollections = [
+    seoConfig?.blog?.articles,
+    seoConfig?.blogArticles,
+    seoConfig?.pages,
+    seoConfig?.routes,
+  ];
+
+  for (const collection of candidateCollections) {
+    if (!Array.isArray(collection)) {
+      continue;
+    }
+
+    const blogPages = collection
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          return {
+            path: entry.replace(/^\/+|\/+$/gu, ''),
+            sitemap: {
+              changeFrequency: 'monthly',
+              priority: 0.5,
+            },
+          };
+        }
+
+        if (!entry || typeof entry !== 'object') {
+          return null;
+        }
+
+        const normalizedPath =
+          typeof entry.path === 'string'
+            ? entry.path.replace(/^\/+|\/+$/gu, '')
+            : null;
+
+        if (!normalizedPath) {
+          return null;
+        }
+
+        return {
+          ...entry,
+          path: normalizedPath,
+          sitemap: {
+            changeFrequency: 'monthly',
+            priority: 0.5,
+            ...(entry.sitemap ?? {}),
+          },
+        };
+      })
+      .filter((entry) => entry && entry.path.startsWith('blog/'));
+
+    if (blogPages.length > 0) {
+      return blogPages;
+    }
+  }
+
+  throw new Error(
+    `Unable to derive blog sitemap pages from ${seoSourcePath}. ` +
+      'Add blog entries to site-seo.json so it remains the single source of truth.',
+  );
+}
+
+const seoSource = JSON.parse(await readFile(seoSourcePath, 'utf8'));
+const blogSitemapPages = extractBlogSitemapPages(seoSource);
 
 const trimTrailingSlashes = (value) => {
   let end = value.length;

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -20,6 +20,29 @@ const seoSourcePath = join(
 );
 const publicDir = join(repoRoot, 'apps', 'client', 'projects', 'web', 'public');
 const defaultSiteUrl = 'https://kraak-consulting.vercel.app';
+const blogSitemapPages = [
+  {
+    path: 'blog/clarifier-son-projet-avant-de-candidater',
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  },
+  {
+    path: 'blog/choisir-un-format-de-formation-utile',
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  },
+  {
+    path: 'blog/preparer-un-dossier-immigration-sans-perdre-le-fil',
+    sitemap: {
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  },
+];
 
 const trimTrailingSlashes = (value) => {
   let end = value.length;
@@ -83,6 +106,7 @@ Sitemap: ${buildAbsoluteUrl('sitemap.xml', siteUrl)}
 const main = async () => {
   const rawSeoConfig = await readFile(seoSourcePath, 'utf8');
   const seoPages = JSON.parse(rawSeoConfig);
+  const sitemapPages = [...seoPages, ...blogSitemapPages];
   const siteUrl = normalizeSiteUrl(
     process.env['PUBLIC_SITE_URL'] || defaultSiteUrl,
   );
@@ -91,7 +115,7 @@ const main = async () => {
   await writeFile(join(publicDir, 'robots.txt'), buildRobotsTxt(siteUrl), 'utf8');
   await writeFile(
     join(publicDir, 'sitemap.xml'),
-    buildSitemapXml(seoPages, siteUrl),
+    buildSitemapXml(sitemapPages, siteUrl),
     'utf8',
   );
 };

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -18,72 +18,19 @@ const seoSourcePath = join(
   'seo',
   'site-seo.json',
 );
+const blogSitemapSourcePath = join(
+  repoRoot,
+  'apps',
+  'client',
+  'projects',
+  'web',
+  'src',
+  'app',
+  'seo',
+  'blog-sitemap-pages.json',
+);
 const publicDir = join(repoRoot, 'apps', 'client', 'projects', 'web', 'public');
 const defaultSiteUrl = 'https://kraak-consulting.vercel.app';
-
-function extractBlogSitemapPages(seoConfig) {
-  const candidateCollections = [
-    seoConfig?.blog?.articles,
-    seoConfig?.blogArticles,
-    seoConfig?.pages,
-    seoConfig?.routes,
-  ];
-
-  for (const collection of candidateCollections) {
-    if (!Array.isArray(collection)) {
-      continue;
-    }
-
-    const blogPages = collection
-      .map((entry) => {
-        if (typeof entry === 'string') {
-          return {
-            path: entry.replace(/^\/+|\/+$/gu, ''),
-            sitemap: {
-              changeFrequency: 'monthly',
-              priority: 0.5,
-            },
-          };
-        }
-
-        if (!entry || typeof entry !== 'object') {
-          return null;
-        }
-
-        const normalizedPath =
-          typeof entry.path === 'string'
-            ? entry.path.replace(/^\/+|\/+$/gu, '')
-            : null;
-
-        if (!normalizedPath) {
-          return null;
-        }
-
-        return {
-          ...entry,
-          path: normalizedPath,
-          sitemap: {
-            changeFrequency: 'monthly',
-            priority: 0.5,
-            ...(entry.sitemap ?? {}),
-          },
-        };
-      })
-      .filter((entry) => entry && entry.path.startsWith('blog/'));
-
-    if (blogPages.length > 0) {
-      return blogPages;
-    }
-  }
-
-  throw new Error(
-    `Unable to derive blog sitemap pages from ${seoSourcePath}. ` +
-      'Add blog entries to site-seo.json so it remains the single source of truth.',
-  );
-}
-
-const seoSource = JSON.parse(await readFile(seoSourcePath, 'utf8'));
-const blogSitemapPages = extractBlogSitemapPages(seoSource);
 
 const trimTrailingSlashes = (value) => {
   let end = value.length;
@@ -146,7 +93,9 @@ Sitemap: ${buildAbsoluteUrl('sitemap.xml', siteUrl)}
 
 const main = async () => {
   const rawSeoConfig = await readFile(seoSourcePath, 'utf8');
+  const rawBlogSitemapConfig = await readFile(blogSitemapSourcePath, 'utf8');
   const seoPages = JSON.parse(rawSeoConfig);
+  const blogSitemapPages = JSON.parse(rawBlogSitemapConfig);
   const sitemapPages = [...seoPages, ...blogSitemapPages];
   const siteUrl = normalizeSiteUrl(
     process.env['PUBLIC_SITE_URL'] || defaultSiteUrl,


### PR DESCRIPTION
## Summary
- implement CMS-03 public blog pages: /blog listing with pagination and /blog/:slug article detail
- add robust public articles service with API consumption and local fallback for SSR/E2E resilience
- enrich SEO with Article metadata (title/description/og:image/og:type), JSON-LD Article, and sitemap blog URLs generation
- add CMS-03 smoke E2E for listing and detail article pages

## Validation
- pnpm --dir apps/client ng test web --watch=false --include projects/web/src/app/features/blog/blog.page.spec.ts --include projects/web/src/app/features/blog/blog-article.page.spec.ts --include projects/web/src/app/features/blog/blog-public.service.spec.ts --include projects/web/src/app/seo/site-seo.spec.ts
- pnpm --dir apps/client e2e tests/e2e/blog.spec.ts --project=chromium
- pre-push hooks (lint, unit with coverage, e2e full matrix)

Closes #354
