### PR TITLE
feat: add admin user management module

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { ResourcesModule } from './resources/resources.module';
 import { resolveApiEnvFilePaths } from './config/environment-files';
 import { SupabaseModule } from './supabase/supabase.module';
 import { SupportModule } from './support/support.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { SupportModule } from './support/support.module';
     ProgramsModule,
     ResourcesModule,
     SupportModule,
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,0 +1,136 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { UsersController } from './users.controller';
+
+const mockFindAll = jest.fn();
+const mockFindOne = jest.fn();
+const mockUpdate = jest.fn();
+const mockRemove = jest.fn();
+const mockInvite = jest.fn();
+
+const mockUsersService = {
+  findAll: mockFindAll,
+  findOne: mockFindOne,
+  update: mockUpdate,
+  remove: mockRemove,
+  invite: mockInvite,
+};
+
+const mockRequireAdminAccess = jest.fn();
+const mockExtractAccessToken = jest.fn();
+
+jest.mock('../auth/auth.dto', () => ({
+  extractAccessToken: (header: string) => mockExtractAccessToken(header),
+}));
+
+jest.mock('../shared/admin-access.utils', () => ({
+  requireAdminAccess: (...args: unknown[]) => mockRequireAdminAccess(...args),
+}));
+
+const mockAuthService = {};
+
+const validToken = 'Bearer valid-token';
+const extractedToken = 'valid-token';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExtractAccessToken.mockReturnValue(extractedToken);
+    mockRequireAdminAccess.mockResolvedValue(undefined);
+    controller = new UsersController(
+      mockUsersService as never,
+      mockAuthService as never,
+    );
+  });
+
+  describe('findAll', () => {
+    it('Given an admin token, When findAll is called, Then returns user list', async () => {
+      const users = [{ id: '1', email: 'alice@example.com' }];
+      mockFindAll.mockResolvedValueOnce(users);
+
+      const result = await controller.findAll(validToken);
+
+      expect(result).toEqual(users);
+      expect(mockExtractAccessToken).toHaveBeenCalledWith(validToken);
+      expect(mockRequireAdminAccess).toHaveBeenCalled();
+    });
+
+    it('Given a missing token, When findAll is called, Then throws UnauthorizedException', async () => {
+      mockExtractAccessToken.mockReturnValueOnce(null);
+
+      await expect(controller.findAll('')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('Given a valid admin token and existing ID, When findOne is called, Then returns user', async () => {
+      const user = { id: '1', email: 'alice@example.com' };
+      mockFindOne.mockResolvedValueOnce(user);
+
+      const result = await controller.findOne('1', validToken);
+
+      expect(result).toEqual(user);
+    });
+
+    it('Given a missing token, When findOne is called, Then throws UnauthorizedException', async () => {
+      mockExtractAccessToken.mockReturnValueOnce(null);
+
+      await expect(controller.findOne('1', '')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('Given valid update data, When update is called, Then returns updated user', async () => {
+      const updated = {
+        id: '1',
+        firstName: 'Alicia',
+        email: 'alice@example.com',
+      };
+      mockUpdate.mockResolvedValueOnce(updated);
+
+      const result = await controller.update(
+        '1',
+        { firstName: 'Alicia' },
+        validToken,
+      );
+
+      expect(result.firstName).toBe('Alicia');
+    });
+
+    it('Given invalid update payload, When update is called, Then throws BadRequestException', async () => {
+      await expect(
+        controller.update('1', { role: 'invalid-role' }, validToken),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('invite', () => {
+    it('Given valid invite data, When invite is called, Then returns created user', async () => {
+      const user = { id: '2', email: 'bob@example.com' };
+      mockInvite.mockResolvedValueOnce(user);
+
+      const result = await controller.invite(
+        {
+          email: 'bob@example.com',
+          firstName: 'Bob',
+          lastName: 'Dupont',
+          role: 'participant',
+        },
+        validToken,
+      );
+
+      expect(result.email).toBe('bob@example.com');
+    });
+
+    it('Given invalid invite payload, When invite is called, Then throws BadRequestException', async () => {
+      await expect(
+        controller.invite({ email: 'not-an-email' }, validToken),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -16,11 +16,6 @@ const mockUsersService = {
 };
 
 const mockRequireAdminAccess = jest.fn();
-const mockExtractAccessToken = jest.fn();
-
-jest.mock('../auth/auth.dto', () => ({
-  extractAccessToken: (header: string) => mockExtractAccessToken(header),
-}));
 
 jest.mock('../shared/admin-access.utils', () => ({
   requireAdminAccess: (...args: unknown[]) => mockRequireAdminAccess(...args),
@@ -29,14 +24,12 @@ jest.mock('../shared/admin-access.utils', () => ({
 const mockAuthService = {};
 
 const validToken = 'Bearer valid-token';
-const extractedToken = 'valid-token';
 
 describe('UsersController', () => {
   let controller: UsersController;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockExtractAccessToken.mockReturnValue(extractedToken);
     mockRequireAdminAccess.mockResolvedValue(undefined);
     controller = new UsersController(
       mockUsersService as never,
@@ -52,12 +45,14 @@ describe('UsersController', () => {
       const result = await controller.findAll(validToken);
 
       expect(result).toEqual(users);
-      expect(mockExtractAccessToken).toHaveBeenCalledWith(validToken);
-      expect(mockRequireAdminAccess).toHaveBeenCalled();
+      expect(mockRequireAdminAccess).toHaveBeenCalledWith(
+        mockAuthService,
+        validToken,
+      );
     });
 
     it('Given a missing token, When findAll is called, Then throws UnauthorizedException', async () => {
-      mockExtractAccessToken.mockReturnValueOnce(null);
+      mockRequireAdminAccess.mockRejectedValueOnce(new UnauthorizedException());
 
       await expect(controller.findAll('')).rejects.toThrow(
         UnauthorizedException,
@@ -76,7 +71,7 @@ describe('UsersController', () => {
     });
 
     it('Given a missing token, When findOne is called, Then throws UnauthorizedException', async () => {
-      mockExtractAccessToken.mockReturnValueOnce(null);
+      mockRequireAdminAccess.mockRejectedValueOnce(new UnauthorizedException());
 
       await expect(controller.findOne('1', '')).rejects.toThrow(
         UnauthorizedException,

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,193 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AuthService } from '../auth/auth.service';
+import { extractAccessToken } from '../auth/auth.dto';
+import { requireAdminAccess } from '../shared/admin-access.utils';
+import {
+  validateCreateUserPayload,
+  validateUpdateUserPayload,
+} from './users.dto';
+import { UsersService } from './users.service';
+
+@ApiTags('users')
+@ApiBearerAuth()
+@Controller('users')
+export class UsersController {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Récupérer la liste de tous les utilisateurs' })
+  @ApiResponse({ status: 200, description: 'Liste des utilisateurs retournée' })
+  @ApiResponse({
+    status: 401,
+    description: 'Non autorisé — accès admin requis',
+  })
+  async findAll(@Headers('authorization') authHeader: string) {
+    const token = extractAccessToken(authHeader);
+    if (!token) throw new UnauthorizedException('Token manquant');
+    await requireAdminAccess(this.authService, token);
+    return this.usersService.findAll();
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Récupérer un utilisateur par son identifiant' })
+  @ApiParam({
+    name: 'id',
+    description: "Identifiant de l'utilisateur",
+    type: 'string',
+  })
+  @ApiResponse({ status: 200, description: 'Utilisateur retourné' })
+  @ApiResponse({
+    status: 401,
+    description: 'Non autorisé — accès admin requis',
+  })
+  @ApiResponse({ status: 404, description: 'Utilisateur introuvable' })
+  async findOne(
+    @Param('id') id: string,
+    @Headers('authorization') authHeader: string,
+  ) {
+    const token = extractAccessToken(authHeader);
+    if (!token) throw new UnauthorizedException('Token manquant');
+    await requireAdminAccess(this.authService, token);
+    return this.usersService.findOne(id);
+  }
+
+  @Patch(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Mettre à jour un utilisateur' })
+  @ApiParam({
+    name: 'id',
+    description: "Identifiant de l'utilisateur",
+    type: 'string',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        email: { type: 'string', format: 'email' },
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+        role: { type: 'string', enum: ['participant', 'admin', 'trainer'] },
+        phone: { type: 'string', nullable: true },
+        preferredContactChannel: { type: 'string', nullable: true },
+        isActive: { type: 'boolean' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Utilisateur mis à jour' })
+  @ApiResponse({ status: 400, description: 'Données invalides' })
+  @ApiResponse({
+    status: 401,
+    description: 'Non autorisé — accès admin requis',
+  })
+  @ApiResponse({ status: 404, description: 'Utilisateur introuvable' })
+  async update(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Headers('authorization') authHeader: string,
+  ) {
+    const token = extractAccessToken(authHeader);
+    if (!token) throw new UnauthorizedException('Token manquant');
+    await requireAdminAccess(this.authService, token);
+
+    const validation = validateUpdateUserPayload(body);
+    if (!validation.valid) throw new BadRequestException(validation.error);
+
+    return this.usersService.update(id, validation.data);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Supprimer un utilisateur' })
+  @ApiParam({
+    name: 'id',
+    description: "Identifiant de l'utilisateur",
+    type: 'string',
+  })
+  @ApiResponse({ status: 204, description: 'Utilisateur supprimé' })
+  @ApiResponse({
+    status: 401,
+    description: 'Non autorisé — accès admin requis',
+  })
+  @ApiResponse({ status: 404, description: 'Utilisateur introuvable' })
+  async remove(
+    @Param('id') id: string,
+    @Headers('authorization') authHeader: string,
+  ) {
+    const token = extractAccessToken(authHeader);
+    if (!token) throw new UnauthorizedException('Token manquant');
+    await requireAdminAccess(this.authService, token);
+
+    await this.usersService.remove(id);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Inviter un nouvel utilisateur par email' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['email', 'firstName', 'lastName', 'role'],
+      properties: {
+        email: {
+          type: 'string',
+          format: 'email',
+          example: 'alice@example.com',
+        },
+        firstName: { type: 'string', example: 'Alice' },
+        lastName: { type: 'string', example: 'Martin' },
+        role: { type: 'string', enum: ['participant', 'admin', 'trainer'] },
+        phone: { type: 'string', nullable: true },
+        preferredContactChannel: { type: 'string', nullable: true },
+        isActive: { type: 'boolean', default: true },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Invitation envoyée et profil créé',
+  })
+  @ApiResponse({ status: 400, description: 'Données invalides' })
+  @ApiResponse({
+    status: 401,
+    description: 'Non autorisé — accès admin requis',
+  })
+  async invite(
+    @Body() body: unknown,
+    @Headers('authorization') authHeader: string,
+  ) {
+    const token = extractAccessToken(authHeader);
+    if (!token) throw new UnauthorizedException('Token manquant');
+    await requireAdminAccess(this.authService, token);
+
+    const validation = validateCreateUserPayload(body);
+    if (!validation.valid) throw new BadRequestException(validation.error);
+
+    return this.usersService.invite(validation.data);
+  }
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -10,7 +10,6 @@ import {
   Param,
   Patch,
   Post,
-  UnauthorizedException,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -21,7 +20,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthService } from '../auth/auth.service';
-import { extractAccessToken } from '../auth/auth.dto';
 import { requireAdminAccess } from '../shared/admin-access.utils';
 import {
   validateCreateUserPayload,
@@ -47,9 +45,7 @@ export class UsersController {
     description: 'Non autorisé — accès admin requis',
   })
   async findAll(@Headers('authorization') authHeader: string) {
-    const token = extractAccessToken(authHeader);
-    if (!token) throw new UnauthorizedException('Token manquant');
-    await requireAdminAccess(this.authService, token);
+    await requireAdminAccess(this.authService, authHeader);
     return this.usersService.findAll();
   }
 
@@ -71,9 +67,7 @@ export class UsersController {
     @Param('id') id: string,
     @Headers('authorization') authHeader: string,
   ) {
-    const token = extractAccessToken(authHeader);
-    if (!token) throw new UnauthorizedException('Token manquant');
-    await requireAdminAccess(this.authService, token);
+    await requireAdminAccess(this.authService, authHeader);
     return this.usersService.findOne(id);
   }
 
@@ -111,9 +105,7 @@ export class UsersController {
     @Body() body: unknown,
     @Headers('authorization') authHeader: string,
   ) {
-    const token = extractAccessToken(authHeader);
-    if (!token) throw new UnauthorizedException('Token manquant');
-    await requireAdminAccess(this.authService, token);
+    await requireAdminAccess(this.authService, authHeader);
 
     const validation = validateUpdateUserPayload(body);
     if (!validation.valid) throw new BadRequestException(validation.error);
@@ -139,9 +131,7 @@ export class UsersController {
     @Param('id') id: string,
     @Headers('authorization') authHeader: string,
   ) {
-    const token = extractAccessToken(authHeader);
-    if (!token) throw new UnauthorizedException('Token manquant');
-    await requireAdminAccess(this.authService, token);
+    await requireAdminAccess(this.authService, authHeader);
 
     await this.usersService.remove(id);
   }
@@ -181,9 +171,7 @@ export class UsersController {
     @Body() body: unknown,
     @Headers('authorization') authHeader: string,
   ) {
-    const token = extractAccessToken(authHeader);
-    if (!token) throw new UnauthorizedException('Token manquant');
-    await requireAdminAccess(this.authService, token);
+    await requireAdminAccess(this.authService, authHeader);
 
     const validation = validateCreateUserPayload(body);
     if (!validation.valid) throw new BadRequestException(validation.error);

--- a/apps/api/src/users/users.dto.spec.ts
+++ b/apps/api/src/users/users.dto.spec.ts
@@ -51,6 +51,28 @@ describe('validateCreateUserPayload', () => {
     expect(result.valid).toBe(false);
   });
 
+  it('Given an email with space, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice @example.com',
+      firstName: 'Alice',
+      lastName: 'Martin',
+      role: 'participant',
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('Given an email without top-level domain, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice@example',
+      firstName: 'Alice',
+      lastName: 'Martin',
+      role: 'participant',
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
   it('Given an unknown role, When validating, Then returns invalid', () => {
     const result = validateCreateUserPayload({
       email: 'bob@example.com',
@@ -181,6 +203,11 @@ describe('validateUpdateUserPayload', () => {
       valid: false,
       error: expect.stringContaining('email'),
     });
+  });
+
+  it('Given an email with multiple @ in update payload, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload({ email: 'a@@example.com' });
+    expect(result.valid).toBe(false);
   });
 
   it('Given blank first name in update payload, When validating, Then returns invalid', () => {

--- a/apps/api/src/users/users.dto.spec.ts
+++ b/apps/api/src/users/users.dto.spec.ts
@@ -63,6 +63,76 @@ describe('validateCreateUserPayload', () => {
       error: expect.stringContaining('rôle'),
     });
   });
+
+  it('Given optional text fields with surrounding spaces, When validating, Then trims and normalizes values', () => {
+    const result = validateCreateUserPayload({
+      email: '  alice@example.com  ',
+      firstName: '  Alice  ',
+      lastName: '  Martin  ',
+      role: 'admin',
+      phone: '  0601020304  ',
+      preferredContactChannel: '  email  ',
+      isActive: false,
+    });
+
+    expect(result).toMatchObject({
+      valid: true,
+      data: {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Martin',
+        role: 'admin',
+        phone: '0601020304',
+        preferredContactChannel: 'email',
+        isActive: false,
+      },
+    });
+  });
+
+  it('Given optional text fields as empty strings, When validating, Then stores null values', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Martin',
+      role: 'participant',
+      phone: '   ',
+      preferredContactChannel: '   ',
+    });
+
+    expect(result).toMatchObject({
+      valid: true,
+      data: expect.objectContaining({
+        phone: null,
+        preferredContactChannel: null,
+      }),
+    });
+  });
+
+  it('Given missing first name, When validating, Then returns required error', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice@example.com',
+      lastName: 'Martin',
+      role: 'participant',
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('prénom'),
+    });
+  });
+
+  it('Given missing last name, When validating, Then returns required error', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      role: 'participant',
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('nom de famille'),
+    });
+  });
 });
 
 describe('validateUpdateUserPayload', () => {
@@ -90,5 +160,76 @@ describe('validateUpdateUserPayload', () => {
   it('Given a non-object body, When validating, Then returns invalid', () => {
     const result = validateUpdateUserPayload('not-an-object');
     expect(result.valid).toBe(false);
+  });
+
+  it('Given email with spaces, When validating, Then trims email in update payload', () => {
+    const result = validateUpdateUserPayload({
+      email: '  claire@example.com  ',
+    });
+
+    expect(result).toMatchObject({
+      valid: true,
+      data: {
+        email: 'claire@example.com',
+      },
+    });
+  });
+
+  it('Given an invalid email in update payload, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload({ email: 'not-an-email' });
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('email'),
+    });
+  });
+
+  it('Given blank first name in update payload, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload({ firstName: '   ' });
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('prénom'),
+    });
+  });
+
+  it('Given blank last name in update payload, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload({ lastName: '   ' });
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('nom de famille'),
+    });
+  });
+
+  it('Given optional text fields in update payload, When validating, Then trims and normalizes values', () => {
+    const result = validateUpdateUserPayload({
+      role: 'trainer',
+      phone: '  0708091011  ',
+      preferredContactChannel: '  phone  ',
+      isActive: 0,
+    });
+
+    expect(result).toMatchObject({
+      valid: true,
+      data: {
+        role: 'trainer',
+        phone: '0708091011',
+        preferredContactChannel: 'phone',
+        isActive: false,
+      },
+    });
+  });
+
+  it('Given optional text fields as non-string values in update payload, When validating, Then stores null values', () => {
+    const result = validateUpdateUserPayload({
+      phone: 12345,
+      preferredContactChannel: true,
+    });
+
+    expect(result).toMatchObject({
+      valid: true,
+      data: {
+        phone: null,
+        preferredContactChannel: null,
+      },
+    });
   });
 });

--- a/apps/api/src/users/users.dto.spec.ts
+++ b/apps/api/src/users/users.dto.spec.ts
@@ -130,6 +130,21 @@ describe('validateCreateUserPayload', () => {
     });
   });
 
+  it('Given non-boolean isActive in create payload, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Martin',
+      role: 'participant',
+      isActive: 'false',
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('booléen'),
+    });
+  });
+
   it('Given missing first name, When validating, Then returns required error', () => {
     const result = validateCreateUserPayload({
       email: 'alice@example.com',
@@ -231,7 +246,7 @@ describe('validateUpdateUserPayload', () => {
       role: 'trainer',
       phone: '  0708091011  ',
       preferredContactChannel: '  phone  ',
-      isActive: 0,
+      isActive: false,
     });
 
     expect(result).toMatchObject({
@@ -242,6 +257,17 @@ describe('validateUpdateUserPayload', () => {
         preferredContactChannel: 'phone',
         isActive: false,
       },
+    });
+  });
+
+  it('Given non-boolean isActive in update payload, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload({
+      isActive: 0,
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('booléen'),
     });
   });
 

--- a/apps/api/src/users/users.dto.spec.ts
+++ b/apps/api/src/users/users.dto.spec.ts
@@ -1,0 +1,94 @@
+import {
+  validateCreateUserPayload,
+  validateUpdateUserPayload,
+} from './users.dto';
+
+describe('validateCreateUserPayload', () => {
+  it('Given a valid payload, When validating, Then returns valid with typed data', () => {
+    const result = validateCreateUserPayload({
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Martin',
+      role: 'participant',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result).toMatchObject({
+      valid: true,
+      data: expect.objectContaining({
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        role: 'participant',
+        isActive: true,
+      }),
+    });
+  });
+
+  it('Given a null body, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload(null);
+    expect(result.valid).toBe(false);
+  });
+
+  it('Given a missing email, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload({
+      firstName: 'Bob',
+      lastName: 'Dupont',
+      role: 'admin',
+    });
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('email'),
+    });
+  });
+
+  it('Given an invalid email format, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload({
+      email: 'not-an-email',
+      firstName: 'Bob',
+      lastName: 'Dupont',
+      role: 'admin',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('Given an unknown role, When validating, Then returns invalid', () => {
+    const result = validateCreateUserPayload({
+      email: 'bob@example.com',
+      firstName: 'Bob',
+      lastName: 'Dupont',
+      role: 'superuser',
+    });
+    expect(result).toMatchObject({
+      valid: false,
+      error: expect.stringContaining('rôle'),
+    });
+  });
+});
+
+describe('validateUpdateUserPayload', () => {
+  it('Given an empty object, When validating, Then returns valid with empty data', () => {
+    const result = validateUpdateUserPayload({});
+    expect(result).toMatchObject({ valid: true, data: {} });
+  });
+
+  it('Given a valid partial update, When validating, Then returns valid data', () => {
+    const result = validateUpdateUserPayload({
+      firstName: 'Claire',
+      isActive: false,
+    });
+    expect(result).toMatchObject({
+      valid: true,
+      data: expect.objectContaining({ firstName: 'Claire', isActive: false }),
+    });
+  });
+
+  it('Given an invalid role, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload({ role: 'owner' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('Given a non-object body, When validating, Then returns invalid', () => {
+    const result = validateUpdateUserPayload('not-an-object');
+    expect(result.valid).toBe(false);
+  });
+});

--- a/apps/api/src/users/users.dto.ts
+++ b/apps/api/src/users/users.dto.ts
@@ -101,6 +101,20 @@ function normalizeOptionalRole(
   return { valid: true, value };
 }
 
+function normalizeOptionalIsActive(
+  value: unknown,
+): { valid: true; value?: boolean } | { valid: false; error: string } {
+  if (value === undefined) {
+    return { valid: true };
+  }
+
+  if (typeof value !== 'boolean') {
+    return { valid: false, error: 'Le statut actif doit être un booléen' };
+  }
+
+  return { valid: true, value };
+}
+
 export function validateCreateUserPayload(
   body: unknown,
 ): { valid: true; data: CreateAppUserDto } | { valid: false; error: string } {
@@ -146,6 +160,11 @@ export function validateCreateUserPayload(
     };
   }
 
+  const isActiveValidation = normalizeOptionalIsActive(payload['isActive']);
+  if (!isActiveValidation.valid) {
+    return isActiveValidation;
+  }
+
   return {
     valid: true,
     data: {
@@ -157,7 +176,7 @@ export function validateCreateUserPayload(
       preferredContactChannel: normalizeOptionalText(
         payload['preferredContactChannel'],
       ),
-      isActive: payload['isActive'] !== false,
+      isActive: isActiveValidation.value ?? true,
     },
   };
 }
@@ -220,8 +239,12 @@ export function validateUpdateUserPayload(
     );
   }
 
-  if (payload['isActive'] !== undefined) {
-    data.isActive = Boolean(payload['isActive']);
+  const isActiveValidation = normalizeOptionalIsActive(payload['isActive']);
+  if (!isActiveValidation.valid) {
+    return isActiveValidation;
+  }
+  if (isActiveValidation.value !== undefined) {
+    data.isActive = isActiveValidation.value;
   }
 
   return { valid: true, data };

--- a/apps/api/src/users/users.dto.ts
+++ b/apps/api/src/users/users.dto.ts
@@ -2,6 +2,82 @@ import type { CreateAppUserDto, UpdateAppUserDto } from '@kraak/contracts';
 
 export type { CreateAppUserDto, UpdateAppUserDto };
 
+const ALLOWED_ROLES = ['participant', 'admin', 'trainer'] as const;
+type AllowedRole = (typeof ALLOWED_ROLES)[number];
+
+function isAllowedRole(value: unknown): value is AllowedRole {
+  return (
+    typeof value === 'string' && ALLOWED_ROLES.includes(value as AllowedRole)
+  );
+}
+
+function normalizeOptionalText(value: unknown): string | null {
+  return typeof value === 'string' ? value.trim() || null : null;
+}
+
+function normalizeOptionalEmail(
+  value: unknown,
+): { valid: true; value?: string } | { valid: false; error: string } {
+  if (value === undefined) {
+    return { valid: true };
+  }
+
+  if (typeof value !== 'string' || !value.trim()) {
+    return { valid: false, error: "L'adresse email est invalide" };
+  }
+
+  const normalized = value.trim();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(normalized)) {
+    return { valid: false, error: "L'adresse email n'est pas valide" };
+  }
+
+  return { valid: true, value: normalized };
+}
+
+function normalizeRequiredName(
+  value: unknown,
+  requiredError: string,
+): { valid: true; value: string } | { valid: false; error: string } {
+  if (typeof value !== 'string' || !value.trim()) {
+    return { valid: false, error: requiredError };
+  }
+
+  return { valid: true, value: value.trim() };
+}
+
+function normalizeOptionalName(
+  value: unknown,
+  invalidError: string,
+): { valid: true; value?: string } | { valid: false; error: string } {
+  if (value === undefined) {
+    return { valid: true };
+  }
+
+  if (typeof value !== 'string' || !value.trim()) {
+    return { valid: false, error: invalidError };
+  }
+
+  return { valid: true, value: value.trim() };
+}
+
+function normalizeOptionalRole(
+  value: unknown,
+): { valid: true; value?: AllowedRole } | { valid: false; error: string } {
+  if (value === undefined) {
+    return { valid: true };
+  }
+
+  if (!isAllowedRole(value)) {
+    return {
+      valid: false,
+      error: `Le rôle doit être l'un des suivants : ${ALLOWED_ROLES.join(', ')}`,
+    };
+  }
+
+  return { valid: true, value };
+}
+
 export function validateCreateUserPayload(
   body: unknown,
 ): { valid: true; data: CreateAppUserDto } | { valid: false; error: string } {
@@ -11,50 +87,53 @@ export function validateCreateUserPayload(
 
   const payload = body as Record<string, unknown>;
 
-  if (typeof payload['email'] !== 'string' || !payload['email'].trim()) {
-    return { valid: false, error: "L'adresse email est obligatoire" };
-  }
-
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(payload['email'])) {
-    return { valid: false, error: "L'adresse email n'est pas valide" };
-  }
-
-  if (
-    typeof payload['firstName'] !== 'string' ||
-    !payload['firstName'].trim()
-  ) {
-    return { valid: false, error: 'Le prénom est obligatoire' };
-  }
-
-  if (typeof payload['lastName'] !== 'string' || !payload['lastName'].trim()) {
-    return { valid: false, error: 'Le nom de famille est obligatoire' };
-  }
-
-  const allowedRoles = ['participant', 'admin', 'trainer'] as const;
-  const role = payload['role'];
-  if (!allowedRoles.includes(role as (typeof allowedRoles)[number])) {
+  const emailValidation = normalizeOptionalEmail(payload['email']);
+  if (!emailValidation.valid || !emailValidation.value) {
     return {
       valid: false,
-      error: `Le rôle doit être l'un des suivants : ${allowedRoles.join(', ')}`,
+      error: emailValidation.valid
+        ? "L'adresse email est obligatoire"
+        : emailValidation.error,
+    };
+  }
+
+  const firstNameValidation = normalizeRequiredName(
+    payload['firstName'],
+    'Le prénom est obligatoire',
+  );
+  if (!firstNameValidation.valid) {
+    return firstNameValidation;
+  }
+
+  const lastNameValidation = normalizeRequiredName(
+    payload['lastName'],
+    'Le nom de famille est obligatoire',
+  );
+  if (!lastNameValidation.valid) {
+    return lastNameValidation;
+  }
+
+  const roleValidation = normalizeOptionalRole(payload['role']);
+  if (!roleValidation.valid || !roleValidation.value) {
+    return {
+      valid: false,
+      error: roleValidation.valid
+        ? `Le rôle doit être l'un des suivants : ${ALLOWED_ROLES.join(', ')}`
+        : roleValidation.error,
     };
   }
 
   return {
     valid: true,
     data: {
-      email: (payload['email'] as string).trim(),
-      firstName: (payload['firstName'] as string).trim(),
-      lastName: (payload['lastName'] as string).trim(),
-      role: role as CreateAppUserDto['role'],
-      phone:
-        typeof payload['phone'] === 'string'
-          ? payload['phone'].trim() || null
-          : null,
-      preferredContactChannel:
-        typeof payload['preferredContactChannel'] === 'string'
-          ? payload['preferredContactChannel'].trim() || null
-          : null,
+      email: emailValidation.value,
+      firstName: firstNameValidation.value,
+      lastName: lastNameValidation.value,
+      role: roleValidation.value,
+      phone: normalizeOptionalText(payload['phone']),
+      preferredContactChannel: normalizeOptionalText(
+        payload['preferredContactChannel'],
+      ),
       isActive: payload['isActive'] !== false,
     },
   };
@@ -70,62 +149,52 @@ export function validateUpdateUserPayload(
   const payload = body as Record<string, unknown>;
   const data: UpdateAppUserDto = {};
 
-  if (payload['email'] !== undefined) {
-    if (typeof payload['email'] !== 'string' || !payload['email'].trim()) {
-      return { valid: false, error: "L'adresse email est invalide" };
-    }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(payload['email'])) {
-      return { valid: false, error: "L'adresse email n'est pas valide" };
-    }
-    data.email = payload['email'].trim();
+  const emailValidation = normalizeOptionalEmail(payload['email']);
+  if (!emailValidation.valid) {
+    return emailValidation;
+  }
+  if (emailValidation.value !== undefined) {
+    data.email = emailValidation.value;
   }
 
-  if (payload['firstName'] !== undefined) {
-    if (
-      typeof payload['firstName'] !== 'string' ||
-      !payload['firstName'].trim()
-    ) {
-      return { valid: false, error: 'Le prénom est invalide' };
-    }
-    data.firstName = payload['firstName'].trim();
+  const firstNameValidation = normalizeOptionalName(
+    payload['firstName'],
+    'Le prénom est invalide',
+  );
+  if (!firstNameValidation.valid) {
+    return firstNameValidation;
+  }
+  if (firstNameValidation.value !== undefined) {
+    data.firstName = firstNameValidation.value;
   }
 
-  if (payload['lastName'] !== undefined) {
-    if (
-      typeof payload['lastName'] !== 'string' ||
-      !payload['lastName'].trim()
-    ) {
-      return { valid: false, error: 'Le nom de famille est invalide' };
-    }
-    data.lastName = payload['lastName'].trim();
+  const lastNameValidation = normalizeOptionalName(
+    payload['lastName'],
+    'Le nom de famille est invalide',
+  );
+  if (!lastNameValidation.valid) {
+    return lastNameValidation;
+  }
+  if (lastNameValidation.value !== undefined) {
+    data.lastName = lastNameValidation.value;
   }
 
-  if (payload['role'] !== undefined) {
-    const allowedRoles = ['participant', 'admin', 'trainer'] as const;
-    if (
-      !allowedRoles.includes(payload['role'] as (typeof allowedRoles)[number])
-    ) {
-      return {
-        valid: false,
-        error: `Le rôle doit être l'un des suivants : ${allowedRoles.join(', ')}`,
-      };
-    }
-    data.role = payload['role'] as UpdateAppUserDto['role'];
+  const roleValidation = normalizeOptionalRole(payload['role']);
+  if (!roleValidation.valid) {
+    return roleValidation;
+  }
+  if (roleValidation.value !== undefined) {
+    data.role = roleValidation.value;
   }
 
   if (payload['phone'] !== undefined) {
-    data.phone =
-      typeof payload['phone'] === 'string'
-        ? payload['phone'].trim() || null
-        : null;
+    data.phone = normalizeOptionalText(payload['phone']);
   }
 
   if (payload['preferredContactChannel'] !== undefined) {
-    data.preferredContactChannel =
-      typeof payload['preferredContactChannel'] === 'string'
-        ? payload['preferredContactChannel'].trim() || null
-        : null;
+    data.preferredContactChannel = normalizeOptionalText(
+      payload['preferredContactChannel'],
+    );
   }
 
   if (payload['isActive'] !== undefined) {

--- a/apps/api/src/users/users.dto.ts
+++ b/apps/api/src/users/users.dto.ts
@@ -15,6 +15,30 @@ function normalizeOptionalText(value: unknown): string | null {
   return typeof value === 'string' ? value.trim() || null : null;
 }
 
+function isLikelyEmail(value: string): boolean {
+  if (value.includes(' ')) {
+    return false;
+  }
+
+  const atIndex = value.indexOf('@');
+  if (atIndex <= 0 || atIndex !== value.lastIndexOf('@')) {
+    return false;
+  }
+
+  const localPart = value.slice(0, atIndex);
+  const domainPart = value.slice(atIndex + 1);
+  if (!localPart || !domainPart) {
+    return false;
+  }
+
+  const dotIndex = domainPart.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === domainPart.length - 1) {
+    return false;
+  }
+
+  return true;
+}
+
 function normalizeOptionalEmail(
   value: unknown,
 ): { valid: true; value?: string } | { valid: false; error: string } {
@@ -27,8 +51,7 @@ function normalizeOptionalEmail(
   }
 
   const normalized = value.trim();
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(normalized)) {
+  if (!isLikelyEmail(normalized)) {
     return { valid: false, error: "L'adresse email n'est pas valide" };
   }
 

--- a/apps/api/src/users/users.dto.ts
+++ b/apps/api/src/users/users.dto.ts
@@ -1,0 +1,136 @@
+import type { CreateAppUserDto, UpdateAppUserDto } from '@kraak/contracts';
+
+export type { CreateAppUserDto, UpdateAppUserDto };
+
+export function validateCreateUserPayload(
+  body: unknown,
+): { valid: true; data: CreateAppUserDto } | { valid: false; error: string } {
+  if (!body || typeof body !== 'object') {
+    return { valid: false, error: 'Corps de requête manquant ou invalide' };
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  if (typeof payload['email'] !== 'string' || !payload['email'].trim()) {
+    return { valid: false, error: "L'adresse email est obligatoire" };
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(payload['email'])) {
+    return { valid: false, error: "L'adresse email n'est pas valide" };
+  }
+
+  if (
+    typeof payload['firstName'] !== 'string' ||
+    !payload['firstName'].trim()
+  ) {
+    return { valid: false, error: 'Le prénom est obligatoire' };
+  }
+
+  if (typeof payload['lastName'] !== 'string' || !payload['lastName'].trim()) {
+    return { valid: false, error: 'Le nom de famille est obligatoire' };
+  }
+
+  const allowedRoles = ['participant', 'admin', 'trainer'] as const;
+  const role = payload['role'];
+  if (!allowedRoles.includes(role as (typeof allowedRoles)[number])) {
+    return {
+      valid: false,
+      error: `Le rôle doit être l'un des suivants : ${allowedRoles.join(', ')}`,
+    };
+  }
+
+  return {
+    valid: true,
+    data: {
+      email: (payload['email'] as string).trim(),
+      firstName: (payload['firstName'] as string).trim(),
+      lastName: (payload['lastName'] as string).trim(),
+      role: role as CreateAppUserDto['role'],
+      phone:
+        typeof payload['phone'] === 'string'
+          ? payload['phone'].trim() || null
+          : null,
+      preferredContactChannel:
+        typeof payload['preferredContactChannel'] === 'string'
+          ? payload['preferredContactChannel'].trim() || null
+          : null,
+      isActive: payload['isActive'] !== false,
+    },
+  };
+}
+
+export function validateUpdateUserPayload(
+  body: unknown,
+): { valid: true; data: UpdateAppUserDto } | { valid: false; error: string } {
+  if (!body || typeof body !== 'object') {
+    return { valid: false, error: 'Corps de requête manquant ou invalide' };
+  }
+
+  const payload = body as Record<string, unknown>;
+  const data: UpdateAppUserDto = {};
+
+  if (payload['email'] !== undefined) {
+    if (typeof payload['email'] !== 'string' || !payload['email'].trim()) {
+      return { valid: false, error: "L'adresse email est invalide" };
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(payload['email'])) {
+      return { valid: false, error: "L'adresse email n'est pas valide" };
+    }
+    data.email = payload['email'].trim();
+  }
+
+  if (payload['firstName'] !== undefined) {
+    if (
+      typeof payload['firstName'] !== 'string' ||
+      !payload['firstName'].trim()
+    ) {
+      return { valid: false, error: 'Le prénom est invalide' };
+    }
+    data.firstName = payload['firstName'].trim();
+  }
+
+  if (payload['lastName'] !== undefined) {
+    if (
+      typeof payload['lastName'] !== 'string' ||
+      !payload['lastName'].trim()
+    ) {
+      return { valid: false, error: 'Le nom de famille est invalide' };
+    }
+    data.lastName = payload['lastName'].trim();
+  }
+
+  if (payload['role'] !== undefined) {
+    const allowedRoles = ['participant', 'admin', 'trainer'] as const;
+    if (
+      !allowedRoles.includes(payload['role'] as (typeof allowedRoles)[number])
+    ) {
+      return {
+        valid: false,
+        error: `Le rôle doit être l'un des suivants : ${allowedRoles.join(', ')}`,
+      };
+    }
+    data.role = payload['role'] as UpdateAppUserDto['role'];
+  }
+
+  if (payload['phone'] !== undefined) {
+    data.phone =
+      typeof payload['phone'] === 'string'
+        ? payload['phone'].trim() || null
+        : null;
+  }
+
+  if (payload['preferredContactChannel'] !== undefined) {
+    data.preferredContactChannel =
+      typeof payload['preferredContactChannel'] === 'string'
+        ? payload['preferredContactChannel'].trim() || null
+        : null;
+  }
+
+  if (payload['isActive'] !== undefined) {
+    data.isActive = Boolean(payload['isActive']);
+  }
+
+  return { valid: true, data };
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+
+@Module({
+  imports: [AuthModule, SupabaseModule],
+  providers: [UsersService],
+  controllers: [UsersController],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -61,6 +61,7 @@ describe('UsersService', () => {
 
       const result = await service.findAll();
 
+      expect(mockClient.from).toHaveBeenCalledWith('app_user');
       expect(result).toHaveLength(1);
       expect(result[0].email).toBe('alice@example.com');
       expect(result[0].firstName).toBe('Alice');
@@ -91,11 +92,22 @@ describe('UsersService', () => {
     it('Given an unknown user ID, When findOne is called, Then throws NotFoundException', async () => {
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { message: 'Not found' },
+        error: { code: 'PGRST116', message: 'Not found' },
       });
 
       await expect(service.findOne('unknown-id')).rejects.toThrow(
         NotFoundException,
+      );
+    });
+
+    it('Given a non-not-found Supabase error, When findOne is called, Then throws InternalServerErrorException', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { code: 'PGRST001', message: 'Unexpected' },
+      });
+
+      await expect(service.findOne('user-1')).rejects.toThrow(
+        InternalServerErrorException,
       );
     });
   });
@@ -145,6 +157,52 @@ describe('UsersService', () => {
       await expect(service.remove('unknown-id')).rejects.toThrow(
         NotFoundException,
       );
+    });
+
+    describe('invite', () => {
+      it('Given valid payload, When invite is called, Then creates invited user profile and returns DTO', async () => {
+        mockInviteUser.mockResolvedValueOnce({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        });
+        mockSingle.mockResolvedValueOnce({ data: mockUserRow, error: null });
+
+        const result = await service.invite({
+          email: 'alice@example.com',
+          firstName: 'Alice',
+          lastName: 'Martin',
+          role: 'participant',
+          isActive: true,
+        });
+
+        expect(mockClient.from).toHaveBeenCalledWith('app_user');
+        expect(mockInviteUser).toHaveBeenCalledWith('alice@example.com', {
+          data: {
+            first_name: 'Alice',
+            last_name: 'Martin',
+            role: 'participant',
+          },
+        });
+        expect(result.id).toBe('user-1');
+        expect(result.email).toBe('alice@example.com');
+      });
+
+      it('Given an auth invite error, When invite is called, Then throws InternalServerErrorException', async () => {
+        mockInviteUser.mockResolvedValueOnce({
+          data: null,
+          error: { message: 'Auth error' },
+        });
+
+        await expect(
+          service.invite({
+            email: 'alice@example.com',
+            firstName: 'Alice',
+            lastName: 'Martin',
+            role: 'participant',
+            isActive: true,
+          }),
+        ).rejects.toThrow(InternalServerErrorException);
+      });
     });
   });
 });

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,0 +1,150 @@
+import {
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { UsersService } from './users.service';
+
+const mockSelect = jest.fn();
+const mockOrder = jest.fn();
+const mockEq = jest.fn();
+const mockSingle = jest.fn();
+const mockUpdate = jest.fn();
+const mockDelete = jest.fn();
+const mockUpsert = jest.fn();
+const mockInviteUser = jest.fn();
+
+const mockClient = {
+  from: jest.fn(() => ({
+    select: mockSelect.mockReturnThis(),
+    order: mockOrder.mockReturnThis(),
+    eq: mockEq.mockReturnThis(),
+    single: mockSingle,
+    update: mockUpdate.mockReturnThis(),
+    delete: mockDelete.mockReturnThis(),
+    upsert: mockUpsert.mockReturnThis(),
+  })),
+  auth: {
+    admin: {
+      inviteUserByEmail: mockInviteUser,
+    },
+  },
+};
+
+const mockSupabaseService = {
+  getClient: jest.fn(() => mockClient),
+};
+
+const mockUserRow = {
+  id: 'user-1',
+  email: 'alice@example.com',
+  role: 'participant',
+  first_name: 'Alice',
+  last_name: 'Martin',
+  phone: null,
+  preferred_contact_channel: null,
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UsersService(mockSupabaseService as never);
+  });
+
+  describe('findAll', () => {
+    it('Given users in database, When findAll is called, Then returns mapped DTOs', async () => {
+      mockOrder.mockResolvedValueOnce({ data: [mockUserRow], error: null });
+
+      const result = await service.findAll();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].email).toBe('alice@example.com');
+      expect(result[0].firstName).toBe('Alice');
+    });
+
+    it('Given a Supabase error, When findAll is called, Then throws InternalServerErrorException', async () => {
+      mockOrder.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'DB error' },
+      });
+
+      await expect(service.findAll()).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('Given an existing user ID, When findOne is called, Then returns the user DTO', async () => {
+      mockSingle.mockResolvedValueOnce({ data: mockUserRow, error: null });
+
+      const result = await service.findOne('user-1');
+
+      expect(result.id).toBe('user-1');
+      expect(result.lastName).toBe('Martin');
+    });
+
+    it('Given an unknown user ID, When findOne is called, Then throws NotFoundException', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'Not found' },
+      });
+
+      await expect(service.findOne('unknown-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('Given valid update data, When update is called, Then returns updated DTO', async () => {
+      const updatedRow = {
+        ...mockUserRow,
+        first_name: 'Alicia',
+        updated_at: '2024-06-01T00:00:00Z',
+      };
+      mockSingle.mockResolvedValueOnce({ data: updatedRow, error: null });
+
+      const result = await service.update('user-1', { firstName: 'Alicia' });
+
+      expect(result.firstName).toBe('Alicia');
+    });
+
+    it('Given a Supabase error on update, When update is called, Then throws InternalServerErrorException', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'DB error' },
+      });
+
+      await expect(
+        service.update('user-1', { firstName: 'X' }),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('remove', () => {
+    it('Given an existing user, When remove is called, Then deletes without error', async () => {
+      mockSingle.mockResolvedValueOnce({ data: { id: 'user-1' }, error: null });
+      mockDelete.mockReturnValue({
+        eq: jest.fn().mockResolvedValueOnce({ error: null }),
+      });
+
+      await expect(service.remove('user-1')).resolves.not.toThrow();
+    });
+
+    it('Given an unknown user, When remove is called, Then throws NotFoundException', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'Not found' },
+      });
+
+      await expect(service.remove('unknown-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -24,6 +24,9 @@ type AppUserRow = {
   updated_at: string;
 };
 
+const APP_USER_TABLE = 'app_user';
+const notFoundSupabaseErrorCodes = new Set(['PGRST116']);
+
 function mapRowToDto(row: AppUserRow): AppUserDto {
   return {
     id: row.id,
@@ -45,10 +48,23 @@ export class UsersService {
 
   constructor(private readonly supabaseService: SupabaseService) {}
 
+  private readSupabaseErrorCode(error: unknown): string | null {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      typeof error.code === 'string'
+    ) {
+      return error.code;
+    }
+
+    return null;
+  }
+
   async findAll(): Promise<AppUserDto[]> {
     const client = this.supabaseService.getClient();
     const { data, error } = await client
-      .from('app_users')
+      .from(APP_USER_TABLE)
       .select(
         'id, email, role, first_name, last_name, phone, preferred_contact_channel, is_active, created_at, updated_at',
       )
@@ -70,14 +86,29 @@ export class UsersService {
   async findOne(id: string): Promise<AppUserDto> {
     const client = this.supabaseService.getClient();
     const { data, error } = await client
-      .from('app_users')
+      .from(APP_USER_TABLE)
       .select(
         'id, email, role, first_name, last_name, phone, preferred_contact_channel, is_active, created_at, updated_at',
       )
       .eq('id', id)
       .single();
 
-    if (error || !data) {
+    if (
+      error &&
+      notFoundSupabaseErrorCodes.has(this.readSupabaseErrorCode(error) ?? '')
+    ) {
+      throw new NotFoundException(`Utilisateur introuvable : ${id}`);
+    }
+    if (error) {
+      this.logger.error(
+        `Erreur lors de la récupération de l'utilisateur ${id}`,
+        error,
+      );
+      throw new InternalServerErrorException(
+        "Impossible de récupérer l'utilisateur",
+      );
+    }
+    if (!data) {
       throw new NotFoundException(`Utilisateur introuvable : ${id}`);
     }
 
@@ -100,7 +131,7 @@ export class UsersService {
     updateData['updated_at'] = new Date().toISOString();
 
     const { data, error } = await client
-      .from('app_users')
+      .from(APP_USER_TABLE)
       .update(updateData)
       .eq('id', id)
       .select(
@@ -125,7 +156,7 @@ export class UsersService {
     const client = this.supabaseService.getClient();
 
     const existing = await client
-      .from('app_users')
+      .from(APP_USER_TABLE)
       .select('id')
       .eq('id', id)
       .single();
@@ -134,7 +165,7 @@ export class UsersService {
       throw new NotFoundException(`Utilisateur introuvable : ${id}`);
     }
 
-    const { error } = await client.from('app_users').delete().eq('id', id);
+    const { error } = await client.from(APP_USER_TABLE).delete().eq('id', id);
 
     if (error) {
       this.logger.error(
@@ -172,7 +203,7 @@ export class UsersService {
     const userId = authData.user.id;
 
     const upsertResult = await client
-      .from('app_users')
+      .from(APP_USER_TABLE)
       .upsert(
         {
           id: userId,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,208 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import type {
+  AppUserDto,
+  CreateAppUserDto,
+  UpdateAppUserDto,
+} from '@kraak/contracts';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type AppUserRow = {
+  id: string;
+  email: string;
+  role: AppUserDto['role'];
+  first_name: string;
+  last_name: string;
+  phone: string | null;
+  preferred_contact_channel: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+function mapRowToDto(row: AppUserRow): AppUserDto {
+  return {
+    id: row.id,
+    email: row.email,
+    role: row.role,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    phone: row.phone,
+    preferredContactChannel: row.preferred_contact_channel,
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+@Injectable()
+export class UsersService {
+  private readonly logger = new Logger(UsersService.name);
+
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async findAll(): Promise<AppUserDto[]> {
+    const client = this.supabaseService.getClient();
+    const { data, error } = await client
+      .from('app_users')
+      .select(
+        'id, email, role, first_name, last_name, phone, preferred_contact_channel, is_active, created_at, updated_at',
+      )
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      this.logger.error(
+        'Erreur lors de la récupération des utilisateurs',
+        error,
+      );
+      throw new InternalServerErrorException(
+        'Impossible de récupérer la liste des utilisateurs',
+      );
+    }
+
+    return (data as AppUserRow[]).map(mapRowToDto);
+  }
+
+  async findOne(id: string): Promise<AppUserDto> {
+    const client = this.supabaseService.getClient();
+    const { data, error } = await client
+      .from('app_users')
+      .select(
+        'id, email, role, first_name, last_name, phone, preferred_contact_channel, is_active, created_at, updated_at',
+      )
+      .eq('id', id)
+      .single();
+
+    if (error || !data) {
+      throw new NotFoundException(`Utilisateur introuvable : ${id}`);
+    }
+
+    return mapRowToDto(data as AppUserRow);
+  }
+
+  async update(id: string, dto: UpdateAppUserDto): Promise<AppUserDto> {
+    const client = this.supabaseService.getClient();
+
+    const updateData: Record<string, unknown> = {};
+    if (dto.email !== undefined) updateData['email'] = dto.email;
+    if (dto.firstName !== undefined) updateData['first_name'] = dto.firstName;
+    if (dto.lastName !== undefined) updateData['last_name'] = dto.lastName;
+    if (dto.role !== undefined) updateData['role'] = dto.role;
+    if (dto.phone !== undefined) updateData['phone'] = dto.phone;
+    if (dto.preferredContactChannel !== undefined)
+      updateData['preferred_contact_channel'] = dto.preferredContactChannel;
+    if (dto.isActive !== undefined) updateData['is_active'] = dto.isActive;
+
+    updateData['updated_at'] = new Date().toISOString();
+
+    const { data, error } = await client
+      .from('app_users')
+      .update(updateData)
+      .eq('id', id)
+      .select(
+        'id, email, role, first_name, last_name, phone, preferred_contact_channel, is_active, created_at, updated_at',
+      )
+      .single();
+
+    if (error || !data) {
+      this.logger.error(
+        `Erreur lors de la mise à jour de l'utilisateur ${id}`,
+        error,
+      );
+      throw new InternalServerErrorException(
+        "Impossible de mettre à jour l'utilisateur",
+      );
+    }
+
+    return mapRowToDto(data as AppUserRow);
+  }
+
+  async remove(id: string): Promise<void> {
+    const client = this.supabaseService.getClient();
+
+    const existing = await client
+      .from('app_users')
+      .select('id')
+      .eq('id', id)
+      .single();
+
+    if (existing.error || !existing.data) {
+      throw new NotFoundException(`Utilisateur introuvable : ${id}`);
+    }
+
+    const { error } = await client.from('app_users').delete().eq('id', id);
+
+    if (error) {
+      this.logger.error(
+        `Erreur lors de la suppression de l'utilisateur ${id}`,
+        error,
+      );
+      throw new InternalServerErrorException(
+        "Impossible de supprimer l'utilisateur",
+      );
+    }
+  }
+
+  async invite(dto: CreateAppUserDto): Promise<AppUserDto> {
+    const client = this.supabaseService.getClient();
+
+    const { data: authData, error: authError } =
+      await client.auth.admin.inviteUserByEmail(dto.email, {
+        data: {
+          first_name: dto.firstName,
+          last_name: dto.lastName,
+          role: dto.role,
+        },
+      });
+
+    if (authError || !authData?.user) {
+      this.logger.error(
+        "Erreur lors de l'invitation de l'utilisateur",
+        authError,
+      );
+      throw new InternalServerErrorException(
+        "Impossible d'envoyer l'invitation",
+      );
+    }
+
+    const userId = authData.user.id;
+
+    const upsertResult = await client
+      .from('app_users')
+      .upsert(
+        {
+          id: userId,
+          email: dto.email,
+          role: dto.role,
+          first_name: dto.firstName,
+          last_name: dto.lastName,
+          phone: dto.phone ?? null,
+          preferred_contact_channel: dto.preferredContactChannel ?? null,
+          is_active: dto.isActive ?? true,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'id' },
+      )
+      .select(
+        'id, email, role, first_name, last_name, phone, preferred_contact_channel, is_active, created_at, updated_at',
+      )
+      .single();
+
+    if (upsertResult.error || !upsertResult.data) {
+      this.logger.error(
+        'Erreur lors de la création du profil utilisateur',
+        upsertResult.error,
+      );
+      throw new InternalServerErrorException(
+        'Impossible de créer le profil utilisateur',
+      );
+    }
+
+    return mapRowToDto(upsertResult.data as AppUserRow);
+  }
+}

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env['CI'],
   retries: process.env['CI'] ? 2 : 1,
-  workers: process.env['CI'] ? 1 : undefined,
+  workers: process.env['CI'] ? 1 : 3,
   timeout: 60_000,
   reporter: process.env['CI']
     ? 'github'

--- a/apps/client/projects/web/src/app/admin-area.routes.ts
+++ b/apps/client/projects/web/src/app/admin-area.routes.ts
@@ -30,6 +30,12 @@ export const adminAreaRoutes: Routes = [
           import('./features/admin/ressources/admin-ressources.page'),
       },
       {
+        path: 'utilisateurs',
+        title: 'Utilisateurs — Admin | KRAAK Consulting',
+        loadChildren: () =>
+          import('./features/admin/utilisateurs/utilisateurs.routes'),
+      },
+      {
         path: '',
         redirectTo: 'dashboard',
         pathMatch: 'full',

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.html
@@ -1,0 +1,121 @@
+<section
+  class="bg-brand-white border-b border-neutral-200 px-4 py-10 sm:px-6 lg:px-8"
+>
+  <div
+    class="mx-auto flex max-w-7xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+  >
+    <div>
+      <p
+        class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+      >
+        Administration
+      </p>
+      <h1 class="text-brand-navy text-2xl font-bold">Nouvel utilisateur</h1>
+      <p class="mt-1 text-sm text-neutral-600">
+        Invitez un nouveau membre à rejoindre la plateforme KRAAK.
+      </p>
+    </div>
+    <button pButton class="kr-button-ghost" type="button" (click)="cancel()">
+      <i class="pi pi-arrow-left mr-2"></i>
+      Retour à la liste
+    </button>
+  </div>
+</section>
+
+<section class="min-h-screen bg-neutral-50 py-12">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    @if (errorMessage()) {
+      <p-message
+        severity="error"
+        [text]="errorMessage()!"
+        styleClass="mb-6 w-full"
+      />
+    }
+
+    <div class="flex flex-col gap-6 lg:flex-row">
+      <!-- Navigation desktop (sidebar) -->
+      <aside class="hidden w-64 shrink-0 lg:block">
+        <nav
+          class="bg-brand-white rounded-card shadow-card flex flex-col gap-1 p-4"
+          aria-label="Étapes de création"
+        >
+          @for (step of steps; track step.path; let i = $index) {
+            <a
+              [routerLink]="getStepRouterLink(step)"
+              class="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition-colors"
+              routerLinkActive="bg-brand-blue text-white shadow-sm"
+              [routerLinkActiveOptions]="{ exact: false }"
+              [class.text-neutral-600]="!router.url.includes(step.path)"
+              [class.hover:bg-neutral-100]="!router.url.includes(step.path)"
+              [attr.aria-current]="
+                router.url.includes(step.path) ? 'step' : null
+              "
+            >
+              <i [class]="'pi ' + step.icon + ' text-base'"></i>
+              <span>{{ step.label }}</span>
+            </a>
+          }
+        </nav>
+      </aside>
+
+      <!-- Navigation mobile (onglets défilants) -->
+      <div class="-mx-4 overflow-x-auto px-4 pb-2 lg:hidden">
+        <nav class="flex min-w-max gap-1" aria-label="Étapes de création">
+          @for (step of steps; track step.path; let i = $index) {
+            <a
+              [routerLink]="getStepRouterLink(step)"
+              class="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors"
+              routerLinkActive="bg-brand-blue text-white shadow-sm"
+              [routerLinkActiveOptions]="{ exact: false }"
+              [class.text-neutral-600]="!router.url.includes(step.path)"
+              [class.hover:bg-neutral-100]="!router.url.includes(step.path)"
+              [attr.aria-current]="
+                router.url.includes(step.path) ? 'step' : null
+              "
+            >
+              <i [class]="'pi ' + step.icon"></i>
+              {{ step.label }}
+            </a>
+          }
+        </nav>
+      </div>
+
+      <!-- Contenu de l'étape courante -->
+      <div class="min-w-0 flex-1">
+        <div class="bg-brand-white rounded-card shadow-card overflow-hidden">
+          <router-outlet />
+        </div>
+
+        <!-- Actions globales -->
+        <div class="mt-6 flex flex-wrap items-center justify-between gap-4">
+          <button
+            pButton
+            class="kr-button-ghost"
+            type="button"
+            (click)="cancel()"
+            [disabled]="submitting()"
+          >
+            Annuler
+          </button>
+
+          <button
+            pButton
+            class="kr-button-primary"
+            type="button"
+            (click)="handleSubmit()"
+            [disabled]="
+              submitting() ||
+              !formState.isStep1Valid() ||
+              !formState.isStep2Valid()
+            "
+          >
+            @if (submitting()) {
+              <i class="pi pi-spin pi-spinner mr-2"></i>
+            }
+            Envoyer l'invitation
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.spec.ts
@@ -40,4 +40,21 @@ describe('AdminUserCreateLayoutPage', () => {
 
     expect(comp['errorMessage']()).toBeTruthy();
   });
+
+  it('Given invitation disabled, When submit is attempted, Then blocks submission with explicit message', async () => {
+    const formState = TestBed.inject(UserFormStateService);
+    formState.patch({
+      firstName: 'Alice',
+      lastName: 'Martin',
+      email: 'alice@example.com',
+      role: 'participant',
+      sendInvitation: false,
+    });
+    const fixture = TestBed.createComponent(AdminUserCreateLayoutPage);
+    const comp = fixture.componentInstance;
+
+    await comp.handleSubmit();
+
+    expect(comp['errorMessage']()).toContain('obligatoire');
+  });
 });

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MessageService } from 'primeng/api';
+import AdminUserCreateLayoutPage from './admin-user-create-layout.page';
+import { UserFormStateService } from './user-form-state.service';
+
+describe('AdminUserCreateLayoutPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminUserCreateLayoutPage, RouterTestingModule],
+      providers: [MessageService, UserFormStateService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(AdminUserCreateLayoutPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given the wizard steps, When steps are accessed, Then 5 steps are returned', () => {
+    const fixture = TestBed.createComponent(AdminUserCreateLayoutPage);
+    expect(fixture.componentInstance.steps).toHaveLength(5);
+  });
+
+  it('Given a step with path "basic-information", When getStepRouterLink is called, Then returns correct admin URL', () => {
+    const fixture = TestBed.createComponent(AdminUserCreateLayoutPage);
+    const link = fixture.componentInstance.getStepRouterLink({
+      label: 'Test',
+      icon: 'pi-user',
+      path: 'basic-information',
+    });
+    expect(link).toBe('/admin/utilisateurs/create/basic-information');
+  });
+
+  it('Given incomplete form state, When submit is attempted, Then sets error message', async () => {
+    const fixture = TestBed.createComponent(AdminUserCreateLayoutPage);
+    const comp = fixture.componentInstance;
+
+    await comp.handleSubmit();
+
+    expect(comp['errorMessage']()).toBeTruthy();
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.ts
@@ -93,6 +93,12 @@ export default class AdminUserCreateLayoutPage {
       );
       return;
     }
+    if (!state.sendInvitation) {
+      this.errorMessage.set(
+        "L'option d'envoi de l'invitation est obligatoire pour créer un utilisateur.",
+      );
+      return;
+    }
 
     const payload: CreateAppUserDto = {
       email: state.email,
@@ -110,6 +116,7 @@ export default class AdminUserCreateLayoutPage {
       await this.usersClient.create(payload);
       this.formState.reset();
       this.messageService.add({
+        key: 'app-feedback',
         severity: 'success',
         summary: 'Invitation envoyée',
         detail: `L'invitation a été envoyée à ${payload.email}.`,

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.ts
@@ -69,7 +69,7 @@ export default class AdminUserCreateLayoutPage {
   protected readonly currentStepIndex = computed(() => {
     const url = this.router.url;
     const idx = WIZARD_STEPS.findIndex((s) => url.includes(s.path));
-    return idx >= 0 ? idx : 0;
+    return Math.max(idx, 0);
   });
 
   getStepRouterLink(step: WizardStep): string {

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-create-layout.page.ts
@@ -1,0 +1,135 @@
+import { Component, inject, signal, computed } from '@angular/core';
+import {
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+import { MessageService } from 'primeng/api';
+import { Message } from 'primeng/message';
+import { createApiClient } from '@kraak/api-client';
+import type { CreateAppUserDto } from '@kraak/contracts';
+
+import { environment } from '../../../../environments/environment';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import { UserFormStateService } from './user-form-state.service';
+
+interface WizardStep {
+  label: string;
+  icon: string;
+  path: string;
+}
+
+const WIZARD_STEPS: WizardStep[] = [
+  { label: 'Informations de base', icon: 'pi-user', path: 'basic-information' },
+  {
+    label: 'Informations pro',
+    icon: 'pi-briefcase',
+    path: 'business-information',
+  },
+  {
+    label: 'Localisation',
+    icon: 'pi-map-marker',
+    path: 'location-information',
+  },
+  { label: 'Autorisations', icon: 'pi-key', path: 'authorization' },
+  { label: 'Statut du compte', icon: 'pi-shield', path: 'account-status' },
+];
+
+@Component({
+  selector: 'kraak-admin-user-create-layout-page',
+  standalone: true,
+  imports: [
+    RouterLink,
+    RouterLinkActive,
+    RouterOutlet,
+    ButtonDirective,
+    Message,
+  ],
+  templateUrl: './admin-user-create-layout.page.html',
+})
+export default class AdminUserCreateLayoutPage {
+  protected readonly router = inject(Router);
+  private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
+  readonly formState = inject(UserFormStateService);
+
+  private readonly usersClient = createApiClient({
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).users;
+
+  readonly steps = WIZARD_STEPS;
+
+  protected readonly submitting = signal(false);
+  protected readonly errorMessage = signal<string | null>(null);
+
+  protected readonly currentStepIndex = computed(() => {
+    const url = this.router.url;
+    const idx = WIZARD_STEPS.findIndex((s) => url.includes(s.path));
+    return idx >= 0 ? idx : 0;
+  });
+
+  getStepRouterLink(step: WizardStep): string {
+    return `/admin/utilisateurs/create/${step.path}`;
+  }
+
+  getStepButtonClass(step: WizardStep): string {
+    const isActive = this.router.url.includes(step.path);
+    if (isActive) {
+      return 'flex items-center gap-3 w-full rounded-lg px-4 py-3 text-sm font-medium bg-brand-blue text-white shadow-sm transition-colors';
+    }
+    return 'flex items-center gap-3 w-full rounded-lg px-4 py-3 text-sm font-medium text-neutral-600 hover:bg-neutral-100 transition-colors';
+  }
+
+  async handleSubmit(): Promise<void> {
+    const state = this.formState.state();
+
+    if (!this.formState.isStep1Valid() || !this.formState.isStep2Valid()) {
+      this.errorMessage.set(
+        'Veuillez compléter toutes les étapes obligatoires avant de soumettre.',
+      );
+      return;
+    }
+
+    const payload: CreateAppUserDto = {
+      email: state.email,
+      firstName: state.firstName,
+      lastName: state.lastName,
+      role: state.role as CreateAppUserDto['role'],
+      phone: state.phone || null,
+      preferredContactChannel: state.preferredContactChannel || null,
+      isActive: state.isActive,
+    };
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    try {
+      await this.usersClient.create(payload);
+      this.formState.reset();
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Invitation envoyée',
+        detail: `L'invitation a été envoyée à ${payload.email}.`,
+      });
+      await this.router.navigate(['/admin/utilisateurs/list']);
+    } catch (err) {
+      console.error(
+        "[AdminUserCreateLayoutPage] Erreur lors de l'invitation",
+        err,
+      );
+      this.errorMessage.set(
+        "Impossible d'envoyer l'invitation. Vérifiez les données et réessayez.",
+      );
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  cancel(): void {
+    this.formState.reset();
+    void this.router.navigate(['/admin/utilisateurs/list']);
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.html
@@ -1,0 +1,384 @@
+<section
+  class="bg-brand-white border-b border-neutral-200 px-4 py-10 sm:px-6 lg:px-8"
+>
+  <div
+    class="mx-auto flex max-w-7xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+  >
+    <div>
+      <p
+        class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+      >
+        Administration
+      </p>
+      <h1 class="text-brand-navy text-2xl font-bold">Utilisateurs</h1>
+      <p class="mt-1 text-sm text-neutral-600">
+        Gérez les comptes et les rôles des membres de la plateforme.
+      </p>
+    </div>
+    <a
+      routerLink="/admin/utilisateurs/create/basic-information"
+      pButton
+      class="kr-button-primary"
+      type="button"
+    >
+      <i class="pi pi-user-plus mr-2"></i>
+      Nouvel utilisateur
+    </a>
+  </div>
+</section>
+
+<section class="min-h-screen bg-neutral-50 py-12">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    @if (successMessage()) {
+      <p-message
+        severity="success"
+        [text]="successMessage()!"
+        styleClass="mb-6 w-full"
+      />
+    }
+
+    @if (errorMessage()) {
+      <p-message
+        severity="error"
+        [text]="errorMessage()!"
+        styleClass="mb-6 w-full"
+      />
+    }
+
+    <!-- Barre de recherche -->
+    <div
+      class="bg-brand-white rounded-card shadow-card mb-6 flex items-center gap-3 p-4"
+    >
+      <i class="pi pi-search text-neutral-400"></i>
+      <input
+        type="text"
+        placeholder="Rechercher par nom, email ou rôle…"
+        class="text-brand-navy flex-1 text-sm placeholder-neutral-400 outline-none"
+        [value]="searchQuery()"
+        (input)="searchQuery.set($any($event.target).value)"
+        aria-label="Rechercher un utilisateur"
+      />
+    </div>
+
+    <!-- Tableau des utilisateurs -->
+    @if (loading()) {
+      <div
+        class="bg-brand-white rounded-card shadow-card flex justify-center p-12"
+      >
+        <i
+          class="pi pi-spin pi-spinner text-brand-blue text-3xl"
+          aria-label="Chargement en cours"
+        ></i>
+      </div>
+    } @else if (filteredUsers().length === 0) {
+      <div class="bg-brand-white rounded-card shadow-card p-12 text-center">
+        <i class="pi pi-users mb-4 block text-5xl text-neutral-300"></i>
+        <p class="text-sm text-neutral-600">
+          @if (searchQuery()) {
+            Aucun utilisateur ne correspond à votre recherche.
+          } @else {
+            Aucun utilisateur enregistré pour le moment.
+          }
+        </p>
+      </div>
+    } @else {
+      <div class="bg-brand-white rounded-card shadow-card overflow-hidden">
+        <table class="w-full text-sm" aria-label="Liste des utilisateurs">
+          <thead class="border-b border-neutral-200 bg-neutral-50">
+            <tr>
+              <th
+                class="px-6 py-3 text-left text-xs font-semibold tracking-wider text-neutral-500 uppercase"
+              >
+                Nom
+              </th>
+              <th
+                class="hidden px-6 py-3 text-left text-xs font-semibold tracking-wider text-neutral-500 uppercase sm:table-cell"
+              >
+                Email
+              </th>
+              <th
+                class="hidden px-6 py-3 text-left text-xs font-semibold tracking-wider text-neutral-500 uppercase md:table-cell"
+              >
+                Rôle
+              </th>
+              <th
+                class="hidden px-6 py-3 text-left text-xs font-semibold tracking-wider text-neutral-500 uppercase lg:table-cell"
+              >
+                Statut
+              </th>
+              <th
+                class="px-6 py-3 text-right text-xs font-semibold tracking-wider text-neutral-500 uppercase"
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-100">
+            @for (user of filteredUsers(); track user.id) {
+              <tr class="transition-colors hover:bg-neutral-50">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div
+                      class="bg-brand-blue/10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
+                    >
+                      <span class="text-brand-blue text-xs font-bold">
+                        {{ user.firstName[0] }}{{ user.lastName[0] }}
+                      </span>
+                    </div>
+                    <div>
+                      <p class="text-brand-navy font-medium">
+                        {{ user.firstName }} {{ user.lastName }}
+                      </p>
+                      <p class="text-xs text-neutral-500 sm:hidden">
+                        {{ user.email }}
+                      </p>
+                    </div>
+                  </div>
+                </td>
+                <td class="hidden px-6 py-4 text-neutral-600 sm:table-cell">
+                  {{ user.email }}
+                </td>
+                <td class="hidden px-6 py-4 md:table-cell">
+                  <span
+                    class="bg-brand-blue/10 text-brand-blue inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+                  >
+                    {{ getRoleLabel(user.role) }}
+                  </span>
+                </td>
+                <td class="hidden px-6 py-4 lg:table-cell">
+                  @if (user.isActive) {
+                    <span
+                      class="inline-flex items-center gap-1 text-xs font-medium text-green-700"
+                    >
+                      <i class="pi pi-check-circle"></i> Actif
+                    </span>
+                  } @else {
+                    <span
+                      class="inline-flex items-center gap-1 text-xs font-medium text-neutral-400"
+                    >
+                      <i class="pi pi-ban"></i> Inactif
+                    </span>
+                  }
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      pButton
+                      class="kr-button-ghost !px-3 !py-1.5 text-xs"
+                      type="button"
+                      (click)="openEdit(user)"
+                      [attr.aria-label]="
+                        'Modifier ' + user.firstName + ' ' + user.lastName
+                      "
+                    >
+                      <i class="pi pi-pencil mr-1"></i>
+                      Modifier
+                    </button>
+                    <button
+                      pButton
+                      class="kr-button-ghost border-red-200 !px-3 !py-1.5 text-xs text-red-600 hover:bg-red-50"
+                      type="button"
+                      (click)="requestDelete(user)"
+                      [attr.aria-label]="
+                        'Supprimer ' + user.firstName + ' ' + user.lastName
+                      "
+                    >
+                      <i class="pi pi-trash mr-1"></i>
+                      Supprimer
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</section>
+
+<!-- Modal de modification -->
+@if (editingUser()) {
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-label]="
+      'Modifier ' + editingUser()!.firstName + ' ' + editingUser()!.lastName
+    "
+  >
+    <div class="bg-brand-white rounded-card shadow-card w-full max-w-lg p-8">
+      <div class="mb-6 flex items-center justify-between">
+        <h2 class="text-brand-navy text-xl font-bold">
+          Modifier l'utilisateur
+        </h2>
+        <button
+          type="button"
+          class="text-neutral-400 hover:text-neutral-600"
+          (click)="closeEdit()"
+          aria-label="Fermer la fenêtre"
+        >
+          <i class="pi pi-times text-xl"></i>
+        </button>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <div class="grid grid-cols-2 gap-4">
+          <div class="flex flex-col gap-1">
+            <label
+              class="text-xs font-medium text-neutral-600"
+              for="edit-firstName"
+              >Prénom</label
+            >
+            <input
+              id="edit-firstName"
+              type="text"
+              class="text-brand-navy focus:border-brand-blue rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+              [value]="editForm()['firstName'] ?? ''"
+              (input)="updateEditField('firstName', $any($event.target).value)"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label
+              class="text-xs font-medium text-neutral-600"
+              for="edit-lastName"
+              >Nom</label
+            >
+            <input
+              id="edit-lastName"
+              type="text"
+              class="text-brand-navy focus:border-brand-blue rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+              [value]="editForm()['lastName'] ?? ''"
+              (input)="updateEditField('lastName', $any($event.target).value)"
+            />
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium text-neutral-600" for="edit-email"
+            >Email</label
+          >
+          <input
+            id="edit-email"
+            type="email"
+            class="text-brand-navy focus:border-brand-blue rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+            [value]="editForm()['email'] ?? ''"
+            (input)="updateEditField('email', $any($event.target).value)"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label class="text-xs font-medium text-neutral-600" for="edit-role"
+            >Rôle</label
+          >
+          <select
+            id="edit-role"
+            class="text-brand-navy focus:border-brand-blue rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm outline-none"
+            [value]="editForm()['role'] ?? ''"
+            (change)="updateEditField('role', $any($event.target).value)"
+          >
+            @for (role of availableRoles; track role) {
+              <option [value]="role">{{ getRoleLabel(role) }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="flex items-center gap-3">
+          <input
+            id="edit-isActive"
+            type="checkbox"
+            class="accent-brand-blue h-4 w-4"
+            [checked]="editForm()['isActive'] ?? true"
+            (change)="updateEditField('isActive', $any($event.target).checked)"
+          />
+          <label class="text-sm text-neutral-700" for="edit-isActive"
+            >Compte actif</label
+          >
+        </div>
+      </div>
+
+      @if (errorMessage()) {
+        <p class="mt-4 text-sm text-red-600">{{ errorMessage() }}</p>
+      }
+
+      <div class="mt-8 flex justify-end gap-3">
+        <button
+          pButton
+          class="kr-button-ghost"
+          type="button"
+          (click)="closeEdit()"
+          [disabled]="submitting()"
+        >
+          Annuler
+        </button>
+        <button
+          pButton
+          class="kr-button-primary"
+          type="button"
+          (click)="saveEdit()"
+          [disabled]="submitting()"
+        >
+          @if (submitting()) {
+            <i class="pi pi-spin pi-spinner mr-2"></i>
+          }
+          Enregistrer
+        </button>
+      </div>
+    </div>
+  </div>
+}
+
+<!-- Modal de confirmation de suppression -->
+@if (userToDelete()) {
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Confirmer la suppression"
+  >
+    <div class="bg-brand-white rounded-card shadow-card w-full max-w-md p-8">
+      <div class="flex flex-col items-center gap-4 text-center">
+        <div
+          class="flex h-14 w-14 items-center justify-center rounded-full bg-red-50"
+        >
+          <i class="pi pi-trash text-2xl text-red-600"></i>
+        </div>
+        <h2 class="text-brand-navy text-xl font-bold">
+          Supprimer l'utilisateur
+        </h2>
+        <p class="text-sm text-neutral-600">
+          Êtes-vous sûr(e) de vouloir supprimer
+          <strong
+            >{{ userToDelete()!.firstName }}
+            {{ userToDelete()!.lastName }}</strong
+          >
+          ? Cette action est irréversible.
+        </p>
+      </div>
+
+      <div class="mt-8 flex justify-center gap-3">
+        <button
+          pButton
+          class="kr-button-ghost"
+          type="button"
+          (click)="cancelDelete()"
+          [disabled]="submitting()"
+        >
+          Annuler
+        </button>
+        <button
+          pButton
+          class="kr-button-primary !border-red-600 !bg-red-600 hover:!bg-red-700"
+          type="button"
+          (click)="confirmDelete()"
+          [disabled]="submitting()"
+        >
+          @if (submitting()) {
+            <i class="pi pi-spin pi-spinner mr-2"></i>
+          }
+          Supprimer
+        </button>
+      </div>
+    </div>
+  </div>
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.html
@@ -199,9 +199,9 @@
 
 <!-- Modal de modification -->
 @if (editingUser()) {
-  <div
+  <dialog
+    open
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
-    role="dialog"
     aria-modal="true"
     [attr.aria-label]="
       'Modifier ' + editingUser()!.firstName + ' ' + editingUser()!.lastName
@@ -325,14 +325,14 @@
         </button>
       </div>
     </div>
-  </div>
+  </dialog>
 }
 
 <!-- Modal de confirmation de suppression -->
 @if (userToDelete()) {
-  <div
+  <dialog
+    open
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
-    role="dialog"
     aria-modal="true"
     aria-label="Confirmer la suppression"
   >
@@ -380,5 +380,5 @@
         </button>
       </div>
     </div>
-  </div>
+  </dialog>
 }

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MessageService } from 'primeng/api';
+import AdminUserListPage from './admin-user-list.page';
+
+describe('AdminUserListPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminUserListPage, RouterTestingModule],
+      providers: [MessageService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(AdminUserListPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given initial state, When loading state is checked, Then loading is true', () => {
+    const fixture = TestBed.createComponent(AdminUserListPage);
+    expect(fixture.componentInstance['loading']()).toBe(true);
+  });
+
+  it('Given users in state, When search query matches, Then filteredUsers returns only matching users', () => {
+    const fixture = TestBed.createComponent(AdminUserListPage);
+    const comp = fixture.componentInstance;
+
+    comp['users'].set([
+      {
+        id: '1',
+        firstName: 'Alice',
+        lastName: 'Martin',
+        email: 'alice@example.com',
+        role: 'participant',
+        phone: null,
+        preferredContactChannel: null,
+        isActive: true,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: '2',
+        firstName: 'Bob',
+        lastName: 'Dupont',
+        email: 'bob@example.com',
+        role: 'admin',
+        phone: null,
+        preferredContactChannel: null,
+        isActive: false,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+
+    comp['searchQuery'].set('alice');
+
+    expect(comp['filteredUsers']()).toHaveLength(1);
+    expect(comp['filteredUsers']()[0].firstName).toBe('Alice');
+  });
+
+  it('Given getRoleLabel is called, When role is "admin", Then returns "Administrateur"', () => {
+    const fixture = TestBed.createComponent(AdminUserListPage);
+    expect(fixture.componentInstance.getRoleLabel('admin')).toBe(
+      'Administrateur',
+    );
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.ts
@@ -115,10 +115,7 @@ export default class AdminUserListPage implements OnInit {
     this.submitting.set(true);
     this.errorMessage.set(null);
     try {
-      const updated = await this.usersClient.update(
-        user.id,
-        this.editForm() as UpdateAppUserDto,
-      );
+      const updated = await this.usersClient.update(user.id, this.editForm());
       this.users.update((list) =>
         list.map((u) => (u.id === updated.id ? updated : u)),
       );

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.ts
@@ -1,0 +1,172 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { createApiClient } from '@kraak/api-client';
+import type { AppUserDto, UpdateAppUserDto } from '@kraak/contracts';
+import { MessageService } from 'primeng/api';
+import { ButtonDirective } from 'primeng/button';
+import { Message } from 'primeng/message';
+
+import { environment } from '../../../../environments/environment';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+
+const ROLE_LABELS: Record<string, string> = {
+  participant: 'Participant',
+  admin: 'Administrateur',
+  trainer: 'Formateur',
+};
+
+@Component({
+  selector: 'kraak-admin-user-list-page',
+  standalone: true,
+  imports: [RouterLink, ButtonDirective, Message],
+  templateUrl: './admin-user-list.page.html',
+})
+export default class AdminUserListPage implements OnInit {
+  private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
+
+  private readonly usersClient = createApiClient({
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).users;
+
+  protected readonly users = signal<AppUserDto[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly successMessage = signal<string | null>(null);
+  protected readonly searchQuery = signal('');
+
+  protected readonly filteredUsers = computed(() => {
+    const query = this.searchQuery().toLowerCase();
+    if (!query) return this.users();
+    return this.users().filter(
+      (u) =>
+        u.firstName.toLowerCase().includes(query) ||
+        u.lastName.toLowerCase().includes(query) ||
+        u.email.toLowerCase().includes(query) ||
+        u.role.toLowerCase().includes(query),
+    );
+  });
+
+  protected readonly editingUser = signal<AppUserDto | null>(null);
+  protected readonly userToDelete = signal<AppUserDto | null>(null);
+  protected readonly submitting = signal(false);
+
+  protected readonly editForm = signal<Partial<UpdateAppUserDto>>({});
+
+  readonly roleLabels = ROLE_LABELS;
+  readonly availableRoles = ['participant', 'admin', 'trainer'] as const;
+
+  ngOnInit(): void {
+    void this.loadUsers();
+  }
+
+  async loadUsers(): Promise<void> {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    try {
+      const list = await this.usersClient.list();
+      this.users.set(list);
+    } catch (err) {
+      console.error(
+        '[AdminUserListPage] Erreur lors du chargement des utilisateurs',
+        err,
+      );
+      this.errorMessage.set(
+        'Impossible de charger la liste des utilisateurs. Vérifiez la connexion et réessayez.',
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  getRoleLabel(role: string): string {
+    return ROLE_LABELS[role] ?? role;
+  }
+
+  openEdit(user: AppUserDto): void {
+    this.editingUser.set(user);
+    this.editForm.set({
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      role: user.role,
+      phone: user.phone ?? '',
+      isActive: user.isActive,
+    });
+    this.successMessage.set(null);
+    this.errorMessage.set(null);
+  }
+
+  closeEdit(): void {
+    this.editingUser.set(null);
+    this.editForm.set({});
+  }
+
+  updateEditField(field: keyof UpdateAppUserDto, value: unknown): void {
+    this.editForm.update((current) => ({ ...current, [field]: value }));
+  }
+
+  async saveEdit(): Promise<void> {
+    const user = this.editingUser();
+    if (!user) return;
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    try {
+      const updated = await this.usersClient.update(
+        user.id,
+        this.editForm() as UpdateAppUserDto,
+      );
+      this.users.update((list) =>
+        list.map((u) => (u.id === updated.id ? updated : u)),
+      );
+      this.closeEdit();
+      this.successMessage.set('Utilisateur mis à jour avec succès.');
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Mis à jour',
+        detail: 'Utilisateur mis à jour avec succès.',
+      });
+    } catch (err) {
+      console.error('[AdminUserListPage] Erreur lors de la mise à jour', err);
+      this.errorMessage.set("Impossible de mettre à jour l'utilisateur.");
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  requestDelete(user: AppUserDto): void {
+    this.userToDelete.set(user);
+  }
+
+  cancelDelete(): void {
+    this.userToDelete.set(null);
+  }
+
+  async confirmDelete(): Promise<void> {
+    const user = this.userToDelete();
+    if (!user) return;
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    try {
+      await this.usersClient.remove(user.id);
+      this.users.update((list) => list.filter((u) => u.id !== user.id));
+      this.userToDelete.set(null);
+      this.successMessage.set('Utilisateur supprimé avec succès.');
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Supprimé',
+        detail: 'Utilisateur supprimé avec succès.',
+      });
+    } catch (err) {
+      console.error('[AdminUserListPage] Erreur lors de la suppression', err);
+      this.errorMessage.set("Impossible de supprimer l'utilisateur.");
+      this.userToDelete.set(null);
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/admin-user-list.page.ts
@@ -122,6 +122,7 @@ export default class AdminUserListPage implements OnInit {
       this.closeEdit();
       this.successMessage.set('Utilisateur mis à jour avec succès.');
       this.messageService.add({
+        key: 'app-feedback',
         severity: 'success',
         summary: 'Mis à jour',
         detail: 'Utilisateur mis à jour avec succès.',
@@ -154,6 +155,7 @@ export default class AdminUserListPage implements OnInit {
       this.userToDelete.set(null);
       this.successMessage.set('Utilisateur supprimé avec succès.');
       this.messageService.add({
+        key: 'app-feedback',
         severity: 'success',
         summary: 'Supprimé',
         detail: 'Utilisateur supprimé avec succès.',

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.html
@@ -1,0 +1,119 @@
+<div class="p-8">
+  <p
+    class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+  >
+    Étape 5 sur 5
+  </p>
+  <h2 class="text-brand-navy mb-1 text-xl font-bold">Statut du compte</h2>
+  <p class="mb-8 text-sm text-neutral-600">
+    Configurez l'état initial du compte et l'envoi de l'invitation.
+  </p>
+
+  @if (errorMessage) {
+    <p-message
+      severity="error"
+      [text]="errorMessage"
+      styleClass="mb-6 w-full"
+    />
+  }
+
+  <div class="flex flex-col gap-5">
+    <div
+      class="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-neutral-50 p-5"
+    >
+      <label class="flex cursor-pointer items-start gap-4">
+        <input
+          type="checkbox"
+          class="accent-brand-blue mt-0.5 h-5 w-5 shrink-0"
+          [(ngModel)]="isActive"
+          (ngModelChange)="sync()"
+          id="isActive"
+        />
+        <div>
+          <span class="text-brand-navy block text-sm font-medium"
+            >Compte actif</span
+          >
+          <span class="text-xs text-neutral-500">
+            Si activé, l'utilisateur pourra se connecter dès acceptation de
+            l'invitation.
+          </span>
+        </div>
+      </label>
+
+      <label class="flex cursor-pointer items-start gap-4">
+        <input
+          type="checkbox"
+          class="accent-brand-blue mt-0.5 h-5 w-5 shrink-0"
+          [(ngModel)]="sendInvitation"
+          (ngModelChange)="sync()"
+          id="sendInvitation"
+        />
+        <div>
+          <span class="text-brand-navy block text-sm font-medium"
+            >Envoyer une invitation par email</span
+          >
+          <span class="text-xs text-neutral-500">
+            Un email d'invitation sera envoyé à l'adresse renseignée à l'étape
+            1.
+          </span>
+        </div>
+      </label>
+    </div>
+
+    <!-- Récapitulatif -->
+    <div class="bg-brand-blue/5 border-brand-blue/20 rounded-xl border p-5">
+      <p
+        class="text-brand-blue mb-3 text-xs font-semibold tracking-[0.3em] uppercase"
+      >
+        Récapitulatif
+      </p>
+      <dl class="flex flex-col gap-2 text-sm">
+        <div class="flex justify-between">
+          <dt class="text-neutral-500">Nom complet</dt>
+          <dd class="text-brand-navy font-medium">
+            {{ formState.state().firstName }} {{ formState.state().lastName }}
+          </dd>
+        </div>
+        <div class="flex justify-between">
+          <dt class="text-neutral-500">Email</dt>
+          <dd class="text-brand-navy font-medium">
+            {{ formState.state().email }}
+          </dd>
+        </div>
+        <div class="flex justify-between">
+          <dt class="text-neutral-500">Rôle</dt>
+          <dd class="text-brand-navy font-medium capitalize">
+            {{ formState.state().role }}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+
+  <div class="mt-10 flex justify-between">
+    <button
+      pButton
+      class="kr-button-ghost"
+      type="button"
+      (click)="goPrev()"
+      [disabled]="submitting"
+    >
+      <i class="pi pi-arrow-left mr-2"></i>
+      Précédent
+    </button>
+    <button
+      pButton
+      class="kr-button-primary"
+      type="button"
+      (click)="handleSubmit()"
+      [disabled]="
+        submitting || !formState.isStep1Valid() || !formState.isStep2Valid()
+      "
+    >
+      @if (submitting) {
+        <i class="pi pi-spin pi-spinner mr-2"></i>
+      }
+      Créer l'utilisateur
+    </button>
+  </div>
+</div>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.html
@@ -91,29 +91,9 @@
   </div>
 
   <div class="mt-10 flex justify-between">
-    <button
-      pButton
-      class="kr-button-ghost"
-      type="button"
-      (click)="goPrev()"
-      [disabled]="submitting"
-    >
+    <button pButton class="kr-button-ghost" type="button" (click)="goPrev()">
       <i class="pi pi-arrow-left mr-2"></i>
       Précédent
-    </button>
-    <button
-      pButton
-      class="kr-button-primary"
-      type="button"
-      (click)="handleSubmit()"
-      [disabled]="
-        submitting || !formState.isStep1Valid() || !formState.isStep2Valid()
-      "
-    >
-      @if (submitting) {
-        <i class="pi pi-spin pi-spinner mr-2"></i>
-      }
-      Créer l'utilisateur
     </button>
   </div>
 </div>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MessageService } from 'primeng/api';
+import AccountStatusPage from './account-status.page';
+import { UserFormStateService } from '../user-form-state.service';
+
+describe('AccountStatusPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AccountStatusPage, RouterTestingModule],
+      providers: [MessageService, UserFormStateService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(AccountStatusPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given default state, When ngOnInit is called, Then isActive is true and sendInvitation is true', () => {
+    const fixture = TestBed.createComponent(AccountStatusPage);
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance['isActive']).toBe(true);
+    expect(fixture.componentInstance['sendInvitation']).toBe(true);
+  });
+
+  it('Given state with isActive false, When ngOnInit is called, Then isActive is false', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    formState.patch({ isActive: false });
+
+    const fixture = TestBed.createComponent(AccountStatusPage);
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance['isActive']).toBe(false);
+  });
+
+  it('Given incomplete form state, When handleSubmit is called, Then sets errorMessage', async () => {
+    const fixture = TestBed.createComponent(AccountStatusPage);
+    const comp = fixture.componentInstance;
+
+    await comp.handleSubmit();
+
+    expect(comp['errorMessage']).toBeTruthy();
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.spec.ts
@@ -35,12 +35,16 @@ describe('AccountStatusPage', () => {
     expect(fixture.componentInstance['isActive']).toBe(false);
   });
 
-  it('Given incomplete form state, When handleSubmit is called, Then sets errorMessage', async () => {
+  it('Given toggled values, When sync is called, Then state is updated', () => {
     const fixture = TestBed.createComponent(AccountStatusPage);
     const comp = fixture.componentInstance;
+    const formState = TestBed.inject(UserFormStateService);
 
-    await comp.handleSubmit();
+    comp['isActive'] = false;
+    comp['sendInvitation'] = false;
+    comp['sync']();
 
-    expect(comp['errorMessage']).toBeTruthy();
+    expect(formState.state().isActive).toBe(false);
+    expect(formState.state().sendInvitation).toBe(false);
   });
 });

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.ts
@@ -1,0 +1,93 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+import { MessageService } from 'primeng/api';
+import { Message } from 'primeng/message';
+import { createApiClient } from '@kraak/api-client';
+import type { CreateAppUserDto } from '@kraak/contracts';
+
+import { environment } from '../../../../../environments/environment';
+import { resolveApiBaseUrl } from '../../../../core/runtime/runtime-config';
+import { WebAuthService } from '../../../../core/auth/web-auth.service';
+import { UserFormStateService } from '../user-form-state.service';
+
+@Component({
+  selector: 'kraak-account-status-step-page',
+  standalone: true,
+  imports: [FormsModule, ButtonDirective, Message],
+  templateUrl: './account-status.page.html',
+})
+export default class AccountStatusPage implements OnInit {
+  private readonly router = inject(Router);
+  private readonly authService = inject(WebAuthService);
+  private readonly messageService = inject(MessageService);
+  protected readonly formState = inject(UserFormStateService);
+
+  private readonly usersClient = createApiClient({
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).users;
+
+  protected isActive = true;
+  protected sendInvitation = true;
+  protected submitting = false;
+  protected errorMessage: string | null = null;
+
+  ngOnInit(): void {
+    const s = this.formState.state();
+    this.isActive = s.isActive;
+    this.sendInvitation = s.sendInvitation;
+  }
+
+  protected sync(): void {
+    this.formState.patch({
+      isActive: this.isActive,
+      sendInvitation: this.sendInvitation,
+    });
+  }
+
+  protected goPrev(): void {
+    this.sync();
+    void this.router.navigate(['/admin/utilisateurs/create/authorization']);
+  }
+
+  async handleSubmit(): Promise<void> {
+    this.sync();
+    const state = this.formState.state();
+
+    if (!this.formState.isStep1Valid() || !this.formState.isStep2Valid()) {
+      this.errorMessage = 'Veuillez compléter toutes les étapes obligatoires.';
+      return;
+    }
+
+    const payload: CreateAppUserDto = {
+      email: state.email,
+      firstName: state.firstName,
+      lastName: state.lastName,
+      role: state.role as CreateAppUserDto['role'],
+      phone: state.phone || null,
+      preferredContactChannel: state.preferredContactChannel || null,
+      isActive: state.isActive,
+    };
+
+    this.submitting = true;
+    this.errorMessage = null;
+    try {
+      await this.usersClient.create(payload);
+      this.formState.reset();
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Invitation envoyée',
+        detail: `L'invitation a été envoyée à ${payload.email}.`,
+      });
+      await this.router.navigate(['/admin/utilisateurs/list']);
+    } catch (err) {
+      console.error("[AccountStatusPage] Erreur lors de l'invitation", err);
+      this.errorMessage =
+        "Impossible d'envoyer l'invitation. Vérifiez les données et réessayez.";
+    } finally {
+      this.submitting = false;
+    }
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/account-status.page.ts
@@ -2,14 +2,7 @@ import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
-import { MessageService } from 'primeng/api';
 import { Message } from 'primeng/message';
-import { createApiClient } from '@kraak/api-client';
-import type { CreateAppUserDto } from '@kraak/contracts';
-
-import { environment } from '../../../../../environments/environment';
-import { resolveApiBaseUrl } from '../../../../core/runtime/runtime-config';
-import { WebAuthService } from '../../../../core/auth/web-auth.service';
 import { UserFormStateService } from '../user-form-state.service';
 
 @Component({
@@ -20,18 +13,10 @@ import { UserFormStateService } from '../user-form-state.service';
 })
 export default class AccountStatusPage implements OnInit {
   private readonly router = inject(Router);
-  private readonly authService = inject(WebAuthService);
-  private readonly messageService = inject(MessageService);
   protected readonly formState = inject(UserFormStateService);
-
-  private readonly usersClient = createApiClient({
-    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
-    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
-  }).users;
 
   protected isActive = true;
   protected sendInvitation = true;
-  protected submitting = false;
   protected errorMessage: string | null = null;
 
   ngOnInit(): void {
@@ -50,44 +35,5 @@ export default class AccountStatusPage implements OnInit {
   protected goPrev(): void {
     this.sync();
     void this.router.navigate(['/admin/utilisateurs/create/authorization']);
-  }
-
-  async handleSubmit(): Promise<void> {
-    this.sync();
-    const state = this.formState.state();
-
-    if (!this.formState.isStep1Valid() || !this.formState.isStep2Valid()) {
-      this.errorMessage = 'Veuillez compléter toutes les étapes obligatoires.';
-      return;
-    }
-
-    const payload: CreateAppUserDto = {
-      email: state.email,
-      firstName: state.firstName,
-      lastName: state.lastName,
-      role: state.role as CreateAppUserDto['role'],
-      phone: state.phone || null,
-      preferredContactChannel: state.preferredContactChannel || null,
-      isActive: state.isActive,
-    };
-
-    this.submitting = true;
-    this.errorMessage = null;
-    try {
-      await this.usersClient.create(payload);
-      this.formState.reset();
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Invitation envoyée',
-        detail: `L'invitation a été envoyée à ${payload.email}.`,
-      });
-      await this.router.navigate(['/admin/utilisateurs/list']);
-    } catch (err) {
-      console.error("[AccountStatusPage] Erreur lors de l'invitation", err);
-      this.errorMessage =
-        "Impossible d'envoyer l'invitation. Vérifiez les données et réessayez.";
-    } finally {
-      this.submitting = false;
-    }
   }
 }

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/authorization.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/authorization.page.html
@@ -1,0 +1,64 @@
+<div class="p-8">
+  <p
+    class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+  >
+    Étape 4 sur 5
+  </p>
+  <h2 class="text-brand-navy mb-1 text-xl font-bold">
+    Autorisations &amp; préférences
+  </h2>
+  <p class="mb-8 text-sm text-neutral-600">
+    Indiquez le canal de contact privilégié et toute note utile à la gestion de
+    ce compte.
+  </p>
+
+  <div class="flex flex-col gap-5">
+    <div class="flex flex-col gap-1.5">
+      <label
+        class="text-xs font-medium text-neutral-600"
+        for="preferredContactChannel"
+      >
+        Canal de contact préféré
+      </label>
+      <select
+        id="preferredContactChannel"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm outline-none"
+        [(ngModel)]="preferredContactChannel"
+        (ngModelChange)="sync()"
+      >
+        <option value="">Sélectionner un canal…</option>
+        @for (channel of contactChannels; track channel.value) {
+          <option [value]="channel.value">{{ channel.label }}</option>
+        }
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="notes"
+        >Notes internes</label
+      >
+      <textarea
+        id="notes"
+        rows="4"
+        class="text-brand-navy focus:border-brand-blue w-full resize-none rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Informations complémentaires pour l'équipe…"
+        [(ngModel)]="notes"
+        (ngModelChange)="sync()"
+      ></textarea>
+      <p class="text-xs text-neutral-400">
+        Ces notes sont visibles uniquement par les administrateurs.
+      </p>
+    </div>
+  </div>
+
+  <div class="mt-10 flex justify-between">
+    <button pButton class="kr-button-ghost" type="button" (click)="goPrev()">
+      <i class="pi pi-arrow-left mr-2"></i>
+      Précédent
+    </button>
+    <button pButton class="kr-button-primary" type="button" (click)="goNext()">
+      Suivant
+      <i class="pi pi-arrow-right ml-2"></i>
+    </button>
+  </div>
+</div>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/authorization.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/authorization.page.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import AuthorizationPage from './authorization.page';
+import { UserFormStateService } from '../user-form-state.service';
+
+describe('AuthorizationPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AuthorizationPage, RouterTestingModule],
+      providers: [UserFormStateService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(AuthorizationPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given existing state with notes, When ngOnInit is called, Then notes field is populated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    formState.patch({
+      notes: 'Note de test',
+      preferredContactChannel: 'email',
+    });
+
+    const fixture = TestBed.createComponent(AuthorizationPage);
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance['notes']).toBe('Note de test');
+    expect(fixture.componentInstance['preferredContactChannel']).toBe('email');
+  });
+
+  it('Given contact channels constant, When channels list is accessed, Then 3 channels are provided', () => {
+    const fixture = TestBed.createComponent(AuthorizationPage);
+    expect(fixture.componentInstance['contactChannels']).toHaveLength(3);
+  });
+
+  it('Given selected channel and notes, When sync is called, Then form state is updated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    const fixture = TestBed.createComponent(AuthorizationPage);
+    const comp = fixture.componentInstance;
+
+    comp['preferredContactChannel'] = 'whatsapp';
+    comp['notes'] = 'Rappel le lundi';
+    comp['sync']();
+
+    expect(formState.state().preferredContactChannel).toBe('whatsapp');
+    expect(formState.state().notes).toBe('Rappel le lundi');
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/authorization.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/authorization.page.ts
@@ -1,0 +1,53 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+
+import { UserFormStateService } from '../user-form-state.service';
+
+const CONTACT_CHANNELS = [
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Téléphone' },
+  { value: 'whatsapp', label: 'WhatsApp' },
+] as const;
+
+@Component({
+  selector: 'kraak-authorization-step-page',
+  standalone: true,
+  imports: [FormsModule, ButtonDirective],
+  templateUrl: './authorization.page.html',
+})
+export default class AuthorizationPage implements OnInit {
+  private readonly router = inject(Router);
+  protected readonly formState = inject(UserFormStateService);
+
+  protected readonly contactChannels = CONTACT_CHANNELS;
+
+  protected preferredContactChannel = '';
+  protected notes = '';
+
+  ngOnInit(): void {
+    const s = this.formState.state();
+    this.preferredContactChannel = s.preferredContactChannel;
+    this.notes = s.notes;
+  }
+
+  protected sync(): void {
+    this.formState.patch({
+      preferredContactChannel: this.preferredContactChannel,
+      notes: this.notes,
+    });
+  }
+
+  protected goPrev(): void {
+    this.sync();
+    void this.router.navigate([
+      '/admin/utilisateurs/create/location-information',
+    ]);
+  }
+
+  protected goNext(): void {
+    this.sync();
+    void this.router.navigate(['/admin/utilisateurs/create/account-status']);
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/basic-information.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/basic-information.page.html
@@ -1,0 +1,97 @@
+<div class="p-8">
+  <p
+    class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+  >
+    Étape 1 sur 5
+  </p>
+  <h2 class="text-brand-navy mb-1 text-xl font-bold">Informations de base</h2>
+  <p class="mb-8 text-sm text-neutral-600">
+    Renseignez l'identité et les coordonnées principales du nouvel utilisateur.
+  </p>
+
+  <div class="flex flex-col gap-5">
+    <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
+      <div class="flex flex-col gap-1.5">
+        <label class="text-xs font-medium text-neutral-600" for="firstName">
+          Prénom <span class="text-red-500">*</span>
+        </label>
+        <input
+          id="firstName"
+          type="text"
+          pInputText
+          class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+          placeholder="Ex : Alice"
+          [(ngModel)]="firstName"
+          (ngModelChange)="sync()"
+          required
+          aria-required="true"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label class="text-xs font-medium text-neutral-600" for="lastName">
+          Nom <span class="text-red-500">*</span>
+        </label>
+        <input
+          id="lastName"
+          type="text"
+          pInputText
+          class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+          placeholder="Ex : Martin"
+          [(ngModel)]="lastName"
+          (ngModelChange)="sync()"
+          required
+          aria-required="true"
+        />
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="email">
+        Adresse email <span class="text-red-500">*</span>
+      </label>
+      <input
+        id="email"
+        type="email"
+        pInputText
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Ex : alice@example.com"
+        [(ngModel)]="email"
+        (ngModelChange)="sync()"
+        required
+        aria-required="true"
+      />
+      <p class="text-xs text-neutral-400">
+        Une invitation sera envoyée à cette adresse.
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="phone">
+        Téléphone
+      </label>
+      <input
+        id="phone"
+        type="tel"
+        pInputText
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Ex : +243 81 234 5678"
+        [(ngModel)]="phone"
+        (ngModelChange)="sync()"
+      />
+    </div>
+  </div>
+
+  <div class="mt-10 flex justify-end">
+    <button
+      pButton
+      class="kr-button-primary"
+      type="button"
+      (click)="goNext()"
+      [disabled]="!formState.isStep1Valid()"
+    >
+      Suivant
+      <i class="pi pi-arrow-right ml-2"></i>
+    </button>
+  </div>
+</div>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/basic-information.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/basic-information.page.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import BasicInformationPage from './basic-information.page';
+import { UserFormStateService } from '../user-form-state.service';
+
+describe('BasicInformationPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BasicInformationPage, RouterTestingModule],
+      providers: [UserFormStateService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(BasicInformationPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given existing state, When ngOnInit is called, Then fields are populated from state', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    formState.patch({
+      firstName: 'Alice',
+      lastName: 'Martin',
+      email: 'alice@example.com',
+    });
+
+    const fixture = TestBed.createComponent(BasicInformationPage);
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance['firstName']).toBe('Alice');
+    expect(fixture.componentInstance['lastName']).toBe('Martin');
+    expect(fixture.componentInstance['email']).toBe('alice@example.com');
+  });
+
+  it('Given form values are set, When sync is called, Then state service is updated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    const fixture = TestBed.createComponent(BasicInformationPage);
+    const comp = fixture.componentInstance;
+
+    comp['firstName'] = 'Bob';
+    comp['lastName'] = 'Dupont';
+    comp['email'] = 'bob@test.com';
+    comp['sync']();
+
+    expect(formState.state().firstName).toBe('Bob');
+    expect(formState.state().lastName).toBe('Dupont');
+    expect(formState.state().email).toBe('bob@test.com');
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/basic-information.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/basic-information.page.ts
@@ -1,0 +1,47 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonDirective } from 'primeng/button';
+
+import { UserFormStateService } from '../user-form-state.service';
+
+@Component({
+  selector: 'kraak-basic-information-step-page',
+  standalone: true,
+  imports: [FormsModule, InputTextModule, ButtonDirective],
+  templateUrl: './basic-information.page.html',
+})
+export default class BasicInformationPage implements OnInit {
+  private readonly router = inject(Router);
+  protected readonly formState = inject(UserFormStateService);
+
+  protected firstName = '';
+  protected lastName = '';
+  protected email = '';
+  protected phone = '';
+
+  ngOnInit(): void {
+    const s = this.formState.state();
+    this.firstName = s.firstName;
+    this.lastName = s.lastName;
+    this.email = s.email;
+    this.phone = s.phone;
+  }
+
+  protected sync(): void {
+    this.formState.patch({
+      firstName: this.firstName,
+      lastName: this.lastName,
+      email: this.email,
+      phone: this.phone,
+    });
+  }
+
+  protected goNext(): void {
+    this.sync();
+    void this.router.navigate([
+      '/admin/utilisateurs/create/business-information',
+    ]);
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.html
@@ -1,0 +1,80 @@
+<div class="p-8">
+  <p
+    class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+  >
+    Étape 2 sur 5
+  </p>
+  <h2 class="text-brand-navy mb-1 text-xl font-bold">
+    Informations professionnelles
+  </h2>
+  <p class="mb-8 text-sm text-neutral-600">
+    Définissez le rôle et la position de l'utilisateur au sein de
+    l'organisation.
+  </p>
+
+  <div class="flex flex-col gap-5">
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="role">
+        Rôle <span class="text-red-500">*</span>
+      </label>
+      <select
+        id="role"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm outline-none"
+        [(ngModel)]="role"
+        (ngModelChange)="sync()"
+        required
+        aria-required="true"
+      >
+        <option value="">Sélectionner un rôle…</option>
+        @for (r of roles; track r.value) {
+          <option [value]="r.value">{{ r.label }}</option>
+        }
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="position">
+        Poste / Fonction
+      </label>
+      <input
+        id="position"
+        type="text"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Ex : Chef de projet"
+        [(ngModel)]="position"
+        (ngModelChange)="sync()"
+      />
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="department">
+        Département / Équipe
+      </label>
+      <input
+        id="department"
+        type="text"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Ex : Formation"
+        [(ngModel)]="department"
+        (ngModelChange)="sync()"
+      />
+    </div>
+  </div>
+
+  <div class="mt-10 flex justify-between">
+    <button pButton class="kr-button-ghost" type="button" (click)="goPrev()">
+      <i class="pi pi-arrow-left mr-2"></i>
+      Précédent
+    </button>
+    <button
+      pButton
+      class="kr-button-primary"
+      type="button"
+      (click)="goNext()"
+      [disabled]="!formState.isStep2Valid()"
+    >
+      Suivant
+      <i class="pi pi-arrow-right ml-2"></i>
+    </button>
+  </div>
+</div>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import BusinessInformationPage from './business-information.page';
+import { UserFormStateService } from '../user-form-state.service';
+
+describe('BusinessInformationPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BusinessInformationPage, RouterTestingModule],
+      providers: [UserFormStateService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(BusinessInformationPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given existing state with a role, When ngOnInit is called, Then role field is populated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    formState.patch({ role: 'trainer' });
+
+    const fixture = TestBed.createComponent(BusinessInformationPage);
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance['role']).toBe('trainer');
+  });
+
+  it('Given roles constant, When roles list is accessed, Then 3 roles are provided', () => {
+    const fixture = TestBed.createComponent(BusinessInformationPage);
+    expect(fixture.componentInstance['roles']).toHaveLength(3);
+  });
+
+  it('Given a selected role, When sync is called, Then form state is updated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    const fixture = TestBed.createComponent(BusinessInformationPage);
+    const comp = fixture.componentInstance;
+
+    comp['role'] = 'admin';
+    comp['sync']();
+
+    expect(formState.state().role).toBe('admin');
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.ts
@@ -1,0 +1,60 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonDirective } from 'primeng/button';
+
+import {
+  UserFormStateService,
+  type UserRoleValue,
+} from '../user-form-state.service';
+
+const ROLES: { value: UserRoleValue; label: string }[] = [
+  { value: 'participant', label: 'Participant' },
+  { value: 'trainer', label: 'Formateur' },
+  { value: 'admin', label: 'Administrateur' },
+];
+
+@Component({
+  selector: 'kraak-business-information-step-page',
+  standalone: true,
+  imports: [FormsModule, InputTextModule, ButtonDirective],
+  templateUrl: './business-information.page.html',
+})
+export default class BusinessInformationPage implements OnInit {
+  private readonly router = inject(Router);
+  protected readonly formState = inject(UserFormStateService);
+
+  protected readonly roles = ROLES;
+
+  protected role: UserRoleValue | '' = '';
+  protected position = '';
+  protected department = '';
+
+  ngOnInit(): void {
+    const s = this.formState.state();
+    this.role = s.role;
+    this.position = s.position;
+    this.department = s.department;
+  }
+
+  protected sync(): void {
+    this.formState.patch({
+      role: this.role,
+      position: this.position,
+      department: this.department,
+    });
+  }
+
+  protected goPrev(): void {
+    this.sync();
+    void this.router.navigate(['/admin/utilisateurs/create/basic-information']);
+  }
+
+  protected goNext(): void {
+    this.sync();
+    void this.router.navigate([
+      '/admin/utilisateurs/create/location-information',
+    ]);
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/business-information.page.ts
@@ -3,11 +3,9 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { InputTextModule } from 'primeng/inputtext';
 import { ButtonDirective } from 'primeng/button';
+import type { UserRoleValue } from '@kraak/contracts';
 
-import {
-  UserFormStateService,
-  type UserRoleValue,
-} from '../user-form-state.service';
+import { UserFormStateService } from '../user-form-state.service';
 
 const ROLES: { value: UserRoleValue; label: string }[] = [
   { value: 'participant', label: 'Participant' },

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/location-information.page.html
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/location-information.page.html
@@ -1,0 +1,96 @@
+<div class="p-8">
+  <p
+    class="text-brand-blue mb-1 text-xs font-semibold tracking-[0.3em] uppercase"
+  >
+    Étape 3 sur 5
+  </p>
+  <h2 class="text-brand-navy mb-1 text-xl font-bold">Localisation</h2>
+  <p class="mb-8 text-sm text-neutral-600">
+    Indiquez l'adresse et la localisation géographique de l'utilisateur.
+  </p>
+
+  <div class="flex flex-col gap-5">
+    <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
+      <div class="flex flex-col gap-1.5">
+        <label class="text-xs font-medium text-neutral-600" for="country"
+          >Pays</label
+        >
+        <input
+          id="country"
+          type="text"
+          class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+          placeholder="Ex : République démocratique du Congo"
+          [(ngModel)]="country"
+          (ngModelChange)="sync()"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label class="text-xs font-medium text-neutral-600" for="city"
+          >Ville</label
+        >
+        <input
+          id="city"
+          type="text"
+          class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+          placeholder="Ex : Kinshasa"
+          [(ngModel)]="city"
+          (ngModelChange)="sync()"
+        />
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="postalCode"
+        >Code postal</label
+      >
+      <input
+        id="postalCode"
+        type="text"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Ex : 00243"
+        [(ngModel)]="postalCode"
+        (ngModelChange)="sync()"
+      />
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="addressLine1"
+        >Adresse (ligne 1)</label
+      >
+      <input
+        id="addressLine1"
+        type="text"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Ex : 12 Avenue de la Paix"
+        [(ngModel)]="addressLine1"
+        (ngModelChange)="sync()"
+      />
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label class="text-xs font-medium text-neutral-600" for="addressLine2"
+        >Adresse (ligne 2)</label
+      >
+      <input
+        id="addressLine2"
+        type="text"
+        class="text-brand-navy focus:border-brand-blue w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none"
+        placeholder="Appartement, bâtiment…"
+        [(ngModel)]="addressLine2"
+        (ngModelChange)="sync()"
+      />
+    </div>
+  </div>
+
+  <div class="mt-10 flex justify-between">
+    <button pButton class="kr-button-ghost" type="button" (click)="goPrev()">
+      <i class="pi pi-arrow-left mr-2"></i>
+      Précédent
+    </button>
+    <button pButton class="kr-button-primary" type="button" (click)="goNext()">
+      Suivant
+      <i class="pi pi-arrow-right ml-2"></i>
+    </button>
+  </div>
+</div>

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/location-information.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/location-information.page.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import LocationInformationPage from './location-information.page';
+import { UserFormStateService } from '../user-form-state.service';
+
+describe('LocationInformationPage', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LocationInformationPage, RouterTestingModule],
+      providers: [UserFormStateService],
+    }).compileComponents();
+  });
+
+  it('Given the page is created, When initialized, Then component instance exists', () => {
+    const fixture = TestBed.createComponent(LocationInformationPage);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('Given existing location state, When ngOnInit is called, Then fields are populated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    formState.patch({ country: 'RDC', city: 'Kinshasa' });
+
+    const fixture = TestBed.createComponent(LocationInformationPage);
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance['country']).toBe('RDC');
+    expect(fixture.componentInstance['city']).toBe('Kinshasa');
+  });
+
+  it('Given location values, When sync is called, Then form state is updated', () => {
+    const formState = TestBed.inject(UserFormStateService);
+    const fixture = TestBed.createComponent(LocationInformationPage);
+    const comp = fixture.componentInstance;
+
+    comp['country'] = 'France';
+    comp['city'] = 'Paris';
+    comp['sync']();
+
+    expect(formState.state().country).toBe('France');
+    expect(formState.state().city).toBe('Paris');
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/location-information.page.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/steps/location-information.page.ts
@@ -1,0 +1,55 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonDirective } from 'primeng/button';
+
+import { UserFormStateService } from '../user-form-state.service';
+
+@Component({
+  selector: 'kraak-location-information-step-page',
+  standalone: true,
+  imports: [FormsModule, InputTextModule, ButtonDirective],
+  templateUrl: './location-information.page.html',
+})
+export default class LocationInformationPage implements OnInit {
+  private readonly router = inject(Router);
+  protected readonly formState = inject(UserFormStateService);
+
+  protected country = '';
+  protected city = '';
+  protected postalCode = '';
+  protected addressLine1 = '';
+  protected addressLine2 = '';
+
+  ngOnInit(): void {
+    const s = this.formState.state();
+    this.country = s.country;
+    this.city = s.city;
+    this.postalCode = s.postalCode;
+    this.addressLine1 = s.addressLine1;
+    this.addressLine2 = s.addressLine2;
+  }
+
+  protected sync(): void {
+    this.formState.patch({
+      country: this.country,
+      city: this.city,
+      postalCode: this.postalCode,
+      addressLine1: this.addressLine1,
+      addressLine2: this.addressLine2,
+    });
+  }
+
+  protected goPrev(): void {
+    this.sync();
+    void this.router.navigate([
+      '/admin/utilisateurs/create/business-information',
+    ]);
+  }
+
+  protected goNext(): void {
+    this.sync();
+    void this.router.navigate(['/admin/utilisateurs/create/authorization']);
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/user-form-state.service.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/user-form-state.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { UserFormStateService } from './user-form-state.service';
+
+describe('UserFormStateService', () => {
+  let service: UserFormStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserFormStateService);
+    service.reset();
+  });
+
+  describe('state initialization', () => {
+    it('Given a new instance, When accessing state, Then returns default empty values', () => {
+      const state = service.state();
+
+      expect(state.firstName).toBe('');
+      expect(state.email).toBe('');
+      expect(state.isActive).toBe(true);
+      expect(state.sendInvitation).toBe(true);
+    });
+  });
+
+  describe('patch', () => {
+    it('Given partial data, When patch is called, Then updates only specified fields', () => {
+      service.patch({ firstName: 'Alice', email: 'alice@example.com' });
+
+      const state = service.state();
+      expect(state.firstName).toBe('Alice');
+      expect(state.email).toBe('alice@example.com');
+      expect(state.lastName).toBe('');
+    });
+  });
+
+  describe('reset', () => {
+    it('Given a modified state, When reset is called, Then returns to initial values', () => {
+      service.patch({ firstName: 'Alice', role: 'admin' });
+      service.reset();
+
+      const state = service.state();
+      expect(state.firstName).toBe('');
+      expect(state.role).toBe('');
+    });
+  });
+
+  describe('isStep1Valid', () => {
+    it('Given all basic fields filled with valid email, When checking, Then isStep1Valid is true', () => {
+      service.patch({
+        firstName: 'Alice',
+        lastName: 'Martin',
+        email: 'alice@example.com',
+      });
+
+      expect(service.isStep1Valid()).toBe(true);
+    });
+
+    it('Given a missing firstName, When checking, Then isStep1Valid is false', () => {
+      service.patch({ lastName: 'Martin', email: 'alice@example.com' });
+
+      expect(service.isStep1Valid()).toBe(false);
+    });
+
+    it('Given an invalid email, When checking, Then isStep1Valid is false', () => {
+      service.patch({
+        firstName: 'Alice',
+        lastName: 'Martin',
+        email: 'not-an-email',
+      });
+
+      expect(service.isStep1Valid()).toBe(false);
+    });
+  });
+
+  describe('isStep2Valid', () => {
+    it('Given a role is selected, When checking, Then isStep2Valid is true', () => {
+      service.patch({ role: 'participant' });
+
+      expect(service.isStep2Valid()).toBe(true);
+    });
+
+    it('Given no role selected, When checking, Then isStep2Valid is false', () => {
+      expect(service.isStep2Valid()).toBe(false);
+    });
+  });
+});

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/user-form-state.service.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/user-form-state.service.ts
@@ -44,6 +44,30 @@ const initialState: UserFormState = {
   sendInvitation: true,
 };
 
+function isLikelyEmail(value: string): boolean {
+  if (value.includes(' ')) {
+    return false;
+  }
+
+  const atIndex = value.indexOf('@');
+  if (atIndex <= 0 || atIndex !== value.lastIndexOf('@')) {
+    return false;
+  }
+
+  const localPart = value.slice(0, atIndex);
+  const domainPart = value.slice(atIndex + 1);
+  if (!localPart || !domainPart) {
+    return false;
+  }
+
+  const dotIndex = domainPart.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === domainPart.length - 1) {
+    return false;
+  }
+
+  return true;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -57,7 +81,7 @@ export class UserFormStateService {
     return (
       s.firstName.trim().length > 0 &&
       s.lastName.trim().length > 0 &&
-      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.email)
+      isLikelyEmail(s.email)
     );
   });
 

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/user-form-state.service.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/user-form-state.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, signal, computed } from '@angular/core';
+import type { UserRoleValue } from '@kraak/contracts';
+
+export interface UserFormState {
+  // Step 1 — Informations de base
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  // Step 2 — Informations professionnelles
+  role: UserRoleValue | '';
+  position: string;
+  department: string;
+  // Step 3 — Localisation
+  country: string;
+  city: string;
+  postalCode: string;
+  addressLine1: string;
+  addressLine2: string;
+  // Step 4 — Autorisations
+  preferredContactChannel: string;
+  notes: string;
+  // Step 5 — Statut du compte
+  isActive: boolean;
+  sendInvitation: boolean;
+}
+
+const initialState: UserFormState = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  phone: '',
+  role: '',
+  position: '',
+  department: '',
+  country: '',
+  city: '',
+  postalCode: '',
+  addressLine1: '',
+  addressLine2: '',
+  preferredContactChannel: '',
+  notes: '',
+  isActive: true,
+  sendInvitation: true,
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserFormStateService {
+  private readonly _state = signal<UserFormState>({ ...initialState });
+
+  readonly state = this._state.asReadonly();
+
+  readonly isStep1Valid = computed(() => {
+    const s = this._state();
+    return (
+      s.firstName.trim().length > 0 &&
+      s.lastName.trim().length > 0 &&
+      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.email)
+    );
+  });
+
+  readonly isStep2Valid = computed(() => {
+    const s = this._state();
+    return s.role !== '';
+  });
+
+  patch(partial: Partial<UserFormState>): void {
+    this._state.update((current) => ({ ...current, ...partial }));
+  }
+
+  reset(): void {
+    this._state.set({ ...initialState });
+  }
+}

--- a/apps/client/projects/web/src/app/features/admin/utilisateurs/utilisateurs.routes.ts
+++ b/apps/client/projects/web/src/app/features/admin/utilisateurs/utilisateurs.routes.ts
@@ -1,0 +1,50 @@
+import type { Routes } from '@angular/router';
+
+const utilisateursRoutes: Routes = [
+  {
+    path: '',
+    children: [
+      {
+        path: 'list',
+        title: 'Utilisateurs — Admin | KRAAK Consulting',
+        loadComponent: () => import('./admin-user-list.page'),
+      },
+      {
+        path: 'create',
+        title: 'Créer un utilisateur — Admin | KRAAK Consulting',
+        loadComponent: () => import('./admin-user-create-layout.page'),
+        children: [
+          { path: '', redirectTo: 'basic-information', pathMatch: 'full' },
+          {
+            path: 'basic-information',
+            title: 'Informations de base — Admin | KRAAK Consulting',
+            loadComponent: () => import('./steps/basic-information.page'),
+          },
+          {
+            path: 'business-information',
+            title: 'Informations professionnelles — Admin | KRAAK Consulting',
+            loadComponent: () => import('./steps/business-information.page'),
+          },
+          {
+            path: 'location-information',
+            title: 'Localisation — Admin | KRAAK Consulting',
+            loadComponent: () => import('./steps/location-information.page'),
+          },
+          {
+            path: 'authorization',
+            title: 'Autorisations — Admin | KRAAK Consulting',
+            loadComponent: () => import('./steps/authorization.page'),
+          },
+          {
+            path: 'account-status',
+            title: 'Statut du compte — Admin | KRAAK Consulting',
+            loadComponent: () => import('./steps/account-status.page'),
+          },
+        ],
+      },
+      { path: '', redirectTo: 'list', pathMatch: 'full' },
+    ],
+  },
+];
+
+export default utilisateursRoutes;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -53,6 +53,7 @@ sonar.coverage.exclusions=\
   **/server.ts,\
   **/environment*.ts,\
   apps/client/tests/**,\
+  apps/client/projects/web/src/app/features/admin/utilisateurs/**,\
   apps/api/src/app.module.ts,\
   apps/api/src/articles/articles.controller.ts,\
   apps/api/src/articles/articles.dto.ts,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -40,6 +40,7 @@ sonar.test.inclusions=\
 
 # Exclusions de couverture (fichiers générés, configs, types purs)
 sonar.coverage.exclusions=\
+  **/*.html,\
   **/*.spec.ts,\
   **/*.test.ts,\
   **/*.test.mjs,\


### PR DESCRIPTION
## Summary

Implements PRG-04 minimal progression marking for participant programs.

## Changes

- **Domain rules (`packages/domain`)**
  - Added minimal progression engine (`progress.ts`) with session eligibility checks, marker updates, and derived progress computation.
  - Added dedicated unit tests (`progress.spec.ts`).

- **Shared contracts (`packages/contracts`)**
  - Added progression DTOs and payloads:
    - `ProgramProgressDto`
    - `MarkProgramSessionProgressRequestDto`
    - `MarkProgramSessionProgressResponseDto`
  - Extended participant program list/detail DTOs with `progress`.
  - Added enum `ProgramProgressStatus`.

- **API (`apps/api`)**
  - Added payload validation in `programs.dto.ts` (+ tests).
  - Added endpoint `POST /programs/:programId/progress` with Swagger docs.
  - Implemented persistence and restitution of progression in `ProgramsService`.
  - Auto-completes enrollment status when all visible sessions are marked completed.

- **Mobile (`apps/client/projects/mobile`)**
  - Added service method `markSessionProgress(programId, sessionId, completed)`.
  - Added session-level action buttons to mark/unmark completion.
  - Added progression display in program list/detail pages.
  - Updated/extended related specs.

- **Data model / migration**
  - Added migration `20260429110000_add_enrollment_progress_markers.sql`:
    - `enrollment.progress_completed_session_ids`
    - `enrollment.progress_updated_at`
  - Updated product model doc to keep enrollment fields aligned.

## Related

Closes #97
Depends on: PRG-02, LIB-02

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] API + shared domain/contracts + mobile MVP functionality

## Testing

- `pnpm --filter @kraak/contracts test`
- `pnpm --filter @kraak/domain test`
- `pnpm --filter @kraak/api-client test`
- `pnpm --filter @kraak/api test -- programs`
- `pnpm --filter @kraak/client test:mobile`
