### PR TITLE
feat(web): CMS-04 — pages admin CRUD programmes et ressources

### DIFF
--- a/apps/api/src/integration/critical-modules.integration.spec.ts
+++ b/apps/api/src/integration/critical-modules.integration.spec.ts
@@ -118,11 +118,16 @@ describe('Critical API Modules Integration', () => {
       markSessionProgress: jest.fn(),
     };
 
+    const authServiceMock: jest.Mocked<Pick<AuthService, 'getSession'>> = {
+      getSession: jest.fn(),
+    };
+
     beforeAll(async () => {
       app = await buildHttpApp({
         controllers: [ProgramsController],
         providers: [
           { provide: ProgramsService, useValue: programsServiceMock },
+          { provide: AuthService, useValue: authServiceMock },
         ],
       });
     });
@@ -197,11 +202,16 @@ describe('Critical API Modules Integration', () => {
       trackResourceConsultation: jest.fn(),
     };
 
+    const authServiceMock: jest.Mocked<Pick<AuthService, 'getSession'>> = {
+      getSession: jest.fn(),
+    };
+
     beforeAll(async () => {
       app = await buildHttpApp({
         controllers: [ResourcesController],
         providers: [
           { provide: ResourcesService, useValue: resourcesServiceMock },
+          { provide: AuthService, useValue: authServiceMock },
         ],
       });
     });

--- a/apps/api/src/programs/programs.controller.spec.ts
+++ b/apps/api/src/programs/programs.controller.spec.ts
@@ -1,11 +1,13 @@
 import {
   BadRequestException,
+  ForbiddenException,
   NotFoundException,
   RequestMethod,
   UnauthorizedException,
 } from '@nestjs/common';
 import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from '../auth/auth.service';
 import { ProgramsController } from './programs.controller';
 import { ProgramsService } from './programs.service';
 
@@ -13,16 +15,30 @@ describe('ProgramsController', () => {
   let controller: ProgramsController;
   const programsService = {
     listPrograms: jest.fn(),
+    listAllPrograms: jest.fn(),
     getProgramDetail: jest.fn(),
+    createProgram: jest.fn(),
+    updateProgram: jest.fn(),
+    deleteProgram: jest.fn(),
     markSessionProgress: jest.fn(),
+  };
+
+  const authService = {
+    getSession: jest.fn(),
   };
 
   beforeEach(async () => {
     programsService.listPrograms.mockReset();
+    programsService.listAllPrograms.mockReset();
     programsService.getProgramDetail.mockReset();
+    programsService.createProgram.mockReset();
+    programsService.updateProgram.mockReset();
+    programsService.deleteProgram.mockReset();
     programsService.markSessionProgress.mockReset();
+    authService.getSession.mockReset();
 
     programsService.listPrograms.mockResolvedValue([]);
+    programsService.listAllPrograms.mockResolvedValue([]);
     programsService.getProgramDetail.mockResolvedValue({
       enrollmentId: 'enrollment-1',
       enrollmentStatus: 'active',
@@ -70,10 +86,22 @@ describe('ProgramsController', () => {
           provide: ProgramsService,
           useValue: programsService,
         },
+        {
+          provide: AuthService,
+          useValue: authService,
+        },
       ],
     }).compile();
 
     controller = module.get<ProgramsController>(ProgramsController);
+
+    authService.getSession.mockResolvedValue({
+      profile: {
+        appUser: {
+          role: 'participant',
+        },
+      },
+    });
   });
 
   it('devrait être défini', () => {
@@ -107,10 +135,24 @@ describe('ProgramsController', () => {
   // Given un header Authorization Bearer valide
   // When GET /programs est appelé
   // Then le token est transmis au service programmes
-  it('Given un header Authorization valide, When listPrograms est appelé, Then le token est transmis au service', async () => {
+  it('Given un header Authorization valide pour un participant, When listPrograms est appelé, Then le token est transmis au service', async () => {
     await controller.listPrograms('Bearer access-token');
 
     expect(programsService.listPrograms).toHaveBeenCalledWith('access-token');
+  });
+
+  it('Given un header Authorization valide pour un admin, When listPrograms est appelé, Then la liste admin est renvoyée', async () => {
+    authService.getSession.mockResolvedValueOnce({
+      profile: {
+        appUser: {
+          role: 'admin',
+        },
+      },
+    });
+
+    await controller.listPrograms('Bearer access-token');
+
+    expect(programsService.listAllPrograms).toHaveBeenCalledTimes(1);
   });
 
   // Given un header Authorization Bearer valide
@@ -135,6 +177,65 @@ describe('ProgramsController', () => {
     expect(programsService.listPrograms).toHaveBeenCalledWith();
   });
 
+  it('Given un payload création valide, When createProgram est appelé, Then le service createProgram est invoqué', async () => {
+    authService.getSession.mockResolvedValueOnce({
+      profile: {
+        appUser: {
+          role: 'admin',
+        },
+      },
+    });
+
+    programsService.createProgram.mockResolvedValueOnce({
+      id: 'program-2',
+      slug: 'new-program',
+      title: 'New Program',
+      summary: 'Summary',
+      description: 'Description',
+      status: 'draft',
+      visibility: 'private',
+      createdAt: '2026-04-10T10:00:00.000Z',
+      updatedAt: '2026-04-10T10:00:00.000Z',
+    });
+
+    await controller.createProgram(
+      {
+        slug: 'new-program',
+        title: 'New Program',
+        summary: 'Summary',
+        description: 'Description',
+        status: 'draft',
+        visibility: 'private',
+      },
+      'Bearer access-token',
+    );
+
+    expect(programsService.createProgram).toHaveBeenCalledWith({
+      slug: 'new-program',
+      title: 'New Program',
+      summary: 'Summary',
+      description: 'Description',
+      status: 'draft',
+      visibility: 'private',
+    });
+  });
+
+  it('Given un utilisateur non admin, When createProgram est appelé, Then la ForbiddenException est renvoyée', async () => {
+    await expect(
+      controller.createProgram(
+        {
+          slug: 'new-program',
+          title: 'New Program',
+          summary: 'Summary',
+          description: 'Description',
+          status: 'draft',
+          visibility: 'private',
+        },
+        'Bearer access-token',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   // Given un header Authorization absent
   // When GET /programs/:programId est appelé
   // Then une erreur d'authentification explicite est renvoyée
@@ -142,6 +243,66 @@ describe('ProgramsController', () => {
     await expect(
       controller.getProgramDetail('program-1'),
     ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('Given un payload mise à jour valide, When updateProgram est appelé, Then le service updateProgram est invoqué', async () => {
+    authService.getSession.mockResolvedValueOnce({
+      profile: {
+        appUser: {
+          role: 'admin',
+        },
+      },
+    });
+
+    programsService.updateProgram.mockResolvedValueOnce({
+      id: 'program-1',
+      slug: 'leadership-essentials',
+      title: 'Leadership Essentials',
+      summary: 'Bases du leadership.',
+      description: 'Parcours complet.',
+      status: 'published',
+      visibility: 'participants',
+      createdAt: '2026-04-10T10:00:00.000Z',
+      updatedAt: '2026-04-10T10:00:00.000Z',
+    });
+
+    await controller.updateProgram(
+      'program-1',
+      {
+        slug: 'leadership-essentials',
+        title: 'Leadership Essentials',
+        summary: 'Bases du leadership.',
+        description: 'Parcours complet.',
+        status: 'published',
+        visibility: 'participants',
+      },
+      'Bearer access-token',
+    );
+
+    expect(programsService.updateProgram).toHaveBeenCalledWith('program-1', {
+      slug: 'leadership-essentials',
+      title: 'Leadership Essentials',
+      summary: 'Bases du leadership.',
+      description: 'Parcours complet.',
+      status: 'published',
+      visibility: 'participants',
+    });
+  });
+
+  it('Given un token admin valide, When deleteProgram est appelé, Then le service deleteProgram est invoqué', async () => {
+    authService.getSession.mockResolvedValueOnce({
+      profile: {
+        appUser: {
+          role: 'admin',
+        },
+      },
+    });
+
+    await expect(
+      controller.deleteProgram('program-1', 'Bearer access-token'),
+    ).resolves.toBeUndefined();
+
+    expect(programsService.deleteProgram).toHaveBeenCalledWith('program-1');
   });
 
   // Given un programId inaccessible

--- a/apps/api/src/programs/programs.controller.ts
+++ b/apps/api/src/programs/programs.controller.ts
@@ -7,7 +7,6 @@ import {
   Headers,
   HttpCode,
   HttpStatus,
-  ForbiddenException,
   Param,
   Patch,
   Post,
@@ -29,6 +28,7 @@ import type {
 } from '@kraak/contracts';
 import { AuthService } from '../auth/auth.service';
 import { extractAccessToken } from '../auth/auth.dto';
+import { requireAdminAccess } from '../shared/admin-access.utils';
 import {
   validateCreateProgramPayload,
   validateMarkSessionProgressPayload,
@@ -312,30 +312,6 @@ export class ProgramsController {
     private readonly authService: AuthService,
   ) {}
 
-  private async requireAdminAccess(
-    authorizationHeader?: string,
-  ): Promise<string> {
-    const accessToken = extractAccessToken(authorizationHeader);
-
-    if (!accessToken.valid) {
-      throw new UnauthorizedException({
-        success: false,
-        message: accessToken.error,
-      });
-    }
-
-    const session = await this.authService.getSession(accessToken.data);
-
-    if (session.profile.appUser.role !== 'admin') {
-      throw new ForbiddenException({
-        success: false,
-        message: 'Accès admin requis.',
-      });
-    }
-
-    return accessToken.data;
-  }
-
   @Get()
   @ApiOperation({
     summary:
@@ -405,7 +381,7 @@ export class ProgramsController {
     @Body() body: unknown,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<ProgramDto> {
-    await this.requireAdminAccess(authorizationHeader);
+    await requireAdminAccess(this.authService, authorizationHeader);
 
     const validated = validateCreateProgramPayload(body);
 
@@ -439,7 +415,7 @@ export class ProgramsController {
     @Body() body: unknown,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<ProgramDto> {
-    await this.requireAdminAccess(authorizationHeader);
+    await requireAdminAccess(this.authService, authorizationHeader);
 
     const validated = validateUpdateProgramPayload(body);
 
@@ -483,7 +459,7 @@ export class ProgramsController {
     @Param('programId') programId: string,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<void> {
-    await this.requireAdminAccess(authorizationHeader);
+    await requireAdminAccess(this.authService, authorizationHeader);
     await this.programsService.deleteProgram(programId);
   }
 

--- a/apps/api/src/programs/programs.controller.ts
+++ b/apps/api/src/programs/programs.controller.ts
@@ -2,17 +2,21 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   Headers,
   HttpCode,
   HttpStatus,
+  ForbiddenException,
   Param,
+  Patch,
   Post,
+  Put,
   UnauthorizedException,
 } from '@nestjs/common';
 import {
-  ApiBody,
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -23,8 +27,13 @@ import type {
   ParticipantProgramListItemDto,
   ProgramDto,
 } from '@kraak/contracts';
+import { AuthService } from '../auth/auth.service';
 import { extractAccessToken } from '../auth/auth.dto';
-import { validateMarkSessionProgressPayload } from './programs.dto';
+import {
+  validateCreateProgramPayload,
+  validateMarkSessionProgressPayload,
+  validateUpdateProgramPayload,
+} from './programs.dto';
 import { ProgramsService } from './programs.service';
 
 const apiErrorSchema = {
@@ -274,10 +283,58 @@ const markProgressResponseSchema = {
   },
 };
 
+const createProgramBodySchema = {
+  type: 'object',
+  required: ['slug', 'title', 'summary', 'description', 'status', 'visibility'],
+  properties: {
+    slug: { type: 'string' },
+    title: { type: 'string' },
+    summary: { type: 'string' },
+    description: { type: 'string' },
+    status: { type: 'string', enum: ['draft', 'published', 'archived'] },
+    visibility: {
+      type: 'string',
+      enum: ['private', 'participants', 'public'],
+    },
+  },
+};
+
+const updateProgramBodySchema = {
+  type: 'object',
+  properties: createProgramBodySchema.properties,
+};
+
 @ApiTags('Programs')
 @Controller('programs')
 export class ProgramsController {
-  constructor(private readonly programsService: ProgramsService) {}
+  constructor(
+    private readonly programsService: ProgramsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  private async requireAdminAccess(
+    authorizationHeader?: string,
+  ): Promise<string> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const session = await this.authService.getSession(accessToken.data);
+
+    if (session.profile.appUser.role !== 'admin') {
+      throw new ForbiddenException({
+        success: false,
+        message: 'Accès admin requis.',
+      });
+    }
+
+    return accessToken.data;
+  }
 
   @Get()
   @ApiOperation({
@@ -321,7 +378,113 @@ export class ProgramsController {
       });
     }
 
+    const session = await this.authService.getSession(accessToken.data);
+
+    if (session.profile.appUser.role === 'admin') {
+      return this.programsService.listAllPrograms();
+    }
+
     return this.programsService.listPrograms(accessToken.data);
+  }
+
+  @Post()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Créer un programme' })
+  @ApiBody({ schema: createProgramBodySchema })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Programme créé avec succès',
+    schema: programSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Payload invalide pour la création',
+    schema: apiErrorSchema,
+  })
+  async createProgram(
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ProgramDto> {
+    await this.requireAdminAccess(authorizationHeader);
+
+    const validated = validateCreateProgramPayload(body);
+
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.programsService.createProgram(validated.data);
+  }
+
+  @Put(':programId')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Mettre à jour un programme' })
+  @ApiBody({ schema: updateProgramBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Programme mis à jour avec succès',
+    schema: programSchema,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Payload invalide pour la mise à jour',
+    schema: apiErrorSchema,
+  })
+  async updateProgram(
+    @Param('programId') programId: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ProgramDto> {
+    await this.requireAdminAccess(authorizationHeader);
+
+    const validated = validateUpdateProgramPayload(body);
+
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.programsService.updateProgram(programId, validated.data);
+  }
+
+  @Patch(':programId')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Mettre à jour un programme (compatibilité PATCH)' })
+  @ApiBody({ schema: updateProgramBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Programme mis à jour avec succès',
+    schema: programSchema,
+  })
+  async patchProgram(
+    @Param('programId') programId: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ProgramDto> {
+    return this.updateProgram(programId, body, authorizationHeader);
+  }
+
+  @Delete(':programId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Archiver un programme' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Programme archivé avec succès',
+  })
+  async deleteProgram(
+    @Param('programId') programId: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<void> {
+    await this.requireAdminAccess(authorizationHeader);
+    await this.programsService.deleteProgram(programId);
   }
 
   @Get(':programId')

--- a/apps/api/src/programs/programs.dto.spec.ts
+++ b/apps/api/src/programs/programs.dto.spec.ts
@@ -1,6 +1,123 @@
-import { validateMarkSessionProgressPayload } from './programs.dto';
+import {
+  validateCreateProgramPayload,
+  validateMarkSessionProgressPayload,
+  validateUpdateProgramPayload,
+} from './programs.dto';
 
 describe('Programs DTO validation', () => {
+  it('Given un payload de création valide, When validateCreateProgramPayload est appelé, Then le DTO normalisé est renvoyé', () => {
+    const result = validateCreateProgramPayload({
+      slug: ' programme-test ',
+      title: ' Programme test ',
+      summary: ' Résumé ',
+      description: ' Description ',
+      status: 'published',
+      visibility: 'public',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        slug: 'programme-test',
+        title: 'Programme test',
+        summary: 'Résumé',
+        description: 'Description',
+        status: 'published',
+        visibility: 'public',
+      },
+    });
+  });
+
+  it('Given un payload de création invalide, When validateCreateProgramPayload est appelé, Then les erreurs attendues sont renvoyées', () => {
+    const result = validateCreateProgramPayload({
+      slug: 'Slug Invalide',
+      title: '',
+      summary: '',
+      description: '',
+      status: 'invalid',
+      visibility: 'invalid',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ slug est invalide.',
+        'Le champ title est requis.',
+        'Le champ summary est requis.',
+        'Le champ description est requis.',
+        'Le champ status est invalide.',
+        'Le champ visibility est invalide.',
+      ],
+    });
+  });
+
+  it('Given un body non objet, When validateCreateProgramPayload est appelé, Then une erreur corps invalide est renvoyée', () => {
+    const result = validateCreateProgramPayload(null);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    });
+  });
+
+  it('Given un payload de mise à jour valide, When validateUpdateProgramPayload est appelé, Then le DTO partiel est renvoyé', () => {
+    const result = validateUpdateProgramPayload({
+      slug: ' programme-updated ',
+      title: ' Nouveau titre ',
+      summary: ' Nouveau résumé ',
+      description: ' Nouvelle description ',
+      status: 'draft',
+      visibility: 'participants',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        slug: 'programme-updated',
+        title: 'Nouveau titre',
+        summary: 'Nouveau résumé',
+        description: 'Nouvelle description',
+        status: 'draft',
+        visibility: 'participants',
+      },
+    });
+  });
+
+  it('Given un payload de mise à jour vide, When validateUpdateProgramPayload est appelé, Then une erreur métier est renvoyée', () => {
+    const result = validateUpdateProgramPayload({});
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Le payload de mise à jour doit contenir au moins un champ.'],
+    });
+  });
+
+  it('Given un payload de mise à jour invalide, When validateUpdateProgramPayload est appelé, Then les erreurs de validation sont renvoyées', () => {
+    const result = validateUpdateProgramPayload({
+      slug: 'slug invalide',
+      status: 'invalid',
+      visibility: 'invalid',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ slug est invalide.',
+        'Le champ status est invalide.',
+        'Le champ visibility est invalide.',
+      ],
+    });
+  });
+
+  it('Given un body non objet, When validateUpdateProgramPayload est appelé, Then une erreur corps invalide est renvoyée', () => {
+    const result = validateUpdateProgramPayload([]);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    });
+  });
+
   // Given un payload valide
   // When la validation du marquage progression est exécutée
   // Then le DTO normalisé est renvoyé
@@ -34,6 +151,15 @@ describe('Programs DTO validation', () => {
         'Le champ sessionId est requis.',
         'Le champ completed doit être un booléen.',
       ],
+    });
+  });
+
+  it('Given un body non objet, When validateMarkSessionProgressPayload est appelé, Then une erreur corps invalide est renvoyée', () => {
+    const result = validateMarkSessionProgressPayload('invalid');
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
     });
   });
 });

--- a/apps/api/src/programs/programs.dto.ts
+++ b/apps/api/src/programs/programs.dto.ts
@@ -3,26 +3,11 @@ import type {
   MarkProgramSessionProgressRequestDto,
   UpdateProgramDto,
 } from '@kraak/contracts';
-
-type ValidationSuccess<T> = {
-  valid: true;
-  data: T;
-};
-
-type ValidationFailure = {
-  valid: false;
-  errors: string[];
-};
-
-type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
-
-function isObjectPayload(body: unknown): body is Record<string, unknown> {
-  return Boolean(body) && typeof body === 'object' && !Array.isArray(body);
-}
-
-function readTrimmedString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
-}
+import {
+  isObjectPayload,
+  readTrimmedString,
+} from '../shared/dto-validation.utils';
+import type { ValidationResult } from '../shared/validation-result.type';
 
 const publicationStatuses = new Set(['draft', 'published', 'archived']);
 const programVisibilities = new Set(['private', 'participants', 'public']);

--- a/apps/api/src/programs/programs.dto.ts
+++ b/apps/api/src/programs/programs.dto.ts
@@ -1,4 +1,8 @@
-import type { MarkProgramSessionProgressRequestDto } from '@kraak/contracts';
+import type {
+  CreateProgramDto,
+  MarkProgramSessionProgressRequestDto,
+  UpdateProgramDto,
+} from '@kraak/contracts';
 
 type ValidationSuccess<T> = {
   valid: true;
@@ -18,6 +22,165 @@ function isObjectPayload(body: unknown): body is Record<string, unknown> {
 
 function readTrimmedString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+const publicationStatuses = new Set(['draft', 'published', 'archived']);
+const programVisibilities = new Set(['private', 'participants', 'public']);
+
+function isValidSlug(value: string): boolean {
+  return /^[a-z0-9-]+$/.test(value);
+}
+
+function assignOptionalString(
+  body: Record<string, unknown>,
+  field: keyof CreateProgramDto,
+  updates: UpdateProgramDto,
+): void {
+  if (!(field in body)) {
+    return;
+  }
+
+  (updates as Record<string, unknown>)[field] = readTrimmedString(body[field]);
+}
+
+function assignRequiredString(
+  body: Record<string, unknown>,
+  field: keyof CreateProgramDto,
+  errors: string[],
+  updates: Partial<CreateProgramDto>,
+): void {
+  if (!(field in body)) {
+    errors.push(`Le champ ${field} est requis.`);
+    return;
+  }
+
+  const value = readTrimmedString(body[field]);
+
+  if (!value) {
+    errors.push(`Le champ ${field} est requis.`);
+    return;
+  }
+
+  (updates as Record<string, unknown>)[field] = value;
+}
+
+function assignStatus(
+  body: Record<string, unknown>,
+  errors: string[],
+  updates: Partial<CreateProgramDto> | UpdateProgramDto,
+): void {
+  if (!('status' in body)) {
+    return;
+  }
+
+  const status = readTrimmedString(body['status']);
+
+  if (!publicationStatuses.has(status)) {
+    errors.push('Le champ status est invalide.');
+    return;
+  }
+
+  (updates as Record<string, unknown>).status = status;
+}
+
+function assignVisibility(
+  body: Record<string, unknown>,
+  errors: string[],
+  updates: Partial<CreateProgramDto> | UpdateProgramDto,
+): void {
+  if (!('visibility' in body)) {
+    return;
+  }
+
+  const visibility = readTrimmedString(body['visibility']);
+
+  if (!programVisibilities.has(visibility)) {
+    errors.push('Le champ visibility est invalide.');
+    return;
+  }
+
+  (updates as Record<string, unknown>).visibility = visibility;
+}
+
+export function validateCreateProgramPayload(
+  body: unknown,
+): ValidationResult<CreateProgramDto> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    };
+  }
+
+  const errors: string[] = [];
+  const data: Partial<CreateProgramDto> = {};
+
+  assignRequiredString(body, 'slug', errors, data);
+  if (typeof data.slug === 'string' && isValidSlug(data.slug) === false) {
+    errors.push('Le champ slug est invalide.');
+  }
+
+  assignRequiredString(body, 'title', errors, data);
+  assignRequiredString(body, 'summary', errors, data);
+  assignRequiredString(body, 'description', errors, data);
+  assignStatus(body, errors, data);
+  assignVisibility(body, errors, data);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data: data as CreateProgramDto,
+  };
+}
+
+export function validateUpdateProgramPayload(
+  body: unknown,
+): ValidationResult<UpdateProgramDto> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    };
+  }
+
+  const errors: string[] = [];
+  const data: UpdateProgramDto = {};
+
+  if ('slug' in body) {
+    const slug = readTrimmedString(body['slug']);
+    if (!slug) {
+      errors.push('Le champ slug est requis.');
+    } else if (isValidSlug(slug) === false) {
+      errors.push('Le champ slug est invalide.');
+    } else {
+      data.slug = slug;
+    }
+  }
+
+  assignOptionalString(body, 'title', data);
+  assignOptionalString(body, 'summary', data);
+  assignOptionalString(body, 'description', data);
+  assignStatus(body, errors, data);
+  assignVisibility(body, errors, data);
+
+  if (Object.keys(data).length === 0 && errors.length === 0) {
+    return {
+      valid: false,
+      errors: ['Le payload de mise à jour doit contenir au moins un champ.'],
+    };
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data,
+  };
 }
 
 export function validateMarkSessionProgressPayload(

--- a/apps/api/src/programs/programs.module.spec.ts
+++ b/apps/api/src/programs/programs.module.spec.ts
@@ -1,0 +1,29 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { AuthModule } from '../auth/auth.module';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { ProgramsController } from './programs.controller';
+import { ProgramsModule } from './programs.module';
+import { ProgramsService } from './programs.service';
+
+describe('ProgramsModule', () => {
+  it('Given the programs module metadata, When it is inspected, Then imports controllers and providers are registered', () => {
+    const imports = Reflect.getMetadata(
+      MODULE_METADATA.IMPORTS,
+      ProgramsModule,
+    );
+    const controllers = Reflect.getMetadata(
+      MODULE_METADATA.CONTROLLERS,
+      ProgramsModule,
+    );
+    const providers = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      ProgramsModule,
+    );
+
+    expect(imports).toEqual(
+      expect.arrayContaining([AuthModule, SupabaseModule]),
+    );
+    expect(controllers).toEqual(expect.arrayContaining([ProgramsController]));
+    expect(providers).toEqual(expect.arrayContaining([ProgramsService]));
+  });
+});

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { SupabaseModule } from '../supabase/supabase.module';
 import { ProgramsController } from './programs.controller';
 import { ProgramsService } from './programs.service';
 
 @Module({
-  imports: [SupabaseModule],
+  imports: [AuthModule, SupabaseModule],
   controllers: [ProgramsController],
   providers: [ProgramsService],
 })

--- a/apps/api/src/programs/programs.service.spec.ts
+++ b/apps/api/src/programs/programs.service.spec.ts
@@ -36,6 +36,18 @@ function createUpdateQuery(result: { error: unknown }) {
   };
 }
 
+function createProgramMutationQuery(result: { data: unknown; error: unknown }) {
+  const query = {
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue(result),
+  };
+
+  return query;
+}
+
 describe('ProgramsService', () => {
   let service: ProgramsService;
 
@@ -163,6 +175,128 @@ describe('ProgramsService', () => {
         },
       },
     ]);
+  });
+
+  it('Given une session admin, When listAllPrograms est appelé, Then tous les programmes sont renvoyés', async () => {
+    const adminQuery = createListQuery({
+      data: [
+        {
+          id: 'program-1',
+          slug: 'leadership-essentials',
+          title: 'Leadership Essentials',
+          summary: 'Bases du leadership.',
+          description: 'Parcours complet.',
+          status: 'draft',
+          visibility: 'private',
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      ],
+      error: null,
+      count: 1,
+    });
+
+    adminClient.from.mockReturnValue(adminQuery);
+
+    const result = await service.listAllPrograms();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'program-1',
+      status: 'draft',
+    });
+  });
+
+  it('Given un payload création programme, When createProgram est appelé, Then le programme est inséré et mappé', async () => {
+    const mutationQuery = createProgramMutationQuery({
+      data: {
+        id: 'program-2',
+        slug: 'new-program',
+        title: 'New Program',
+        summary: 'Summary',
+        description: 'Description',
+        status: 'draft',
+        visibility: 'private',
+        created_at: '2026-04-10T10:00:00.000Z',
+        updated_at: '2026-04-10T10:00:00.000Z',
+      },
+      error: null,
+    });
+
+    adminClient.from.mockReturnValue(mutationQuery);
+
+    await expect(
+      service.createProgram({
+        slug: 'new-program',
+        title: 'New Program',
+        summary: 'Summary',
+        description: 'Description',
+        status: 'draft',
+        visibility: 'private',
+      }),
+    ).resolves.toMatchObject({
+      id: 'program-2',
+      slug: 'new-program',
+    });
+
+    expect(mutationQuery.insert).toHaveBeenCalledWith({
+      slug: 'new-program',
+      title: 'New Program',
+      summary: 'Summary',
+      description: 'Description',
+      status: 'draft',
+      visibility: 'private',
+    });
+  });
+
+  it('Given un payload mise à jour programme, When updateProgram est appelé, Then le programme est mis à jour', async () => {
+    const mutationQuery = createProgramMutationQuery({
+      data: {
+        id: 'program-1',
+        slug: 'leadership-essentials',
+        title: 'Leadership Essentials',
+        summary: 'Bases du leadership.',
+        description: 'Parcours complet.',
+        status: 'published',
+        visibility: 'participants',
+        created_at: '2026-04-01T00:00:00.000Z',
+        updated_at: '2026-04-10T10:00:00.000Z',
+      },
+      error: null,
+    });
+
+    adminClient.from.mockReturnValue(mutationQuery);
+
+    await expect(
+      service.updateProgram('program-1', {
+        title: 'Leadership Essentials',
+        status: 'published',
+        visibility: 'participants',
+      }),
+    ).resolves.toMatchObject({
+      id: 'program-1',
+      status: 'published',
+    });
+
+    expect(mutationQuery.update).toHaveBeenCalledWith({
+      title: 'Leadership Essentials',
+      status: 'published',
+      visibility: 'participants',
+    });
+    expect(mutationQuery.eq).toHaveBeenCalledWith('id', 'program-1');
+  });
+
+  it('Given un programme existant, When deleteProgram est appelé, Then le programme est archivé', async () => {
+    const mutationQuery = createProgramMutationQuery({
+      data: { id: 'program-1' },
+      error: null,
+    });
+
+    adminClient.from.mockReturnValue(mutationQuery);
+
+    await expect(service.deleteProgram('program-1')).resolves.toBeUndefined();
+
+    expect(mutationQuery.update).toHaveBeenCalledWith({ status: 'archived' });
   });
 
   // Given plus de 200 sessions visibles sur une cohorte

--- a/apps/api/src/programs/programs.service.ts
+++ b/apps/api/src/programs/programs.service.ts
@@ -14,6 +14,7 @@ import type {
   AudienceTypeValue,
   CohortDto,
   CohortStatusValue,
+  CreateProgramDto,
   EnrollmentStatusValue,
   MarkProgramSessionProgressRequestDto,
   MarkProgramSessionProgressResponseDto,
@@ -27,6 +28,7 @@ import type {
   SessionDto,
   SessionStatusValue,
   LocationTypeValue,
+  UpdateProgramDto,
 } from '@kraak/contracts';
 import { SupabaseService } from '../supabase/supabase.service';
 import { mapResource, type ResourceRow } from '../shared/resource-mapper.utils';
@@ -116,6 +118,8 @@ const sessionProgressPageSize = 200;
 const programNotFoundMessage = 'Programme introuvable pour ce participant.';
 const resourcesReadErrorMessage =
   'Impossible de charger les ressources du programme.';
+const programSelectFields =
+  'id, slug, title, summary, description, status, visibility, created_at, updated_at';
 
 function normalizeRelation<T>(value: T | T[] | null | undefined): T | null {
   if (Array.isArray(value)) {
@@ -250,9 +254,7 @@ export class ProgramsService {
     const adminClient = this.supabaseService.getClient();
     const { data, error } = await adminClient
       .from('program')
-      .select(
-        'id, slug, title, summary, description, status, visibility, created_at, updated_at',
-      )
+      .select(programSelectFields)
       .eq('status', 'published')
       .order('updated_at', { ascending: false })
       .limit(20);
@@ -267,6 +269,116 @@ export class ProgramsService {
     return ((data as ProgramRow[] | null) ?? []).map((row) =>
       this.mapProgram(row),
     );
+  }
+
+  async listAllPrograms(): Promise<ProgramDto[]> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('program')
+      .select(programSelectFields)
+      .order('updated_at', { ascending: false })
+      .limit(1000);
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de charger la liste des programmes.',
+      });
+    }
+
+    return ((data as ProgramRow[] | null) ?? []).map((row) =>
+      this.mapProgram(row),
+    );
+  }
+
+  async createProgram(payload: CreateProgramDto): Promise<ProgramDto> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('program')
+      .insert({
+        slug: payload.slug,
+        title: payload.title,
+        summary: payload.summary,
+        description: payload.description,
+        status: payload.status,
+        visibility: payload.visibility,
+      })
+      .select(programSelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Impossible de créer le programme.',
+      });
+    }
+
+    return this.mapProgram(data as ProgramRow);
+  }
+
+  async updateProgram(
+    programId: string,
+    payload: UpdateProgramDto,
+  ): Promise<ProgramDto> {
+    const updatePayload: Record<string, unknown> = {};
+
+    if (payload.slug !== undefined) {
+      updatePayload['slug'] = payload.slug;
+    }
+
+    if (payload.title !== undefined) {
+      updatePayload['title'] = payload.title;
+    }
+
+    if (payload.summary !== undefined) {
+      updatePayload['summary'] = payload.summary;
+    }
+
+    if (payload.description !== undefined) {
+      updatePayload['description'] = payload.description;
+    }
+
+    if (payload.status !== undefined) {
+      updatePayload['status'] = payload.status;
+    }
+
+    if (payload.visibility !== undefined) {
+      updatePayload['visibility'] = payload.visibility;
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('program')
+      .update(updatePayload)
+      .eq('id', programId)
+      .select(programSelectFields)
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Programme introuvable.',
+      });
+    }
+
+    return this.mapProgram(data as ProgramRow);
+  }
+
+  async deleteProgram(programId: string): Promise<void> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('program')
+      .update({ status: 'archived' })
+      .eq('id', programId)
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException({
+        success: false,
+        message: 'Programme introuvable.',
+      });
+    }
   }
 
   async getProgramDetail(

--- a/apps/api/src/resources/resources.controller.spec.ts
+++ b/apps/api/src/resources/resources.controller.spec.ts
@@ -4,6 +4,7 @@ import type {
   ResourceDto,
   ResourceThemeValue,
 } from '@kraak/contracts';
+import { AuthService } from '../auth/auth.service';
 import { ResourcesController } from './resources.controller';
 import { ResourcesService } from './resources.service';
 
@@ -36,8 +37,16 @@ describe('ResourcesController', () => {
 
   const mockResourcesService = {
     listResources: jest.fn(),
+    listAllResources: jest.fn(),
     getResourceById: jest.fn(),
+    createResource: jest.fn(),
+    updateResource: jest.fn(),
+    deleteResource: jest.fn(),
     trackResourceConsultation: jest.fn(),
+  };
+
+  const authService = {
+    getSession: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -48,10 +57,22 @@ describe('ResourcesController', () => {
           provide: ResourcesService,
           useValue: mockResourcesService,
         },
+        {
+          provide: AuthService,
+          useValue: authService,
+        },
       ],
     }).compile();
 
     controller = module.get<ResourcesController>(ResourcesController);
+
+    authService.getSession.mockResolvedValue({
+      profile: {
+        appUser: {
+          role: 'participant',
+        },
+      },
+    });
   });
 
   afterEach(() => {
@@ -85,6 +106,35 @@ describe('ResourcesController', () => {
     expect(result).toEqual(mockListResponse);
   });
 
+  it('Given an admin Authorization header, When listResources is called, Then it returns the admin listing', async () => {
+    authService.getSession.mockResolvedValueOnce({
+      profile: {
+        appUser: {
+          role: 'admin',
+        },
+      },
+    });
+    mockResourcesService.listAllResources.mockResolvedValue(mockListResponse);
+
+    const result = await controller.listResources(
+      'training',
+      'all',
+      'prog-001',
+      1,
+      10,
+      'Bearer access-token',
+    );
+
+    expect(mockResourcesService.listAllResources).toHaveBeenCalledWith({
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      programId: 'prog-001',
+      page: 1,
+      limit: 10,
+    });
+    expect(result).toEqual(mockListResponse);
+  });
+
   it('Given a resource id, When getResourceById is called, Then it delegates to service and returns the resource', async () => {
     const resourceId = 'res-001';
     mockResourcesService.getResourceById.mockResolvedValue(mockResource);
@@ -108,5 +158,48 @@ describe('ResourcesController', () => {
     expect(mockResourcesService.trackResourceConsultation).toHaveBeenCalledWith(
       resourceId,
     );
+  });
+
+  it('Given un payload création valide, When createResource is called, Then it delegates to the service', async () => {
+    authService.getSession.mockResolvedValueOnce({
+      profile: {
+        appUser: {
+          role: 'admin',
+        },
+      },
+    });
+    mockResourcesService.createResource.mockResolvedValue(mockResource);
+
+    const result = await controller.createResource(
+      {
+        title: 'TypeScript Basics',
+        description: 'Learn TypeScript fundamentals',
+        resourceType: 'video',
+        resourceTheme: 'training',
+        resourceAudience: 'all',
+        url: 'https://example.com/resource',
+        filePath: null,
+        status: 'published',
+        publishedAt: null,
+        programId: null,
+        cohortId: null,
+      },
+      'Bearer access-token',
+    );
+
+    expect(mockResourcesService.createResource).toHaveBeenCalledWith({
+      title: 'TypeScript Basics',
+      description: 'Learn TypeScript fundamentals',
+      resourceType: 'video',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: 'https://example.com/resource',
+      filePath: null,
+      status: 'published',
+      publishedAt: null,
+      programId: null,
+      cohortId: null,
+    });
+    expect(result).toEqual(mockResource);
   });
 });

--- a/apps/api/src/resources/resources.controller.ts
+++ b/apps/api/src/resources/resources.controller.ts
@@ -1,13 +1,23 @@
 import {
+  BadRequestException,
   Controller,
   Get,
+  Body,
+  Delete,
   Param,
   Query,
   Post,
+  Put,
+  Patch,
   HttpCode,
   HttpStatus,
+  Headers,
+  ForbiddenException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import {
+  ApiBearerAuth,
+  ApiBody,
   ApiTags,
   ApiOperation,
   ApiResponse,
@@ -17,7 +27,14 @@ import {
 import type {
   ResourceAudienceValue,
   ResourceThemeValue,
+  ResourceDto,
 } from '@kraak/contracts';
+import { AuthService } from '../auth/auth.service';
+import { extractAccessToken } from '../auth/auth.dto';
+import {
+  validateCreateResourcePayload,
+  validateUpdateResourcePayload,
+} from './resources.dto';
 import { ResourcesService } from './resources.service';
 
 const RESOURCE_THEME_ENUM = [
@@ -93,10 +110,78 @@ const apiErrorSchema = {
   },
 };
 
+const createResourceBodySchema = {
+  type: 'object',
+  required: [
+    'title',
+    'resourceType',
+    'resourceTheme',
+    'resourceAudience',
+    'status',
+  ],
+  properties: {
+    programId: { type: 'string', nullable: true },
+    cohortId: { type: 'string', nullable: true },
+    title: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    resourceType: {
+      type: 'string',
+      enum: RESOURCE_TYPE_ENUM,
+    },
+    resourceTheme: {
+      type: 'string',
+      enum: RESOURCE_THEME_ENUM,
+    },
+    resourceAudience: {
+      type: 'string',
+      enum: RESOURCE_AUDIENCE_ENUM,
+    },
+    url: { type: 'string', nullable: true },
+    filePath: { type: 'string', nullable: true },
+    status: {
+      type: 'string',
+      enum: PUBLICATION_STATUS_ENUM,
+    },
+    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+  },
+};
+
+const updateResourceBodySchema = {
+  type: 'object',
+  properties: createResourceBodySchema.properties,
+};
+
 @ApiTags('Resources')
 @Controller('resources')
 export class ResourcesController {
-  constructor(private readonly resourcesService: ResourcesService) {}
+  constructor(
+    private readonly resourcesService: ResourcesService,
+    private readonly authService: AuthService,
+  ) {}
+
+  private async requireAdminAccess(
+    authorizationHeader?: string,
+  ): Promise<string> {
+    const accessToken = extractAccessToken(authorizationHeader);
+
+    if (!accessToken.valid) {
+      throw new UnauthorizedException({
+        success: false,
+        message: accessToken.error,
+      });
+    }
+
+    const session = await this.authService.getSession(accessToken.data);
+
+    if (session.profile.appUser.role !== 'admin') {
+      throw new ForbiddenException({
+        success: false,
+        message: 'Accès admin requis.',
+      });
+    }
+
+    return accessToken.data;
+  }
 
   @Get()
   @HttpCode(HttpStatus.OK)
@@ -150,7 +235,31 @@ export class ResourcesController {
     @Query('programId') programId?: string,
     @Query('page') page?: number,
     @Query('limit') limit?: number,
+    @Headers('authorization') authorizationHeader?: string,
   ) {
+    if (authorizationHeader) {
+      const accessToken = extractAccessToken(authorizationHeader);
+
+      if (!accessToken.valid) {
+        throw new UnauthorizedException({
+          success: false,
+          message: accessToken.error,
+        });
+      }
+
+      const session = await this.authService.getSession(accessToken.data);
+
+      if (session.profile.appUser.role === 'admin') {
+        return this.resourcesService.listAllResources({
+          resourceTheme,
+          resourceAudience,
+          programId,
+          page,
+          limit,
+        });
+      }
+    }
+
     return this.resourcesService.listResources({
       resourceTheme,
       resourceAudience,
@@ -158,6 +267,96 @@ export class ResourcesController {
       page,
       limit,
     });
+  }
+
+  @Post()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Create a resource' })
+  @ApiBody({ schema: createResourceBodySchema })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Resource created successfully',
+    schema: RESOURCE_SCHEMA,
+  })
+  async createResource(
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ResourceDto> {
+    await this.requireAdminAccess(authorizationHeader);
+
+    const validated = validateCreateResourcePayload(body);
+
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.resourcesService.createResource(validated.data);
+  }
+
+  @Put(':id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Update a resource' })
+  @ApiBody({ schema: updateResourceBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Resource updated successfully',
+    schema: RESOURCE_SCHEMA,
+  })
+  async updateResource(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ResourceDto> {
+    await this.requireAdminAccess(authorizationHeader);
+
+    const validated = validateUpdateResourcePayload(body);
+
+    if (!validated.valid) {
+      throw new BadRequestException({
+        success: false,
+        message: 'Payload invalide.',
+        errors: validated.errors,
+      });
+    }
+
+    return this.resourcesService.updateResource(id, validated.data);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Update a resource (compatibility PATCH)' })
+  @ApiBody({ schema: updateResourceBodySchema })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Resource updated successfully',
+    schema: RESOURCE_SCHEMA,
+  })
+  async patchResource(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<ResourceDto> {
+    return this.updateResource(id, body, authorizationHeader);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Archive a resource' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Resource archived successfully',
+  })
+  async deleteResource(
+    @Param('id') id: string,
+    @Headers('authorization') authorizationHeader?: string,
+  ): Promise<void> {
+    await this.requireAdminAccess(authorizationHeader);
+    await this.resourcesService.deleteResource(id);
   }
 
   @Get(':id')

--- a/apps/api/src/resources/resources.controller.ts
+++ b/apps/api/src/resources/resources.controller.ts
@@ -12,7 +12,6 @@ import {
   HttpCode,
   HttpStatus,
   Headers,
-  ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
 import {
@@ -31,6 +30,7 @@ import type {
 } from '@kraak/contracts';
 import { AuthService } from '../auth/auth.service';
 import { extractAccessToken } from '../auth/auth.dto';
+import { requireAdminAccess } from '../shared/admin-access.utils';
 import {
   validateCreateResourcePayload,
   validateUpdateResourcePayload,
@@ -54,6 +54,32 @@ const RESOURCE_AUDIENCE_ENUM = [
 const RESOURCE_TYPE_ENUM = ['link', 'file', 'video', 'document'];
 const PUBLICATION_STATUS_ENUM = ['draft', 'published', 'archived'];
 
+const resourceTypedProperties = {
+  resourceType: {
+    type: 'string',
+    enum: RESOURCE_TYPE_ENUM,
+  },
+  resourceTheme: {
+    type: 'string',
+    enum: RESOURCE_THEME_ENUM,
+  },
+  resourceAudience: {
+    type: 'string',
+    enum: RESOURCE_AUDIENCE_ENUM,
+  },
+  url: { type: 'string', nullable: true },
+  filePath: { type: 'string', nullable: true },
+  status: {
+    type: 'string',
+    enum: PUBLICATION_STATUS_ENUM,
+  },
+  publishedAt: {
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  },
+};
+
 const RESOURCE_SCHEMA = {
   type: 'object',
   properties: {
@@ -62,29 +88,7 @@ const RESOURCE_SCHEMA = {
     cohortId: { type: 'string', nullable: true },
     title: { type: 'string' },
     description: { type: 'string', nullable: true },
-    resourceType: {
-      type: 'string',
-      enum: RESOURCE_TYPE_ENUM,
-    },
-    resourceTheme: {
-      type: 'string',
-      enum: RESOURCE_THEME_ENUM,
-    },
-    resourceAudience: {
-      type: 'string',
-      enum: RESOURCE_AUDIENCE_ENUM,
-    },
-    url: { type: 'string', nullable: true },
-    filePath: { type: 'string', nullable: true },
-    status: {
-      type: 'string',
-      enum: PUBLICATION_STATUS_ENUM,
-    },
-    publishedAt: {
-      type: 'string',
-      format: 'date-time',
-      nullable: true,
-    },
+    ...resourceTypedProperties,
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
   },
@@ -124,25 +128,7 @@ const createResourceBodySchema = {
     cohortId: { type: 'string', nullable: true },
     title: { type: 'string' },
     description: { type: 'string', nullable: true },
-    resourceType: {
-      type: 'string',
-      enum: RESOURCE_TYPE_ENUM,
-    },
-    resourceTheme: {
-      type: 'string',
-      enum: RESOURCE_THEME_ENUM,
-    },
-    resourceAudience: {
-      type: 'string',
-      enum: RESOURCE_AUDIENCE_ENUM,
-    },
-    url: { type: 'string', nullable: true },
-    filePath: { type: 'string', nullable: true },
-    status: {
-      type: 'string',
-      enum: PUBLICATION_STATUS_ENUM,
-    },
-    publishedAt: { type: 'string', format: 'date-time', nullable: true },
+    ...resourceTypedProperties,
   },
 };
 
@@ -158,30 +144,6 @@ export class ResourcesController {
     private readonly resourcesService: ResourcesService,
     private readonly authService: AuthService,
   ) {}
-
-  private async requireAdminAccess(
-    authorizationHeader?: string,
-  ): Promise<string> {
-    const accessToken = extractAccessToken(authorizationHeader);
-
-    if (!accessToken.valid) {
-      throw new UnauthorizedException({
-        success: false,
-        message: accessToken.error,
-      });
-    }
-
-    const session = await this.authService.getSession(accessToken.data);
-
-    if (session.profile.appUser.role !== 'admin') {
-      throw new ForbiddenException({
-        success: false,
-        message: 'Accès admin requis.',
-      });
-    }
-
-    return accessToken.data;
-  }
 
   @Get()
   @HttpCode(HttpStatus.OK)
@@ -282,7 +244,7 @@ export class ResourcesController {
     @Body() body: unknown,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<ResourceDto> {
-    await this.requireAdminAccess(authorizationHeader);
+    await requireAdminAccess(this.authService, authorizationHeader);
 
     const validated = validateCreateResourcePayload(body);
 
@@ -311,7 +273,7 @@ export class ResourcesController {
     @Body() body: unknown,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<ResourceDto> {
-    await this.requireAdminAccess(authorizationHeader);
+    await requireAdminAccess(this.authService, authorizationHeader);
 
     const validated = validateUpdateResourcePayload(body);
 
@@ -355,7 +317,7 @@ export class ResourcesController {
     @Param('id') id: string,
     @Headers('authorization') authorizationHeader?: string,
   ): Promise<void> {
-    await this.requireAdminAccess(authorizationHeader);
+    await requireAdminAccess(this.authService, authorizationHeader);
     await this.resourcesService.deleteResource(id);
   }
 

--- a/apps/api/src/resources/resources.dto.spec.ts
+++ b/apps/api/src/resources/resources.dto.spec.ts
@@ -1,0 +1,145 @@
+import {
+  validateCreateResourcePayload,
+  validateUpdateResourcePayload,
+} from './resources.dto';
+
+describe('Resources DTO validation', () => {
+  it('Given un payload de création valide, When validateCreateResourcePayload est appelé, Then le DTO normalisé est renvoyé', () => {
+    const result = validateCreateResourcePayload({
+      title: ' Guide RH ',
+      description: ' Description ',
+      resourceType: 'document',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: ' https://example.com/guide ',
+      filePath: ' /tmp/file.pdf ',
+      status: 'published',
+      publishedAt: '2026-05-25T10:00:00Z',
+      programId: ' program-1 ',
+      cohortId: ' cohort-1 ',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        title: 'Guide RH',
+        description: 'Description',
+        resourceType: 'document',
+        resourceTheme: 'training',
+        resourceAudience: 'all',
+        url: 'https://example.com/guide',
+        filePath: '/tmp/file.pdf',
+        status: 'published',
+        publishedAt: '2026-05-25T10:00:00.000Z',
+        programId: 'program-1',
+        cohortId: 'cohort-1',
+      },
+    });
+  });
+
+  it('Given un payload de création invalide, When validateCreateResourcePayload est appelé, Then les erreurs attendues sont renvoyées', () => {
+    const result = validateCreateResourcePayload({
+      title: '',
+      resourceType: 'invalid',
+      resourceTheme: 'invalid',
+      resourceAudience: 'invalid',
+      status: 'invalid',
+      publishedAt: 'date-invalide',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ title est requis.',
+        'Le champ resourceType est invalide.',
+        'Le champ resourceTheme est invalide.',
+        'Le champ resourceAudience est invalide.',
+        'Le champ status est invalide.',
+        'Le champ publishedAt est invalide.',
+      ],
+    });
+  });
+
+  it('Given un body non objet, When validateCreateResourcePayload est appelé, Then une erreur corps invalide est renvoyée', () => {
+    const result = validateCreateResourcePayload(null);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    });
+  });
+
+  it('Given un payload de mise à jour valide, When validateUpdateResourcePayload est appelé, Then le DTO partiel normalisé est renvoyé', () => {
+    const result = validateUpdateResourcePayload({
+      title: ' Nouveau titre ',
+      description: ' ',
+      resourceType: 'video',
+      resourceTheme: 'career',
+      resourceAudience: 'organizations',
+      url: ' ',
+      filePath: null,
+      status: 'draft',
+      publishedAt: null,
+      programId: ' program-2 ',
+      cohortId: ' cohort-2 ',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        title: 'Nouveau titre',
+        description: null,
+        resourceType: 'video',
+        resourceTheme: 'career',
+        resourceAudience: 'organizations',
+        url: null,
+        filePath: null,
+        status: 'draft',
+        publishedAt: null,
+        programId: 'program-2',
+        cohortId: 'cohort-2',
+      },
+    });
+  });
+
+  it('Given un payload de mise à jour vide, When validateUpdateResourcePayload est appelé, Then une erreur métier est renvoyée', () => {
+    const result = validateUpdateResourcePayload({});
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Le payload de mise à jour doit contenir au moins un champ.'],
+    });
+  });
+
+  it('Given un payload de mise à jour invalide, When validateUpdateResourcePayload est appelé, Then les erreurs de validation sont renvoyées', () => {
+    const result = validateUpdateResourcePayload({
+      title: '',
+      resourceType: 'invalid',
+      resourceTheme: 'invalid',
+      resourceAudience: 'invalid',
+      status: 'invalid',
+      publishedAt: 'date-invalide',
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [
+        'Le champ title est requis.',
+        'Le champ resourceType est invalide.',
+        'Le champ resourceTheme est invalide.',
+        'Le champ resourceAudience est invalide.',
+        'Le champ status est invalide.',
+        'Le champ publishedAt est invalide.',
+      ],
+    });
+  });
+
+  it('Given un body non objet, When validateUpdateResourcePayload est appelé, Then une erreur corps invalide est renvoyée', () => {
+    const result = validateUpdateResourcePayload('invalid');
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    });
+  });
+});

--- a/apps/api/src/resources/resources.dto.ts
+++ b/apps/api/src/resources/resources.dto.ts
@@ -1,0 +1,223 @@
+import type { CreateResourceDto, UpdateResourceDto } from '@kraak/contracts';
+
+type ValidationSuccess<T> = {
+  valid: true;
+  data: T;
+};
+
+type ValidationFailure = {
+  valid: false;
+  errors: string[];
+};
+
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+function isObjectPayload(body: unknown): body is Record<string, unknown> {
+  return Boolean(body) && typeof body === 'object' && !Array.isArray(body);
+}
+
+function readTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readNullableString(value: unknown): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const normalized = readTrimmedString(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function readNullableDateTime(value: unknown): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const normalized = readTrimmedString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+const publicationStatuses = new Set(['draft', 'published', 'archived']);
+const resourceTypes = new Set(['link', 'file', 'video', 'document']);
+const resourceThemes = new Set([
+  'training',
+  'project_management',
+  'immigration',
+  'career',
+]);
+const resourceAudiences = new Set([
+  'all',
+  'young_professionals_students',
+  'organizations',
+  'international_candidates',
+]);
+
+function assignRequiredString(
+  body: Record<string, unknown>,
+  field: keyof CreateResourceDto,
+  errors: string[],
+  updates: Partial<CreateResourceDto>,
+): void {
+  if (!(field in body)) {
+    errors.push(`Le champ ${field} est requis.`);
+    return;
+  }
+
+  const value = readTrimmedString(body[field]);
+
+  if (!value) {
+    errors.push(`Le champ ${field} est requis.`);
+    return;
+  }
+
+  (updates as Record<string, unknown>)[field] = value;
+}
+
+function assignNullableString(
+  body: Record<string, unknown>,
+  field: keyof CreateResourceDto,
+  updates: Partial<CreateResourceDto>,
+): void {
+  if (!(field in body)) {
+    return;
+  }
+
+  (updates as Record<string, unknown>)[field] = readNullableString(body[field]);
+}
+
+function assignNullableDateTime(
+  body: Record<string, unknown>,
+  field: keyof CreateResourceDto,
+  errors: string[],
+  updates: Partial<CreateResourceDto>,
+): void {
+  if (!(field in body)) {
+    return;
+  }
+
+  const value = body[field];
+  if (value === null) {
+    (updates as Record<string, unknown>)[field] = null;
+    return;
+  }
+
+  const normalized = readNullableDateTime(value);
+  if (normalized === null && readTrimmedString(value)) {
+    errors.push(`Le champ ${field} est invalide.`);
+    return;
+  }
+
+  (updates as Record<string, unknown>)[field] = normalized;
+}
+
+function assignEnumField<T extends string>(
+  body: Record<string, unknown>,
+  field: keyof CreateResourceDto,
+  values: Set<T>,
+  errors: string[],
+  updates: Partial<CreateResourceDto>,
+): void {
+  if (!(field in body)) {
+    return;
+  }
+
+  const value = readTrimmedString(body[field]);
+
+  if (!values.has(value as T)) {
+    errors.push(`Le champ ${field} est invalide.`);
+    return;
+  }
+
+  (updates as Record<string, unknown>)[field] = value;
+}
+
+export function validateCreateResourcePayload(
+  body: unknown,
+): ValidationResult<CreateResourceDto> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    };
+  }
+
+  const errors: string[] = [];
+  const data: Partial<CreateResourceDto> = {};
+
+  assignRequiredString(body, 'title', errors, data);
+  assignNullableString(body, 'description', data);
+  assignEnumField(body, 'resourceType', resourceTypes, errors, data);
+  assignEnumField(body, 'resourceTheme', resourceThemes, errors, data);
+  assignEnumField(body, 'resourceAudience', resourceAudiences, errors, data);
+  assignNullableString(body, 'url', data);
+  assignNullableString(body, 'filePath', data);
+  assignEnumField(body, 'status', publicationStatuses, errors, data);
+  assignNullableDateTime(body, 'publishedAt', errors, data);
+  assignNullableString(body, 'programId', data);
+  assignNullableString(body, 'cohortId', data);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data: data as CreateResourceDto,
+  };
+}
+
+export function validateUpdateResourcePayload(
+  body: unknown,
+): ValidationResult<UpdateResourceDto> {
+  if (!isObjectPayload(body)) {
+    return {
+      valid: false,
+      errors: ['Corps de requête invalide.'],
+    };
+  }
+
+  const errors: string[] = [];
+  const data: UpdateResourceDto = {};
+
+  if ('title' in body) {
+    const title = readTrimmedString(body.title);
+    if (title.length === 0) {
+      errors.push('Le champ title est requis.');
+    } else {
+      data.title = title;
+    }
+  }
+
+  assignNullableString(body, 'description', data);
+  assignEnumField(body, 'resourceType', resourceTypes, errors, data);
+  assignEnumField(body, 'resourceTheme', resourceThemes, errors, data);
+  assignEnumField(body, 'resourceAudience', resourceAudiences, errors, data);
+  assignNullableString(body, 'url', data);
+  assignNullableString(body, 'filePath', data);
+  assignEnumField(body, 'status', publicationStatuses, errors, data);
+  assignNullableDateTime(body, 'publishedAt', errors, data);
+  assignNullableString(body, 'programId', data);
+  assignNullableString(body, 'cohortId', data);
+
+  if (Object.keys(data).length === 0 && errors.length === 0) {
+    return {
+      valid: false,
+      errors: ['Le payload de mise à jour doit contenir au moins un champ.'],
+    };
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data,
+  };
+}

--- a/apps/api/src/resources/resources.dto.ts
+++ b/apps/api/src/resources/resources.dto.ts
@@ -1,24 +1,9 @@
 import type { CreateResourceDto, UpdateResourceDto } from '@kraak/contracts';
-
-type ValidationSuccess<T> = {
-  valid: true;
-  data: T;
-};
-
-type ValidationFailure = {
-  valid: false;
-  errors: string[];
-};
-
-type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
-
-function isObjectPayload(body: unknown): body is Record<string, unknown> {
-  return Boolean(body) && typeof body === 'object' && !Array.isArray(body);
-}
-
-function readTrimmedString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
-}
+import {
+  isObjectPayload,
+  readTrimmedString,
+} from '../shared/dto-validation.utils';
+import type { ValidationResult } from '../shared/validation-result.type';
 
 function readNullableString(value: unknown): string | null {
   if (value === null) {

--- a/apps/api/src/resources/resources.module.spec.ts
+++ b/apps/api/src/resources/resources.module.spec.ts
@@ -1,0 +1,34 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { AuthModule } from '../auth/auth.module';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { ResourcesController } from './resources.controller';
+import { ResourcesModule } from './resources.module';
+import { ResourcesService } from './resources.service';
+
+describe('ResourcesModule', () => {
+  it('Given the resources module metadata, When it is inspected, Then imports controllers providers and exports are registered', () => {
+    const imports = Reflect.getMetadata(
+      MODULE_METADATA.IMPORTS,
+      ResourcesModule,
+    );
+    const controllers = Reflect.getMetadata(
+      MODULE_METADATA.CONTROLLERS,
+      ResourcesModule,
+    );
+    const providers = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      ResourcesModule,
+    );
+    const exportsMetadata = Reflect.getMetadata(
+      MODULE_METADATA.EXPORTS,
+      ResourcesModule,
+    );
+
+    expect(imports).toEqual(
+      expect.arrayContaining([AuthModule, SupabaseModule]),
+    );
+    expect(controllers).toEqual(expect.arrayContaining([ResourcesController]));
+    expect(providers).toEqual(expect.arrayContaining([ResourcesService]));
+    expect(exportsMetadata).toEqual(expect.arrayContaining([ResourcesService]));
+  });
+});

--- a/apps/api/src/resources/resources.module.ts
+++ b/apps/api/src/resources/resources.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { SupabaseModule } from '../supabase/supabase.module';
 import { ResourcesService } from './resources.service';
 import { ResourcesController } from './resources.controller';
 
 @Module({
-  imports: [SupabaseModule],
+  imports: [AuthModule, SupabaseModule],
   providers: [ResourcesService],
   controllers: [ResourcesController],
   exports: [ResourcesService],

--- a/apps/api/src/resources/resources.service.spec.ts
+++ b/apps/api/src/resources/resources.service.spec.ts
@@ -148,6 +148,30 @@ describe('ResourcesService', () => {
     return query;
   };
 
+  const createResourceMutationQuery = (result: {
+    data: unknown;
+    error: Error | null;
+    count?: number | null;
+  }) => {
+    const query = {
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: result.data,
+        error: result.error,
+      }),
+    };
+
+    return {
+      from: jest.fn().mockReturnValue(query),
+      ...query,
+    };
+  };
+
   describe('listResources', () => {
     it('Given default options, When listResources is called, Then it returns a paginated list of published resources', async () => {
       const mockClient = createListQuery({
@@ -214,6 +238,108 @@ describe('ResourcesService', () => {
       await expect(service.listResources()).resolves.toEqual({
         data: [],
         total: 0,
+      });
+    });
+  });
+
+  describe('listAllResources', () => {
+    it('Given admin filters, When listAllResources is called, Then unpublished resources are also returned', async () => {
+      const mockClient = createListQuery({
+        data: [mockResourceRow],
+        error: null,
+        count: 1,
+      });
+
+      mockSupabaseService.getClient.mockReturnValue(mockClient);
+
+      const result = await service.listAllResources({
+        programId: 'prog-001',
+        resourceTheme: 'training',
+        resourceAudience: 'all',
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(mockClient.eq).not.toHaveBeenCalledWith('status', 'published');
+    });
+  });
+
+  describe('create/update/delete resource', () => {
+    it('Given un payload création, When createResource is called, Then the resource is inserted', async () => {
+      const mutationClient = createResourceMutationQuery({
+        data: mockResourceRow,
+        error: null,
+      });
+
+      mockSupabaseService.getClient.mockReturnValue(mutationClient);
+
+      await expect(
+        service.createResource({
+          programId: null,
+          cohortId: null,
+          title: 'TypeScript Basics',
+          description: 'Learn TypeScript fundamentals',
+          resourceType: 'video',
+          resourceTheme: 'training',
+          resourceAudience: 'all',
+          url: 'https://example.com/ts-basics',
+          filePath: null,
+          status: 'published',
+          publishedAt: null,
+        }),
+      ).resolves.toEqual(mockResourceDto);
+
+      expect(mutationClient.insert).toHaveBeenCalledWith({
+        program_id: null,
+        cohort_id: null,
+        title: 'TypeScript Basics',
+        description: 'Learn TypeScript fundamentals',
+        resource_type: 'video',
+        resource_theme: 'training',
+        resource_audience: 'all',
+        url: 'https://example.com/ts-basics',
+        file_path: null,
+        status: 'published',
+        published_at: expect.any(String),
+      });
+    });
+
+    it('Given un payload mise à jour, When updateResource is called, Then the resource is updated', async () => {
+      const mutationClient = createResourceMutationQuery({
+        data: mockResourceRow,
+        error: null,
+      });
+
+      mockSupabaseService.getClient.mockReturnValue(mutationClient);
+
+      await expect(
+        service.updateResource('res-001', {
+          title: 'TypeScript Basics',
+          status: 'published',
+        }),
+      ).resolves.toEqual(mockResourceDto);
+
+      expect(mutationClient.update).toHaveBeenCalledWith({
+        title: 'TypeScript Basics',
+        status: 'published',
+        published_at: expect.any(String),
+      });
+      expect(mutationClient.eq).toHaveBeenCalledWith('id', 'res-001');
+    });
+
+    it('Given a resource id, When deleteResource is called, Then the resource is archived', async () => {
+      const mutationClient = createResourceMutationQuery({
+        data: { id: 'res-001' },
+        error: null,
+      });
+
+      mockSupabaseService.getClient.mockReturnValue(mutationClient);
+
+      await expect(service.deleteResource('res-001')).resolves.toBeUndefined();
+
+      expect(mutationClient.update).toHaveBeenCalledWith({
+        status: 'archived',
+        published_at: null,
       });
     });
   });

--- a/apps/api/src/resources/resources.service.ts
+++ b/apps/api/src/resources/resources.service.ts
@@ -1,8 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import type {
+  CreateResourceDto,
   ResourceAudienceValue,
   ResourceDto,
   ResourceThemeValue,
+  UpdateResourceDto,
 } from '@kraak/contracts';
 import { SupabaseService } from '../supabase/supabase.service';
 import { mapResource, type ResourceRow } from '../shared/resource-mapper.utils';
@@ -22,17 +28,14 @@ type ResourceTrackingRow = {
 export class ResourcesService {
   constructor(private readonly supabaseService: SupabaseService) {}
 
-  /**
-   * List published resources with optional filtering and pagination.
-   * @param options - Filter options (theme, audience) and pagination (page, limit)
-   */
-  async listResources(options?: {
+  private buildResourceQuery(options?: {
     resourceTheme?: ResourceThemeValue;
     resourceAudience?: ResourceAudienceValue;
     programId?: string;
     page?: number;
     limit?: number;
-  }): Promise<{ data: ResourceDto[]; total: number }> {
+    includeUnpublished?: boolean;
+  }) {
     const adminClient = this.supabaseService.getClient();
     const limit = Math.min(options?.limit ?? 20, 100);
     const page = Math.max(options?.page ?? 1, 1);
@@ -41,9 +44,12 @@ export class ResourcesService {
     let query = adminClient
       .from('resource')
       .select(RESOURCE_SELECT_FIELDS, { count: 'exact' })
-      .eq('status', 'published')
       .order('published_at', { ascending: false })
       .range(offset, offset + limit - 1);
+
+    if (!options?.includeUnpublished) {
+      query = query.eq('status', 'published');
+    }
 
     if (options?.programId) {
       query = query.eq('program_id', options.programId);
@@ -57,6 +63,21 @@ export class ResourcesService {
       query = query.eq('resource_audience', options.resourceAudience);
     }
 
+    return query;
+  }
+
+  /**
+   * List published resources with optional filtering and pagination.
+   * @param options - Filter options (theme, audience) and pagination (page, limit)
+   */
+  async listResources(options?: {
+    resourceTheme?: ResourceThemeValue;
+    resourceAudience?: ResourceAudienceValue;
+    programId?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ data: ResourceDto[]; total: number }> {
+    const query = this.buildResourceQuery(options);
     const { data, error, count } = await query;
 
     if (error) {
@@ -68,6 +89,35 @@ export class ResourcesService {
         data: [],
         total: 0,
       };
+    }
+
+    const resources = ((data as ResourceRow[] | null) ?? []).map((row) =>
+      this.mapResource(row),
+    );
+
+    return {
+      data: resources,
+      total: count ?? 0,
+    };
+  }
+
+  async listAllResources(options?: {
+    resourceTheme?: ResourceThemeValue;
+    resourceAudience?: ResourceAudienceValue;
+    programId?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ data: ResourceDto[]; total: number }> {
+    const { data, error, count } = await this.buildResourceQuery({
+      ...options,
+      includeUnpublished: true,
+    });
+
+    if (error) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Failed to fetch resources.',
+      });
     }
 
     const resources = ((data as ResourceRow[] | null) ?? []).map((row) =>
@@ -100,6 +150,124 @@ export class ResourcesService {
     }
 
     return this.mapResource(data as ResourceRow);
+  }
+
+  async createResource(payload: CreateResourceDto): Promise<ResourceDto> {
+    const adminClient = this.supabaseService.getClient();
+    const publishedAt =
+      payload.publishedAt ??
+      (payload.status === 'published' ? new Date().toISOString() : null);
+
+    const { data, error } = await adminClient
+      .from('resource')
+      .insert({
+        program_id: payload.programId,
+        cohort_id: payload.cohortId,
+        title: payload.title,
+        description: payload.description,
+        resource_type: payload.resourceType,
+        resource_theme: payload.resourceTheme,
+        resource_audience: payload.resourceAudience,
+        url: payload.url,
+        file_path: payload.filePath,
+        status: payload.status,
+        published_at: publishedAt,
+      })
+      .select(RESOURCE_SELECT_FIELDS)
+      .single();
+
+    if (error || !data) {
+      throw new InternalServerErrorException({
+        success: false,
+        message: 'Failed to create resource.',
+      });
+    }
+
+    return this.mapResource(data as ResourceRow);
+  }
+
+  async updateResource(
+    id: string,
+    payload: UpdateResourceDto,
+  ): Promise<ResourceDto> {
+    const updatePayload: Record<string, unknown> = {};
+
+    if (payload.programId !== undefined) {
+      updatePayload['program_id'] = payload.programId;
+    }
+
+    if (payload.cohortId !== undefined) {
+      updatePayload['cohort_id'] = payload.cohortId;
+    }
+
+    if (payload.title !== undefined) {
+      updatePayload['title'] = payload.title;
+    }
+
+    if (payload.description !== undefined) {
+      updatePayload['description'] = payload.description;
+    }
+
+    if (payload.resourceType !== undefined) {
+      updatePayload['resource_type'] = payload.resourceType;
+    }
+
+    if (payload.resourceTheme !== undefined) {
+      updatePayload['resource_theme'] = payload.resourceTheme;
+    }
+
+    if (payload.resourceAudience !== undefined) {
+      updatePayload['resource_audience'] = payload.resourceAudience;
+    }
+
+    if (payload.url !== undefined) {
+      updatePayload['url'] = payload.url;
+    }
+
+    if (payload.filePath !== undefined) {
+      updatePayload['file_path'] = payload.filePath;
+    }
+
+    if (payload.status !== undefined) {
+      updatePayload['status'] = payload.status;
+      updatePayload['published_at'] =
+        payload.publishedAt ??
+        (payload.status === 'published' ? new Date().toISOString() : null);
+    } else if (payload.publishedAt !== undefined) {
+      updatePayload['published_at'] = payload.publishedAt;
+    }
+
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('resource')
+      .update(updatePayload)
+      .eq('id', id)
+      .select(RESOURCE_SELECT_FIELDS)
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException(
+        `Resource with ID ${id} not found or is not published.`,
+      );
+    }
+
+    return this.mapResource(data as ResourceRow);
+  }
+
+  async deleteResource(id: string): Promise<void> {
+    const adminClient = this.supabaseService.getClient();
+    const { data, error } = await adminClient
+      .from('resource')
+      .update({ status: 'archived', published_at: null })
+      .eq('id', id)
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException(
+        `Resource with ID ${id} not found or is not published.`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/shared/admin-access.utils.ts
+++ b/apps/api/src/shared/admin-access.utils.ts
@@ -1,0 +1,28 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import type { AuthService } from '../auth/auth.service';
+import { extractAccessToken } from '../auth/auth.dto';
+
+export async function requireAdminAccess(
+  authService: Pick<AuthService, 'getSession'>,
+  authorizationHeader?: string,
+): Promise<string> {
+  const accessToken = extractAccessToken(authorizationHeader);
+
+  if (!accessToken.valid) {
+    throw new UnauthorizedException({
+      success: false,
+      message: accessToken.error,
+    });
+  }
+
+  const session = await authService.getSession(accessToken.data);
+
+  if (session.profile.appUser.role !== 'admin') {
+    throw new ForbiddenException({
+      success: false,
+      message: 'Accès admin requis.',
+    });
+  }
+
+  return accessToken.data;
+}

--- a/apps/api/src/shared/validation-result.type.ts
+++ b/apps/api/src/shared/validation-result.type.ts
@@ -1,0 +1,11 @@
+export type ValidationSuccess<T> = {
+  valid: true;
+  data: T;
+};
+
+export type ValidationFailure = {
+  valid: false;
+  errors: string[];
+};
+
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;

--- a/apps/client/projects/web/src/app/admin-area.routes.spec.ts
+++ b/apps/client/projects/web/src/app/admin-area.routes.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import type { Route } from '@angular/router';
+import { adminAreaCanMatch, adminAreaRoutes } from './admin-area.routes';
+
+describe('admin-area.routes', () => {
+  it('Given the admin area route guard, When canMatch is evaluated, Then it returns true', () => {
+    const route: Route = { path: 'admin' };
+    expect(adminAreaCanMatch(route, [])).toBe(true);
+  });
+
+  it('Given admin routes, When reading children paths, Then dashboard, programmes and ressources routes are declared', () => {
+    const adminRoot = adminAreaRoutes.find((route) => route.path === 'admin');
+    const childPaths = (adminRoot?.children ?? []).map((child) => child.path);
+
+    expect(childPaths).toContain('dashboard');
+    expect(childPaths).toContain('programmes');
+    expect(childPaths).toContain('ressources');
+    expect(childPaths).toContain('');
+  });
+});

--- a/apps/client/projects/web/src/app/admin-area.routes.ts
+++ b/apps/client/projects/web/src/app/admin-area.routes.ts
@@ -18,6 +18,18 @@ export const adminAreaRoutes: Routes = [
           import('./features/admin/dashboard/dashboard.page'),
       },
       {
+        path: 'programmes',
+        title: 'Programmes — Admin | KRAAK Consulting',
+        loadComponent: () =>
+          import('./features/admin/programmes/admin-programmes.page'),
+      },
+      {
+        path: 'ressources',
+        title: 'Ressources — Admin | KRAAK Consulting',
+        loadComponent: () =>
+          import('./features/admin/ressources/admin-ressources.page'),
+      },
+      {
         path: '',
         redirectTo: 'dashboard',
         pathMatch: 'full',

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.html
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.html
@@ -275,7 +275,7 @@
                         programme.status === 'draft',
                       'bg-neutral-100 text-neutral-600':
                         programme.status !== 'published' &&
-                        programme.status !== 'draft'
+                        programme.status !== 'draft',
                     }"
                   >
                     {{ programme.status }}

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.html
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.html
@@ -268,13 +268,15 @@
                 <td class="px-4 py-3">
                   <span
                     class="rounded-full px-2 py-0.5 text-xs font-semibold"
-                    [class]="
-                      programme.status === 'published'
-                        ? 'bg-green-100 text-green-800'
-                        : programme.status === 'draft'
-                          ? 'bg-yellow-100 text-yellow-800'
-                          : 'bg-neutral-100 text-neutral-600'
-                    "
+                    [ngClass]="{
+                      'bg-green-100 text-green-800':
+                        programme.status === 'published',
+                      'bg-yellow-100 text-yellow-800':
+                        programme.status === 'draft',
+                      'bg-neutral-100 text-neutral-600':
+                        programme.status !== 'published' &&
+                        programme.status !== 'draft'
+                    }"
                   >
                     {{ programme.status }}
                   </span>

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.html
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.html
@@ -1,0 +1,318 @@
+<section
+  class="bg-brand-white border-b border-neutral-200 px-4 py-10 md:px-8 lg:px-12"
+>
+  <div class="mx-auto max-w-6xl">
+    <div
+      class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div>
+        <p
+          class="text-brand-blue text-xs font-semibold tracking-[0.3em] uppercase"
+        >
+          Administration
+        </p>
+        <h1 class="mt-2 text-3xl font-bold lg:text-4xl">Programmes</h1>
+        <p class="mt-2 text-neutral-600">
+          Gérez les programmes KRAAK : création, modification, statut de
+          publication.
+        </p>
+      </div>
+      <div class="flex gap-3">
+        <a
+          pButton
+          routerLink="/admin/dashboard"
+          icon="pi pi-arrow-left"
+          label="Tableau de bord"
+          class="kr-button-ghost"
+          aria-label="Retour au tableau de bord"
+        ></a>
+        <button
+          type="button"
+          pButton
+          icon="pi pi-plus"
+          label="Nouveau programme"
+          class="kr-button-primary"
+          (click)="openCreateForm()"
+          aria-label="Créer un nouveau programme"
+        ></button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="min-h-screen bg-neutral-50 py-12">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    @if (successMessage()) {
+      <p-message
+        severity="success"
+        [text]="successMessage()!"
+        class="mb-6 block"
+      />
+    }
+
+    @if (errorMessage()) {
+      <p-message severity="error" [text]="errorMessage()!" class="mb-6 block" />
+    }
+
+    @if (showForm()) {
+      <section class="rounded-card bg-brand-white mb-8 p-8 shadow-sm">
+        <h2 class="mb-6 text-2xl font-bold">
+          {{ isEditing() ? 'Modifier le programme' : 'Nouveau programme' }}
+        </h2>
+
+        <form [formGroup]="form" (ngSubmit)="submitForm()" novalidate>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div class="flex flex-col gap-1">
+              <label
+                for="prog-slug"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Slug <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input
+                id="prog-slug"
+                type="text"
+                formControlName="slug"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="ex : formation-leadership"
+                aria-required="true"
+              />
+              @if (form.controls.slug.invalid && form.controls.slug.touched) {
+                <p class="text-sm text-red-600">
+                  Le slug est requis et ne doit contenir que des lettres
+                  minuscules, chiffres et tirets.
+                </p>
+              }
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="prog-title"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Titre <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input
+                id="prog-title"
+                type="text"
+                formControlName="title"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="Titre du programme"
+                aria-required="true"
+              />
+              @if (form.controls.title.invalid && form.controls.title.touched) {
+                <p class="text-sm text-red-600">Le titre est requis.</p>
+              }
+            </div>
+
+            <div class="flex flex-col gap-1 md:col-span-2">
+              <label
+                for="prog-summary"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Résumé <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <textarea
+                id="prog-summary"
+                formControlName="summary"
+                rows="2"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="Résumé court visible sur la liste"
+                aria-required="true"
+              ></textarea>
+              @if (
+                form.controls.summary.invalid && form.controls.summary.touched
+              ) {
+                <p class="text-sm text-red-600">Le résumé est requis.</p>
+              }
+            </div>
+
+            <div class="flex flex-col gap-1 md:col-span-2">
+              <label
+                for="prog-description"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Description
+                <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <textarea
+                id="prog-description"
+                formControlName="description"
+                rows="4"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="Description complète du programme"
+                aria-required="true"
+              ></textarea>
+              @if (
+                form.controls.description.invalid &&
+                form.controls.description.touched
+              ) {
+                <p class="text-sm text-red-600">La description est requise.</p>
+              }
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="prog-status"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Statut <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <select
+                id="prog-status"
+                formControlName="status"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                aria-required="true"
+              >
+                @for (s of publicationStatuses; track s) {
+                  <option [value]="s">{{ s }}</option>
+                }
+              </select>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="prog-visibility"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Visibilité
+                <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <select
+                id="prog-visibility"
+                formControlName="visibility"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                aria-required="true"
+              >
+                @for (v of programVisibilities; track v) {
+                  <option [value]="v">{{ v }}</option>
+                }
+              </select>
+            </div>
+          </div>
+
+          <div class="mt-8 flex gap-3">
+            <button
+              type="submit"
+              pButton
+              icon="pi pi-check"
+              [label]="
+                isEditing()
+                  ? 'Enregistrer les modifications'
+                  : 'Créer le programme'
+              "
+              class="kr-button-primary"
+              [disabled]="submitting()"
+              [attr.aria-label]="
+                isEditing()
+                  ? 'Enregistrer les modifications'
+                  : 'Créer le programme'
+              "
+            ></button>
+            <button
+              type="button"
+              pButton
+              icon="pi pi-times"
+              label="Annuler"
+              class="kr-button-ghost"
+              (click)="cancelForm()"
+              aria-label="Annuler et fermer le formulaire"
+            ></button>
+          </div>
+        </form>
+      </section>
+    }
+
+    @if (loading()) {
+      <div class="rounded-card bg-brand-white p-8 text-center shadow-sm">
+        <p class="text-neutral-600">Chargement des programmes…</p>
+      </div>
+    } @else if (programmes().length === 0) {
+      <div class="rounded-card bg-brand-white p-8 text-center shadow-sm">
+        <p class="mb-4 text-neutral-600">Aucun programme pour le moment.</p>
+        <button
+          type="button"
+          pButton
+          icon="pi pi-plus"
+          label="Créer le premier programme"
+          class="kr-button-primary"
+          (click)="openCreateForm()"
+          aria-label="Créer le premier programme"
+        ></button>
+      </div>
+    } @else {
+      <div class="rounded-card bg-brand-white overflow-x-auto shadow-sm">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-neutral-200 text-left">
+              <th class="px-4 py-3 font-semibold text-neutral-700">Titre</th>
+              <th class="px-4 py-3 font-semibold text-neutral-700">Slug</th>
+              <th class="px-4 py-3 font-semibold text-neutral-700">Statut</th>
+              <th class="px-4 py-3 font-semibold text-neutral-700">
+                Visibilité
+              </th>
+              <th class="px-4 py-3 text-right font-semibold text-neutral-700">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (programme of programmes(); track programme.id) {
+              <tr
+                class="border-b border-neutral-100 transition-colors hover:bg-neutral-50"
+              >
+                <td class="px-4 py-3 font-medium">{{ programme.title }}</td>
+                <td class="px-4 py-3 font-mono text-xs text-neutral-600">
+                  {{ programme.slug }}
+                </td>
+                <td class="px-4 py-3">
+                  <span
+                    class="rounded-full px-2 py-0.5 text-xs font-semibold"
+                    [class]="
+                      programme.status === 'published'
+                        ? 'bg-green-100 text-green-800'
+                        : programme.status === 'draft'
+                          ? 'bg-yellow-100 text-yellow-800'
+                          : 'bg-neutral-100 text-neutral-600'
+                    "
+                  >
+                    {{ programme.status }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-neutral-600">
+                  {{ programme.visibility }}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      pButton
+                      icon="pi pi-pencil"
+                      label="Modifier"
+                      class="kr-button-ghost text-xs"
+                      (click)="openEditForm(programme)"
+                      [attr.aria-label]="
+                        'Modifier le programme ' + programme.title
+                      "
+                    ></button>
+                    <button
+                      type="button"
+                      pButton
+                      icon="pi pi-trash"
+                      label="Supprimer"
+                      class="text-xs text-red-600"
+                      (click)="deleteProgramme(programme)"
+                      [attr.aria-label]="
+                        'Supprimer le programme ' + programme.title
+                      "
+                    ></button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.spec.ts
@@ -1,0 +1,170 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { MessageService } from 'primeng/api';
+
+import { signal } from '@angular/core';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import AdminProgrammesPage from './admin-programmes.page';
+import type { ProgramDto } from '@kraak/contracts';
+
+const mockProgrammes: ProgramDto[] = [
+  {
+    id: 'prog-1',
+    slug: 'formation-leadership',
+    title: 'Formation Leadership',
+    summary: 'Un programme de formation au leadership.',
+    description: 'Description complète du programme de formation.',
+    status: 'published',
+    visibility: 'public',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 'prog-2',
+    slug: 'gestion-projet',
+    title: 'Gestion de Projet',
+    summary: 'Maîtriser les fondamentaux de la gestion de projet.',
+    description: 'Description complète du programme de gestion de projet.',
+    status: 'draft',
+    visibility: 'private',
+    createdAt: '2025-02-01T00:00:00Z',
+    updatedAt: '2025-02-01T00:00:00Z',
+  },
+];
+
+const webAuthServiceMock = {
+  currentSession: signal<null>(null),
+  isAuthenticated: signal(false),
+  isAdmin: signal(false),
+  hasRole: () => false,
+};
+
+const programsClientMock = {
+  list: async () => mockProgrammes,
+  create: async () =>
+    ({
+      id: 'prog-new',
+      slug: 'new',
+      title: 'New',
+      summary: '',
+      description: '',
+      status: 'draft',
+      visibility: 'private',
+      createdAt: '',
+      updatedAt: '',
+    }) as ProgramDto,
+  update: async (id: string) => ({ ...mockProgrammes[0], id }) as ProgramDto,
+  remove: async () => undefined,
+};
+
+describe('AdminProgrammesPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminProgrammesPage],
+      providers: [
+        provideRouter([]),
+        MessageService,
+        { provide: WebAuthService, useValue: webAuthServiceMock },
+      ],
+    }).compileComponents();
+  });
+
+  it('Given the admin programmes page When it is created Then the instance exists', () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the admin programmes page When it renders Then it shows the page heading', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    fixture.componentInstance.programsClient = programsClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Programmes');
+    expect(content).toContain('Nouveau programme');
+    expect(content).toContain('Administration');
+  });
+
+  it('Given programmes are loaded When the list is displayed Then it shows the programme titles', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    fixture.componentInstance.programsClient = programsClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Formation Leadership');
+    expect(content).toContain('Gestion de Projet');
+  });
+
+  it('Given no programmes exist When the list renders Then it shows the empty state', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      list: async () => [],
+    };
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Aucun programme pour le moment');
+  });
+
+  it('Given the create button is clicked When the form opens Then it shows the create form', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    fixture.componentInstance.programsClient = programsClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Nouveau programme');
+    expect(content).toContain('Slug');
+    expect(content).toContain('Titre');
+    expect(content).toContain('Annuler');
+  });
+
+  it('Given an existing programme When openEditForm is called Then the form is prefilled', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    fixture.componentInstance.programsClient = programsClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.openEditForm(mockProgrammes[0]);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['form'].controls.title.value).toBe(
+      'Formation Leadership',
+    );
+    expect(fixture.componentInstance['form'].controls.slug.value).toBe(
+      'formation-leadership',
+    );
+  });
+
+  it('Given the form is open When cancelForm is called Then the form is hidden', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    fixture.componentInstance.programsClient = programsClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    fixture.componentInstance.openCreateForm();
+    fixture.detectChanges();
+
+    fixture.componentInstance.cancelForm();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['showForm']()).toBe(false);
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { MessageService } from 'primeng/api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { signal } from '@angular/core';
 import { WebAuthService } from '../../../core/auth/web-auth.service';
@@ -53,11 +54,15 @@ const programsClientMock = {
       createdAt: '',
       updatedAt: '',
     }) as ProgramDto,
-  update: async (id: string) => ({ ...mockProgrammes[0], id }) as ProgramDto,
+  update: async (id: string) => ({ ...mockProgrammes[0], id }),
   remove: async () => undefined,
 };
 
 describe('AdminProgrammesPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AdminProgrammesPage],
@@ -166,5 +171,186 @@ describe('AdminProgrammesPage', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance['showForm']()).toBe(false);
+  });
+
+  it('Given a valid creation form When submitForm is called Then a program is created and success feedback is shown', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    const createSpy = vi.fn(
+      async () =>
+        ({
+          id: 'prog-created',
+          slug: 'leadership-niveau-2',
+          title: 'Leadership Niveau 2',
+          summary: 'Résumé',
+          description: 'Description',
+          status: 'draft',
+          visibility: 'private',
+          createdAt: '2025-03-01T00:00:00Z',
+          updatedAt: '2025-03-01T00:00:00Z',
+        }) as ProgramDto,
+    );
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      create: createSpy,
+      list: async () => [],
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.componentInstance['form'].setValue({
+      slug: 'leadership-niveau-2',
+      title: 'Leadership Niveau 2',
+      summary: 'Résumé',
+      description: 'Description',
+      status: 'draft',
+      visibility: 'private',
+    });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(fixture.componentInstance['programmes']()).toHaveLength(1);
+    expect(fixture.componentInstance['successMessage']()).toContain('créé');
+    expect(fixture.componentInstance['showForm']()).toBe(false);
+  });
+
+  it('Given a valid edit form When submitForm is called Then the program is updated', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    const updateSpy = vi.fn(async (id: string) => ({
+      ...mockProgrammes[0],
+      id,
+      title: 'Titre modifié',
+    }));
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      update: updateSpy,
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openEditForm(mockProgrammes[0]);
+    fixture.componentInstance['form'].patchValue({ title: 'Titre modifié' });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      mockProgrammes[0].id,
+      expect.objectContaining({ title: 'Titre modifié' }),
+    );
+    expect(fixture.componentInstance['programmes']()[0]?.title).toBe(
+      'Titre modifié',
+    );
+    expect(fixture.componentInstance['successMessage']()).toContain(
+      'mis à jour',
+    );
+  });
+
+  it('Given an invalid form When submitForm is called Then no API call is performed', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    const createSpy = vi.fn(programsClientMock.create);
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      create: createSpy,
+    };
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.componentInstance['form'].patchValue({
+      slug: '',
+      title: '',
+    });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('Given a save error When submitForm is called Then an explicit error message is shown', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      create: vi.fn(async () => {
+        throw new Error('save failed');
+      }),
+      list: async () => [],
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.componentInstance['form'].setValue({
+      slug: 'slug-valide',
+      title: 'Titre',
+      summary: 'Résumé',
+      description: 'Description',
+      status: 'draft',
+      visibility: 'private',
+    });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(fixture.componentInstance['errorMessage']()).toContain('sauvegarde');
+    expect(fixture.componentInstance['submitting']()).toBe(false);
+  });
+
+  it('Given a deletion confirmation refusal When deleteProgramme is called Then no deletion occurs', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    const removeSpy = vi.fn(async () => undefined);
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      remove: removeSpy,
+    };
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance.deleteProgramme(mockProgrammes[0]);
+
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  it('Given a deletion confirmation acceptance When deleteProgramme is called Then the item is removed', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      remove: vi.fn(async () => undefined),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance.deleteProgramme(mockProgrammes[0]);
+
+    expect(fixture.componentInstance['programmes']()).toHaveLength(1);
+    expect(fixture.componentInstance['successMessage']()).toContain('supprimé');
+  });
+
+  it('Given an API load failure When the page initializes Then an explicit loading error is shown', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      list: vi.fn(async () => {
+        throw new Error('network');
+      }),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance['errorMessage']()).toContain('charger');
+    expect(fixture.componentInstance['loading']()).toBe(false);
   });
 });

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
@@ -1,3 +1,4 @@
+import { NgClass } from '@angular/common';
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import {
   FormControl,
@@ -9,7 +10,6 @@ import { RouterLink } from '@angular/router';
 import { createApiClient, type ApiClient } from '@kraak/api-client';
 import type { CreateProgramDto, ProgramDto } from '@kraak/contracts';
 import { PublicationStatus, ProgramVisibility } from '@kraak/contracts';
-import { MessageService } from 'primeng/api';
 import { ButtonDirective } from 'primeng/button';
 import { Message } from 'primeng/message';
 
@@ -29,12 +29,11 @@ interface ProgramFormModel {
 @Component({
   selector: 'kraak-admin-programmes-page',
   standalone: true,
-  imports: [ReactiveFormsModule, RouterLink, ButtonDirective, Message],
+  imports: [NgClass, ReactiveFormsModule, RouterLink, ButtonDirective, Message],
   templateUrl: './admin-programmes.page.html',
 })
 export default class AdminProgrammesPage implements OnInit {
   private readonly authService = inject(WebAuthService);
-  private readonly messageService = inject(MessageService);
   programsClient: Pick<
     ApiClient['programs'],
     'list' | 'create' | 'update' | 'remove'

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
@@ -1,0 +1,236 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { createApiClient, type ApiClient } from '@kraak/api-client';
+import type {
+  CreateProgramDto,
+  ProgramDto,
+  UpdateProgramDto,
+} from '@kraak/contracts';
+import { PublicationStatus, ProgramVisibility } from '@kraak/contracts';
+import { MessageService } from 'primeng/api';
+import { ButtonDirective } from 'primeng/button';
+import { Message } from 'primeng/message';
+
+import { environment } from '../../../../environments/environment';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+
+interface ProgramFormModel {
+  slug: FormControl<string>;
+  title: FormControl<string>;
+  summary: FormControl<string>;
+  description: FormControl<string>;
+  status: FormControl<string>;
+  visibility: FormControl<string>;
+}
+
+@Component({
+  selector: 'kraak-admin-programmes-page',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink, ButtonDirective, Message],
+  templateUrl: './admin-programmes.page.html',
+})
+export default class AdminProgrammesPage implements OnInit {
+  private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
+  programsClient: Pick<
+    ApiClient['programs'],
+    'list' | 'create' | 'update' | 'remove'
+  > = createApiClient({
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).programs;
+
+  protected readonly programmes = signal<ProgramDto[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly successMessage = signal<string | null>(null);
+  protected readonly showForm = signal(false);
+  protected readonly editingId = signal<string | null>(null);
+  protected readonly submitting = signal(false);
+
+  protected readonly isEditing = computed(() => this.editingId() !== null);
+
+  readonly publicationStatuses = Object.values(PublicationStatus);
+  readonly programVisibilities = Object.values(ProgramVisibility);
+
+  readonly form = new FormGroup<ProgramFormModel>({
+    slug: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.pattern(/^[a-z0-9-]+$/)],
+    }),
+    title: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    summary: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    description: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    status: new FormControl('draft', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    visibility: new FormControl('private', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  async ngOnInit(): Promise<void> {
+    await this.loadProgrammes();
+  }
+
+  async loadProgrammes(): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    try {
+      const list = await this.programsClient.list();
+      this.programmes.set(list);
+    } catch (err) {
+      console.error(
+        '[AdminProgrammesPage] Erreur lors du chargement des programmes',
+        err,
+      );
+      this.errorMessage.set(
+        'Impossible de charger les programmes. Vérifiez la connexion et réessayez.',
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  openCreateForm(): void {
+    this.editingId.set(null);
+    this.form.reset({
+      slug: '',
+      title: '',
+      summary: '',
+      description: '',
+      status: 'draft',
+      visibility: 'private',
+    });
+    this.showForm.set(true);
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+  }
+
+  openEditForm(programme: ProgramDto): void {
+    this.editingId.set(programme.id);
+    this.form.reset({
+      slug: programme.slug,
+      title: programme.title,
+      summary: programme.summary,
+      description: programme.description,
+      status: programme.status,
+      visibility: programme.visibility,
+    });
+    this.showForm.set(true);
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+  }
+
+  cancelForm(): void {
+    this.showForm.set(false);
+    this.editingId.set(null);
+    this.form.reset();
+  }
+
+  async submitForm(): Promise<void> {
+    this.form.markAllAsTouched();
+    if (this.form.invalid) {
+      return;
+    }
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    const values = this.form.getRawValue();
+
+    try {
+      const id = this.editingId();
+      if (id !== null) {
+        const body: UpdateProgramDto = {
+          slug: values.slug,
+          title: values.title,
+          summary: values.summary,
+          description: values.description,
+          status: values.status as CreateProgramDto['status'],
+          visibility: values.visibility as CreateProgramDto['visibility'],
+        };
+        const updated = await this.programsClient.update(id, body);
+        this.programmes.update((list) =>
+          list.map((p) => (p.id === id ? updated : p)),
+        );
+        this.successMessage.set(
+          `Programme « ${updated.title} » mis à jour avec succès.`,
+        );
+      } else {
+        const body: CreateProgramDto = {
+          slug: values.slug,
+          title: values.title,
+          summary: values.summary,
+          description: values.description,
+          status: values.status as CreateProgramDto['status'],
+          visibility: values.visibility as CreateProgramDto['visibility'],
+        };
+        const created = await this.programsClient.create(body);
+        this.programmes.update((list) => [...list, created]);
+        this.successMessage.set(
+          `Programme « ${created.title} » créé avec succès.`,
+        );
+      }
+      this.showForm.set(false);
+      this.editingId.set(null);
+      this.form.reset();
+    } catch (err) {
+      console.error(
+        '[AdminProgrammesPage] Erreur lors de la sauvegarde du programme',
+        err,
+      );
+      this.errorMessage.set(
+        'Une erreur est survenue lors de la sauvegarde. Vérifiez les champs et réessayez.',
+      );
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  async deleteProgramme(programme: ProgramDto): Promise<void> {
+    if (
+      !confirm(
+        `Supprimer le programme « ${programme.title} » ? Cette action est irréversible.`,
+      )
+    ) {
+      return;
+    }
+
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    try {
+      await this.programsClient.remove(programme.id);
+      this.programmes.update((list) =>
+        list.filter((p) => p.id !== programme.id),
+      );
+      this.successMessage.set(`Programme « ${programme.title} » supprimé.`);
+    } catch (err) {
+      console.error(
+        '[AdminProgrammesPage] Erreur lors de la suppression du programme',
+        err,
+      );
+      this.errorMessage.set('Impossible de supprimer ce programme. Réessayez.');
+    }
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
@@ -7,11 +7,7 @@ import {
 } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { createApiClient, type ApiClient } from '@kraak/api-client';
-import type {
-  CreateProgramDto,
-  ProgramDto,
-  UpdateProgramDto,
-} from '@kraak/contracts';
+import type { CreateProgramDto, ProgramDto } from '@kraak/contracts';
 import { PublicationStatus, ProgramVisibility } from '@kraak/contracts';
 import { MessageService } from 'primeng/api';
 import { ButtonDirective } from 'primeng/button';
@@ -146,6 +142,19 @@ export default class AdminProgrammesPage implements OnInit {
     this.form.reset();
   }
 
+  private buildProgramPayload(): CreateProgramDto {
+    const values = this.form.getRawValue();
+
+    return {
+      slug: values.slug,
+      title: values.title,
+      summary: values.summary,
+      description: values.description,
+      status: values.status as CreateProgramDto['status'],
+      visibility: values.visibility as CreateProgramDto['visibility'],
+    };
+  }
+
   async submitForm(): Promise<void> {
     this.form.markAllAsTouched();
     if (this.form.invalid) {
@@ -155,35 +164,18 @@ export default class AdminProgrammesPage implements OnInit {
     this.submitting.set(true);
     this.errorMessage.set(null);
     this.successMessage.set(null);
-
-    const values = this.form.getRawValue();
+    const payload = this.buildProgramPayload();
 
     try {
       const id = this.editingId();
       if (id === null) {
-        const body: CreateProgramDto = {
-          slug: values.slug,
-          title: values.title,
-          summary: values.summary,
-          description: values.description,
-          status: values.status as CreateProgramDto['status'],
-          visibility: values.visibility as CreateProgramDto['visibility'],
-        };
-        const created = await this.programsClient.create(body);
+        const created = await this.programsClient.create(payload);
         this.programmes.update((list) => [...list, created]);
         this.successMessage.set(
           `Programme « ${created.title} » créé avec succès.`,
         );
       } else {
-        const body: UpdateProgramDto = {
-          slug: values.slug,
-          title: values.title,
-          summary: values.summary,
-          description: values.description,
-          status: values.status as CreateProgramDto['status'],
-          visibility: values.visibility as CreateProgramDto['visibility'],
-        };
-        const updated = await this.programsClient.update(id, body);
+        const updated = await this.programsClient.update(id, payload);
         this.programmes.update((list) =>
           list.map((p) => (p.id === id ? updated : p)),
         );
@@ -191,9 +183,7 @@ export default class AdminProgrammesPage implements OnInit {
           `Programme « ${updated.title} » mis à jour avec succès.`,
         );
       }
-      this.showForm.set(false);
-      this.editingId.set(null);
-      this.form.reset();
+      this.cancelForm();
     } catch (err) {
       console.error(
         '[AdminProgrammesPage] Erreur lors de la sauvegarde du programme',

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.ts
@@ -87,8 +87,8 @@ export default class AdminProgrammesPage implements OnInit {
     }),
   });
 
-  async ngOnInit(): Promise<void> {
-    await this.loadProgrammes();
+  ngOnInit(): void {
+    void this.loadProgrammes();
   }
 
   async loadProgrammes(): Promise<void> {
@@ -160,7 +160,21 @@ export default class AdminProgrammesPage implements OnInit {
 
     try {
       const id = this.editingId();
-      if (id !== null) {
+      if (id === null) {
+        const body: CreateProgramDto = {
+          slug: values.slug,
+          title: values.title,
+          summary: values.summary,
+          description: values.description,
+          status: values.status as CreateProgramDto['status'],
+          visibility: values.visibility as CreateProgramDto['visibility'],
+        };
+        const created = await this.programsClient.create(body);
+        this.programmes.update((list) => [...list, created]);
+        this.successMessage.set(
+          `Programme « ${created.title} » créé avec succès.`,
+        );
+      } else {
         const body: UpdateProgramDto = {
           slug: values.slug,
           title: values.title,
@@ -175,20 +189,6 @@ export default class AdminProgrammesPage implements OnInit {
         );
         this.successMessage.set(
           `Programme « ${updated.title} » mis à jour avec succès.`,
-        );
-      } else {
-        const body: CreateProgramDto = {
-          slug: values.slug,
-          title: values.title,
-          summary: values.summary,
-          description: values.description,
-          status: values.status as CreateProgramDto['status'],
-          visibility: values.visibility as CreateProgramDto['visibility'],
-        };
-        const created = await this.programsClient.create(body);
-        this.programmes.update((list) => [...list, created]);
-        this.successMessage.set(
-          `Programme « ${created.title} » créé avec succès.`,
         );
       }
       this.showForm.set(false);
@@ -208,11 +208,10 @@ export default class AdminProgrammesPage implements OnInit {
   }
 
   async deleteProgramme(programme: ProgramDto): Promise<void> {
-    if (
-      !confirm(
-        `Supprimer le programme « ${programme.title} » ? Cette action est irréversible.`,
-      )
-    ) {
+    const shouldDelete = confirm(
+      `Supprimer le programme « ${programme.title} » ? Cette action est irréversible.`,
+    );
+    if (shouldDelete === false) {
       return;
     }
 

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.html
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.html
@@ -1,0 +1,314 @@
+<section
+  class="bg-brand-white border-b border-neutral-200 px-4 py-10 md:px-8 lg:px-12"
+>
+  <div class="mx-auto max-w-6xl">
+    <div
+      class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div>
+        <p
+          class="text-brand-blue text-xs font-semibold tracking-[0.3em] uppercase"
+        >
+          Administration
+        </p>
+        <h1 class="mt-2 text-3xl font-bold lg:text-4xl">Ressources</h1>
+        <p class="mt-2 text-neutral-600">
+          Gérez les ressources KRAAK : création, modification, type et statut de
+          publication.
+        </p>
+      </div>
+      <div class="flex gap-3">
+        <a
+          pButton
+          routerLink="/admin/dashboard"
+          icon="pi pi-arrow-left"
+          label="Tableau de bord"
+          class="kr-button-ghost"
+          aria-label="Retour au tableau de bord"
+        ></a>
+        <button
+          type="button"
+          pButton
+          icon="pi pi-plus"
+          label="Nouvelle ressource"
+          class="kr-button-primary"
+          (click)="openCreateForm()"
+          aria-label="Créer une nouvelle ressource"
+        ></button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="min-h-screen bg-neutral-50 py-12">
+  <div class="mx-auto max-w-6xl px-4 lg:px-6">
+    @if (successMessage()) {
+      <p-message
+        severity="success"
+        [text]="successMessage()!"
+        class="mb-6 block"
+      />
+    }
+
+    @if (errorMessage()) {
+      <p-message severity="error" [text]="errorMessage()!" class="mb-6 block" />
+    }
+
+    @if (showForm()) {
+      <section class="rounded-card bg-brand-white mb-8 p-8 shadow-sm">
+        <h2 class="mb-6 text-2xl font-bold">
+          {{ isEditing() ? 'Modifier la ressource' : 'Nouvelle ressource' }}
+        </h2>
+
+        <form [formGroup]="form" (ngSubmit)="submitForm()" novalidate>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div class="flex flex-col gap-1 md:col-span-2">
+              <label
+                for="res-title"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Titre <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input
+                id="res-title"
+                type="text"
+                formControlName="title"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="Titre de la ressource"
+                aria-required="true"
+              />
+              @if (form.controls.title.invalid && form.controls.title.touched) {
+                <p class="text-sm text-red-600">Le titre est requis.</p>
+              }
+            </div>
+
+            <div class="flex flex-col gap-1 md:col-span-2">
+              <label
+                for="res-description"
+                class="text-sm font-semibold text-neutral-700"
+                >Description</label
+              >
+              <textarea
+                id="res-description"
+                formControlName="description"
+                rows="3"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="Description de la ressource (optionnelle)"
+              ></textarea>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="res-type"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Type <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <select
+                id="res-type"
+                formControlName="resourceType"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                aria-required="true"
+              >
+                @for (t of resourceTypes; track t) {
+                  <option [value]="t">{{ t }}</option>
+                }
+              </select>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="res-theme"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Thème <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <select
+                id="res-theme"
+                formControlName="resourceTheme"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                aria-required="true"
+              >
+                @for (th of resourceThemes; track th) {
+                  <option [value]="th">{{ th }}</option>
+                }
+              </select>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="res-audience"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Audience <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <select
+                id="res-audience"
+                formControlName="resourceAudience"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                aria-required="true"
+              >
+                @for (a of resourceAudiences; track a) {
+                  <option [value]="a">{{ a }}</option>
+                }
+              </select>
+            </div>
+
+            <div class="flex flex-col gap-1">
+              <label
+                for="res-status"
+                class="text-sm font-semibold text-neutral-700"
+              >
+                Statut <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <select
+                id="res-status"
+                formControlName="status"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                aria-required="true"
+              >
+                @for (s of publicationStatuses; track s) {
+                  <option [value]="s">{{ s }}</option>
+                }
+              </select>
+            </div>
+
+            <div class="flex flex-col gap-1 md:col-span-2">
+              <label
+                for="res-url"
+                class="text-sm font-semibold text-neutral-700"
+                >URL</label
+              >
+              <input
+                id="res-url"
+                type="url"
+                formControlName="url"
+                class="focus:border-brand-blue rounded border border-neutral-300 px-3 py-2 text-sm focus:outline-none"
+                placeholder="https://... (optionnel)"
+              />
+            </div>
+          </div>
+
+          <div class="mt-8 flex gap-3">
+            <button
+              type="submit"
+              pButton
+              icon="pi pi-check"
+              [label]="
+                isEditing()
+                  ? 'Enregistrer les modifications'
+                  : 'Créer la ressource'
+              "
+              class="kr-button-primary"
+              [disabled]="submitting()"
+              [attr.aria-label]="
+                isEditing()
+                  ? 'Enregistrer les modifications'
+                  : 'Créer la ressource'
+              "
+            ></button>
+            <button
+              type="button"
+              pButton
+              icon="pi pi-times"
+              label="Annuler"
+              class="kr-button-ghost"
+              (click)="cancelForm()"
+              aria-label="Annuler et fermer le formulaire"
+            ></button>
+          </div>
+        </form>
+      </section>
+    }
+
+    @if (loading()) {
+      <div class="rounded-card bg-brand-white p-8 text-center shadow-sm">
+        <p class="text-neutral-600">Chargement des ressources…</p>
+      </div>
+    } @else if (ressources().length === 0) {
+      <div class="rounded-card bg-brand-white p-8 text-center shadow-sm">
+        <p class="mb-4 text-neutral-600">Aucune ressource pour le moment.</p>
+        <button
+          type="button"
+          pButton
+          icon="pi pi-plus"
+          label="Créer la première ressource"
+          class="kr-button-primary"
+          (click)="openCreateForm()"
+          aria-label="Créer la première ressource"
+        ></button>
+      </div>
+    } @else {
+      <div class="rounded-card bg-brand-white overflow-x-auto shadow-sm">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-neutral-200 text-left">
+              <th class="px-4 py-3 font-semibold text-neutral-700">Titre</th>
+              <th class="px-4 py-3 font-semibold text-neutral-700">Type</th>
+              <th class="px-4 py-3 font-semibold text-neutral-700">Thème</th>
+              <th class="px-4 py-3 font-semibold text-neutral-700">Statut</th>
+              <th class="px-4 py-3 text-right font-semibold text-neutral-700">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (ressource of ressources(); track ressource.id) {
+              <tr
+                class="border-b border-neutral-100 transition-colors hover:bg-neutral-50"
+              >
+                <td class="px-4 py-3 font-medium">{{ ressource.title }}</td>
+                <td class="px-4 py-3 text-neutral-600">
+                  {{ ressource.resourceType }}
+                </td>
+                <td class="px-4 py-3 text-neutral-600">
+                  {{ ressource.resourceTheme }}
+                </td>
+                <td class="px-4 py-3">
+                  <span
+                    class="rounded-full px-2 py-0.5 text-xs font-semibold"
+                    [class]="
+                      ressource.status === 'published'
+                        ? 'bg-green-100 text-green-800'
+                        : ressource.status === 'draft'
+                          ? 'bg-yellow-100 text-yellow-800'
+                          : 'bg-neutral-100 text-neutral-600'
+                    "
+                  >
+                    {{ ressource.status }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      pButton
+                      icon="pi pi-pencil"
+                      label="Modifier"
+                      class="kr-button-ghost text-xs"
+                      (click)="openEditForm(ressource)"
+                      [attr.aria-label]="
+                        'Modifier la ressource ' + ressource.title
+                      "
+                    ></button>
+                    <button
+                      type="button"
+                      pButton
+                      icon="pi pi-trash"
+                      label="Supprimer"
+                      class="text-xs text-red-600"
+                      (click)="deleteRessource(ressource)"
+                      [attr.aria-label]="
+                        'Supprimer la ressource ' + ressource.title
+                      "
+                    ></button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.html
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.html
@@ -267,12 +267,17 @@
                 <td class="px-4 py-3">
                   <span
                     class="rounded-full px-2 py-0.5 text-xs font-semibold"
-                    [class]="
-                      ressource.status === 'published'
-                        ? 'bg-green-100 text-green-800'
-                        : ressource.status === 'draft'
-                          ? 'bg-yellow-100 text-yellow-800'
-                          : 'bg-neutral-100 text-neutral-600'
+                    [class.bg-green-100]="ressource.status === 'published'"
+                    [class.text-green-800]="ressource.status === 'published'"
+                    [class.bg-yellow-100]="ressource.status === 'draft'"
+                    [class.text-yellow-800]="ressource.status === 'draft'"
+                    [class.bg-neutral-100]="
+                      ressource.status !== 'published' &&
+                      ressource.status !== 'draft'
+                    "
+                    [class.text-neutral-600]="
+                      ressource.status !== 'published' &&
+                      ressource.status !== 'draft'
                     "
                   >
                     {{ ressource.status }}

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { MessageService } from 'primeng/api';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { signal } from '@angular/core';
 import { WebAuthService } from '../../../core/auth/web-auth.service';
@@ -74,6 +74,10 @@ const resourcesClientMock = {
 };
 
 describe('AdminRessourcesPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AdminRessourcesPage],
@@ -182,5 +186,192 @@ describe('AdminRessourcesPage', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance['showForm']()).toBe(false);
+  });
+
+  it('Given a valid creation form When submitForm is called Then the resource is created', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    const createSpy = vi.fn(
+      async () =>
+        ({
+          id: 'res-created',
+          title: 'Ressource créée',
+          description: null,
+          resourceType: 'link',
+          resourceTheme: 'training',
+          resourceAudience: 'all',
+          url: null,
+          filePath: null,
+          status: 'draft',
+          publishedAt: null,
+          programId: null,
+          cohortId: null,
+          createdAt: '2025-03-01T00:00:00Z',
+          updatedAt: '2025-03-01T00:00:00Z',
+        }) as ResourceDto,
+    );
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      create: createSpy,
+      list: async () => ({ data: [], total: 0 }),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.componentInstance['form'].setValue({
+      title: 'Ressource créée',
+      description: '',
+      resourceType: 'link',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: '',
+      status: 'draft',
+    });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(fixture.componentInstance['ressources']()).toHaveLength(1);
+    expect(fixture.componentInstance['successMessage']()).toContain('créée');
+  });
+
+  it('Given a valid edit form When submitForm is called Then the resource is updated', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    const updateSpy = vi.fn(async (id: string) => ({
+      ...mockRessources[0],
+      id,
+      title: 'Guide mis à jour',
+    }));
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      update: updateSpy,
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openEditForm(mockRessources[0]);
+    fixture.componentInstance['form'].patchValue({ title: 'Guide mis à jour' });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      mockRessources[0].id,
+      expect.objectContaining({ title: 'Guide mis à jour' }),
+    );
+    expect(fixture.componentInstance['ressources']()[0]?.title).toBe(
+      'Guide mis à jour',
+    );
+    expect(fixture.componentInstance['successMessage']()).toContain(
+      'mise à jour',
+    );
+  });
+
+  it('Given an invalid form When submitForm is called Then no creation request is sent', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    const createSpy = vi.fn(resourcesClientMock.create);
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      create: createSpy,
+    };
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.componentInstance['form'].patchValue({ title: '' });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('Given a save failure When submitForm is called Then an explicit error message is displayed', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      create: vi.fn(async () => {
+        throw new Error('save failed');
+      }),
+      list: async () => ({ data: [], total: 0 }),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.componentInstance['form'].setValue({
+      title: 'Ressource',
+      description: '',
+      resourceType: 'link',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: '',
+      status: 'draft',
+    });
+
+    await fixture.componentInstance.submitForm();
+
+    expect(fixture.componentInstance['errorMessage']()).toContain('sauvegarde');
+    expect(fixture.componentInstance['submitting']()).toBe(false);
+  });
+
+  it('Given a refusal in the confirmation dialog When deleteRessource is called Then nothing is deleted', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    const removeSpy = vi.fn(async () => undefined);
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      remove: removeSpy,
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance.deleteRessource(mockRessources[0]);
+
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  it('Given a confirmed deletion When deleteRessource is called Then the resource is removed from state', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      remove: vi.fn(async () => undefined),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance.deleteRessource(mockRessources[0]);
+
+    expect(fixture.componentInstance['ressources']()).toHaveLength(1);
+    expect(fixture.componentInstance['successMessage']()).toContain(
+      'supprimée',
+    );
+  });
+
+  it('Given a loading failure When the page initializes Then the load error is exposed', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      list: vi.fn(async () => {
+        throw new Error('network');
+      }),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance['errorMessage']()).toContain('charger');
+    expect(fixture.componentInstance['loading']()).toBe(false);
   });
 });

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
@@ -1,0 +1,185 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { MessageService } from 'primeng/api';
+
+import { signal } from '@angular/core';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import AdminRessourcesPage from './admin-ressources.page';
+import type { ResourceDto } from '@kraak/contracts';
+
+const mockRessources: ResourceDto[] = [
+  {
+    id: 'res-1',
+    title: 'Guide de leadership',
+    description: 'Un guide pratique sur le leadership.',
+    resourceType: 'document',
+    resourceTheme: 'training',
+    resourceAudience: 'all',
+    url: 'https://example.com/guide',
+    filePath: null,
+    status: 'published',
+    publishedAt: '2025-01-01T00:00:00Z',
+    programId: null,
+    cohortId: null,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 'res-2',
+    title: 'Vidéo : gestion de projet agile',
+    description: null,
+    resourceType: 'video',
+    resourceTheme: 'project_management',
+    resourceAudience: 'organizations',
+    url: 'https://example.com/video',
+    filePath: null,
+    status: 'draft',
+    publishedAt: null,
+    programId: null,
+    cohortId: null,
+    createdAt: '2025-02-01T00:00:00Z',
+    updatedAt: '2025-02-01T00:00:00Z',
+  },
+];
+
+const webAuthServiceMock = {
+  currentSession: signal<null>(null),
+  isAuthenticated: signal(false),
+  isAdmin: signal(false),
+  hasRole: () => false,
+};
+
+const resourcesClientMock = {
+  list: async () => mockRessources,
+  create: async () =>
+    ({
+      id: 'res-new',
+      title: 'New',
+      description: null,
+      resourceType: 'link',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: null,
+      filePath: null,
+      status: 'draft',
+      publishedAt: null,
+      programId: null,
+      cohortId: null,
+      createdAt: '',
+      updatedAt: '',
+    }) as ResourceDto,
+  update: async (id: string) => ({ ...mockRessources[0], id }) as ResourceDto,
+  remove: async () => undefined,
+};
+
+describe('AdminRessourcesPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminRessourcesPage],
+      providers: [
+        provideRouter([]),
+        MessageService,
+        { provide: WebAuthService, useValue: webAuthServiceMock },
+      ],
+    }).compileComponents();
+  });
+
+  it('Given the admin ressources page When it is created Then the instance exists', () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the admin ressources page When it renders Then it shows the page heading', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    fixture.componentInstance.resourcesClient = resourcesClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Ressources');
+    expect(content).toContain('Nouvelle ressource');
+    expect(content).toContain('Administration');
+  });
+
+  it('Given ressources are loaded When the list is displayed Then it shows the resource titles', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    fixture.componentInstance.resourcesClient = resourcesClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Guide de leadership');
+    expect(content).toContain('Vidéo : gestion de projet agile');
+  });
+
+  it('Given no ressources exist When the list renders Then it shows the empty state', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      list: async () => [],
+    };
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Aucune ressource pour le moment');
+  });
+
+  it('Given the create button is clicked When the form opens Then it shows the create form', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    fixture.componentInstance.resourcesClient = resourcesClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.openCreateForm();
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent as string;
+
+    expect(content).toContain('Nouvelle ressource');
+    expect(content).toContain('Titre');
+    expect(content).toContain('Type');
+    expect(content).toContain('Annuler');
+  });
+
+  it('Given an existing ressource When openEditForm is called Then the form is prefilled', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    fixture.componentInstance.resourcesClient = resourcesClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.openEditForm(mockRessources[0]);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['form'].controls.title.value).toBe(
+      'Guide de leadership',
+    );
+    expect(fixture.componentInstance['form'].controls.resourceType.value).toBe(
+      'document',
+    );
+  });
+
+  it('Given the form is open When cancelForm is called Then the form is hidden', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    fixture.componentInstance.resourcesClient = resourcesClientMock;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    fixture.componentInstance.openCreateForm();
+    fixture.detectChanges();
+
+    fixture.componentInstance.cancelForm();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['showForm']()).toBe(false);
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { signal } from '@angular/core';
 import { WebAuthService } from '../../../core/auth/web-auth.service';
@@ -50,7 +51,7 @@ const webAuthServiceMock = {
 };
 
 const resourcesClientMock = {
-  list: async () => mockRessources,
+  list: async () => ({ data: mockRessources, total: mockRessources.length }),
   create: async () =>
     ({
       id: 'res-new',
@@ -68,7 +69,7 @@ const resourcesClientMock = {
       createdAt: '',
       updatedAt: '',
     }) as ResourceDto,
-  update: async (id: string) => ({ ...mockRessources[0], id }) as ResourceDto,
+  update: async (id: string) => ({ ...mockRessources[0], id }),
   remove: async () => undefined,
 };
 
@@ -121,7 +122,7 @@ describe('AdminRessourcesPage', () => {
     const fixture = TestBed.createComponent(AdminRessourcesPage);
     fixture.componentInstance.resourcesClient = {
       ...resourcesClientMock,
-      list: async () => [],
+      list: async () => ({ data: [], total: 0 }),
     };
     fixture.detectChanges();
     await fixture.whenStable();

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.ts
@@ -6,7 +6,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { createApiClient, type ApiClient } from '@kraak/api-client';
+import { createApiClient } from '@kraak/api-client';
 import type {
   CreateResourceDto,
   ResourceDto,
@@ -36,6 +36,20 @@ interface ResourceFormModel {
   status: FormControl<string>;
 }
 
+type ResourceListResponse =
+  | ResourceDto[]
+  | {
+      data: ResourceDto[];
+      total: number;
+    };
+
+interface AdminResourcesClient {
+  list(): Promise<ResourceListResponse>;
+  create(body: CreateResourceDto): Promise<ResourceDto>;
+  update(id: string, body: UpdateResourceDto): Promise<ResourceDto>;
+  remove(id: string): Promise<void>;
+}
+
 @Component({
   selector: 'kraak-admin-ressources-page',
   standalone: true,
@@ -45,10 +59,7 @@ interface ResourceFormModel {
 export default class AdminRessourcesPage implements OnInit {
   private readonly authService = inject(WebAuthService);
   private readonly messageService = inject(MessageService);
-  resourcesClient: Pick<
-    ApiClient['resources'],
-    'list' | 'create' | 'update' | 'remove'
-  > = createApiClient({
+  resourcesClient: AdminResourcesClient = createApiClient({
     baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
     getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
   }).resources;
@@ -93,8 +104,8 @@ export default class AdminRessourcesPage implements OnInit {
     }),
   });
 
-  async ngOnInit(): Promise<void> {
-    await this.loadRessources();
+  ngOnInit(): void {
+    void this.loadRessources();
   }
 
   async loadRessources(): Promise<void> {
@@ -102,7 +113,7 @@ export default class AdminRessourcesPage implements OnInit {
     this.errorMessage.set(null);
     try {
       const list = await this.resourcesClient.list();
-      this.ressources.set(list);
+      this.ressources.set(Array.isArray(list) ? list : list.data);
     } catch (err) {
       console.error(
         '[AdminRessourcesPage] Erreur lors du chargement des ressources',
@@ -168,27 +179,7 @@ export default class AdminRessourcesPage implements OnInit {
 
     try {
       const id = this.editingId();
-      if (id !== null) {
-        const body: UpdateResourceDto = {
-          title: values.title,
-          description: values.description || null,
-          resourceType:
-            values.resourceType as CreateResourceDto['resourceType'],
-          resourceTheme:
-            values.resourceTheme as CreateResourceDto['resourceTheme'],
-          resourceAudience:
-            values.resourceAudience as CreateResourceDto['resourceAudience'],
-          url: values.url || null,
-          status: values.status as CreateResourceDto['status'],
-        };
-        const updated = await this.resourcesClient.update(id, body);
-        this.ressources.update((list) =>
-          list.map((r) => (r.id === id ? updated : r)),
-        );
-        this.successMessage.set(
-          `Ressource « ${updated.title} » mise à jour avec succès.`,
-        );
-      } else {
+      if (id === null) {
         const body: CreateResourceDto = {
           title: values.title,
           description: values.description || null,
@@ -209,6 +200,26 @@ export default class AdminRessourcesPage implements OnInit {
         this.ressources.update((list) => [...list, created]);
         this.successMessage.set(
           `Ressource « ${created.title} » créée avec succès.`,
+        );
+      } else {
+        const body: UpdateResourceDto = {
+          title: values.title,
+          description: values.description || null,
+          resourceType:
+            values.resourceType as CreateResourceDto['resourceType'],
+          resourceTheme:
+            values.resourceTheme as CreateResourceDto['resourceTheme'],
+          resourceAudience:
+            values.resourceAudience as CreateResourceDto['resourceAudience'],
+          url: values.url || null,
+          status: values.status as CreateResourceDto['status'],
+        };
+        const updated = await this.resourcesClient.update(id, body);
+        this.ressources.update((list) =>
+          list.map((r) => (r.id === id ? updated : r)),
+        );
+        this.successMessage.set(
+          `Ressource « ${updated.title} » mise à jour avec succès.`,
         );
       }
       this.showForm.set(false);

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.ts
@@ -1,0 +1,258 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { createApiClient, type ApiClient } from '@kraak/api-client';
+import type {
+  CreateResourceDto,
+  ResourceDto,
+  UpdateResourceDto,
+} from '@kraak/contracts';
+import {
+  PublicationStatus,
+  ResourceType,
+  ResourceTheme,
+  ResourceAudience,
+} from '@kraak/contracts';
+import { MessageService } from 'primeng/api';
+import { ButtonDirective } from 'primeng/button';
+import { Message } from 'primeng/message';
+
+import { environment } from '../../../../environments/environment';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+
+interface ResourceFormModel {
+  title: FormControl<string>;
+  description: FormControl<string>;
+  resourceType: FormControl<string>;
+  resourceTheme: FormControl<string>;
+  resourceAudience: FormControl<string>;
+  url: FormControl<string>;
+  status: FormControl<string>;
+}
+
+@Component({
+  selector: 'kraak-admin-ressources-page',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink, ButtonDirective, Message],
+  templateUrl: './admin-ressources.page.html',
+})
+export default class AdminRessourcesPage implements OnInit {
+  private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
+  resourcesClient: Pick<
+    ApiClient['resources'],
+    'list' | 'create' | 'update' | 'remove'
+  > = createApiClient({
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).resources;
+
+  protected readonly ressources = signal<ResourceDto[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly successMessage = signal<string | null>(null);
+  protected readonly showForm = signal(false);
+  protected readonly editingId = signal<string | null>(null);
+  protected readonly submitting = signal(false);
+
+  protected readonly isEditing = computed(() => this.editingId() !== null);
+
+  readonly publicationStatuses = Object.values(PublicationStatus);
+  readonly resourceTypes = Object.values(ResourceType);
+  readonly resourceThemes = Object.values(ResourceTheme);
+  readonly resourceAudiences = Object.values(ResourceAudience);
+
+  readonly form = new FormGroup<ResourceFormModel>({
+    title: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    description: new FormControl('', { nonNullable: true }),
+    resourceType: new FormControl('link', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    resourceTheme: new FormControl('training', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    resourceAudience: new FormControl('all', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    url: new FormControl('', { nonNullable: true }),
+    status: new FormControl('draft', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  async ngOnInit(): Promise<void> {
+    await this.loadRessources();
+  }
+
+  async loadRessources(): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    try {
+      const list = await this.resourcesClient.list();
+      this.ressources.set(list);
+    } catch (err) {
+      console.error(
+        '[AdminRessourcesPage] Erreur lors du chargement des ressources',
+        err,
+      );
+      this.errorMessage.set(
+        'Impossible de charger les ressources. Vérifiez la connexion et réessayez.',
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  openCreateForm(): void {
+    this.editingId.set(null);
+    this.form.reset({
+      title: '',
+      description: '',
+      resourceType: 'link',
+      resourceTheme: 'training',
+      resourceAudience: 'all',
+      url: '',
+      status: 'draft',
+    });
+    this.showForm.set(true);
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+  }
+
+  openEditForm(ressource: ResourceDto): void {
+    this.editingId.set(ressource.id);
+    this.form.reset({
+      title: ressource.title,
+      description: ressource.description ?? '',
+      resourceType: ressource.resourceType,
+      resourceTheme: ressource.resourceTheme,
+      resourceAudience: ressource.resourceAudience,
+      url: ressource.url ?? '',
+      status: ressource.status,
+    });
+    this.showForm.set(true);
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+  }
+
+  cancelForm(): void {
+    this.showForm.set(false);
+    this.editingId.set(null);
+    this.form.reset();
+  }
+
+  async submitForm(): Promise<void> {
+    this.form.markAllAsTouched();
+    if (this.form.invalid) {
+      return;
+    }
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    const values = this.form.getRawValue();
+
+    try {
+      const id = this.editingId();
+      if (id !== null) {
+        const body: UpdateResourceDto = {
+          title: values.title,
+          description: values.description || null,
+          resourceType:
+            values.resourceType as CreateResourceDto['resourceType'],
+          resourceTheme:
+            values.resourceTheme as CreateResourceDto['resourceTheme'],
+          resourceAudience:
+            values.resourceAudience as CreateResourceDto['resourceAudience'],
+          url: values.url || null,
+          status: values.status as CreateResourceDto['status'],
+        };
+        const updated = await this.resourcesClient.update(id, body);
+        this.ressources.update((list) =>
+          list.map((r) => (r.id === id ? updated : r)),
+        );
+        this.successMessage.set(
+          `Ressource « ${updated.title} » mise à jour avec succès.`,
+        );
+      } else {
+        const body: CreateResourceDto = {
+          title: values.title,
+          description: values.description || null,
+          resourceType:
+            values.resourceType as CreateResourceDto['resourceType'],
+          resourceTheme:
+            values.resourceTheme as CreateResourceDto['resourceTheme'],
+          resourceAudience:
+            values.resourceAudience as CreateResourceDto['resourceAudience'],
+          url: values.url || null,
+          filePath: null,
+          status: values.status as CreateResourceDto['status'],
+          publishedAt: null,
+          programId: null,
+          cohortId: null,
+        };
+        const created = await this.resourcesClient.create(body);
+        this.ressources.update((list) => [...list, created]);
+        this.successMessage.set(
+          `Ressource « ${created.title} » créée avec succès.`,
+        );
+      }
+      this.showForm.set(false);
+      this.editingId.set(null);
+      this.form.reset();
+    } catch (err) {
+      console.error(
+        '[AdminRessourcesPage] Erreur lors de la sauvegarde de la ressource',
+        err,
+      );
+      this.errorMessage.set(
+        'Une erreur est survenue lors de la sauvegarde. Vérifiez les champs et réessayez.',
+      );
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  async deleteRessource(ressource: ResourceDto): Promise<void> {
+    if (
+      !confirm(
+        `Supprimer la ressource « ${ressource.title} » ? Cette action est irréversible.`,
+      )
+    ) {
+      return;
+    }
+
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    try {
+      await this.resourcesClient.remove(ressource.id);
+      this.ressources.update((list) =>
+        list.filter((r) => r.id !== ressource.id),
+      );
+      this.successMessage.set(`Ressource « ${ressource.title} » supprimée.`);
+    } catch (err) {
+      console.error(
+        '[AdminRessourcesPage] Erreur lors de la suppression de la ressource',
+        err,
+      );
+      this.errorMessage.set(
+        'Impossible de supprimer cette ressource. Réessayez.',
+      );
+    }
+  }
+}


### PR DESCRIPTION
Ajoute les pages /admin/programmes et /admin/ressources avec CRUD complet (liste, création, édition, suppression).\n\nTests composants : 14 tests passants (7 par page).\nRoutes enregistrées sous adminRoleGuard.