### PR TITLE
fix(api): export AuthService from AuthModule for Programs DI

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -7,5 +7,6 @@ import { AuthService } from './auth.service';
   imports: [SupabaseModule],
   controllers: [AuthController],
   providers: [AuthService],
+  exports: [AuthService],
 })
 export class AuthModule {}


### PR DESCRIPTION
## Summary\n- export AuthService from AuthModule\n- fix Nest DI failure in ProgramsController and other controllers importing AuthService through AuthModule\n\n## Why\nRender deploy crashes with UnknownDependenciesException for ProgramsController because AuthService was not exported by AuthModule.