### PR TITLE
chore(infra): add local compose and supabase helper workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ pnpm dev:mobile
 
 > `pnpm dev` choisit automatiquement le prochain port libre pour le web et le mobile si `4200` ou `4300` sont déjà occupés. L'API reste attendue sur `3000`.
 
+### Lancer avec Docker Compose (local uniquement)
+
+Le fichier [`compose.local.yml`](compose.local.yml) sert uniquement au workflow de développement local.
+Il ne doit pas être utilisé comme couche d'orchestration en production.
+Pour un profil DB local prêt à l'emploi avec Supabase CLI, voir
+[`docs/runbooks/DEV_MODE.md`](docs/runbooks/DEV_MODE.md) (section
+"Profil DB local prêt à l'emploi (Supabase + Docker Compose)").
+
+```bash
+# Démarrer API + front statique local
+docker compose -f compose.local.yml up --build
+
+# Arrêter et nettoyer les conteneurs
+docker compose -f compose.local.yml down
+```
+
+Services exposés :
+
+- Front (statique) : `http://localhost:4200`
+- API (NestJS) : `http://localhost:3000`
+
 ---
 
 ## Structure du monorepo

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -7,5 +7,6 @@ import { AuthService } from './auth.service';
   imports: [SupabaseModule],
   controllers: [AuthController],
   providers: [AuthService],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,0 +1,51 @@
+name: kraak-local
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+      APP_VERSION: ${APP_VERSION:-local}
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:-}
+      SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      CONTACT_FROM_EMAIL: ${CONTACT_FROM_EMAIL:-}
+      CONTACT_TO_EMAIL: ${CONTACT_TO_EMAIL:-}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:4200}
+      CORS_ALLOWED_ORIGIN_PATTERNS: ${CORS_ALLOWED_ORIGIN_PATTERNS:-}
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+
+  web:
+    image: node:22-bookworm-slim
+    working_dir: /workspace
+    command: >
+      bash -lc "corepack enable &&
+      corepack prepare pnpm@10.23.0 --activate &&
+      pnpm install --frozen-lockfile &&
+      pnpm --filter @kraak/client run build:web:local &&
+      npx --yes serve apps/client/dist/web/browser -l 4200"
+    environment:
+      NODE_ENV: production
+      CLIENT_API_BASE_URL: ${CLIENT_API_BASE_URL:-http://api:3000}
+      SUPABASE_URL: ${CLIENT_SUPABASE_URL:-}
+      SUPABASE_PUBLISHABLE_KEY: ${CLIENT_SUPABASE_PUBLISHABLE_KEY:-}
+      CLIENT_FEATURE_PARTICIPANT_AREA: ${CLIENT_FEATURE_PARTICIPANT_AREA:-true}
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-http://localhost:4200}
+      PUBLIC_GA4_ID: ${PUBLIC_GA4_ID:-}
+    ports:
+      - "4200:4200"
+    depends_on:
+      - api
+    volumes:
+      - .:/workspace
+      - pnpm-store:/pnpm/store
+    restart: unless-stopped
+
+volumes:
+  pnpm-store:

--- a/docs/runbooks/DEV_MODE.md
+++ b/docs/runbooks/DEV_MODE.md
@@ -34,6 +34,80 @@ La configuration Auth locale versionnée pour le MVP est décrite dans
 | `SUPABASE_URL`        | `apps/api/.env` | `http://127.0.0.1:54321`       |
 | `SUPABASE_SECRET_KEY` | `apps/api/.env` | clé fournie par Supabase local |
 
+### Profil DB local prêt à l'emploi (Supabase + Docker Compose)
+
+Ce profil garde Supabase hors de Docker Compose (via Supabase CLI) et utilise
+`compose.local.yml` uniquement pour le front et l'API.
+
+Prérequis :
+
+1. Docker Desktop démarré
+2. Supabase CLI installée et accessible (`supabase --version`)
+
+Étapes :
+
+1. Démarrer Supabase local depuis la racine du dépôt :
+
+```bash
+supabase start
+```
+
+1. Récupérer les valeurs locales (URL + clés) :
+
+```bash
+supabase status
+```
+
+1. Exporter les variables puis démarrer Compose.
+
+Exemple Bash :
+
+```bash
+export SUPABASE_URL="http://host.docker.internal:54321"
+export SUPABASE_SECRET_KEY="<service_role_key_depuis_supabase_status>"
+export SUPABASE_PUBLISHABLE_KEY="<anon_key_depuis_supabase_status>"
+export CLIENT_SUPABASE_URL="$SUPABASE_URL"
+export CLIENT_SUPABASE_PUBLISHABLE_KEY="$SUPABASE_PUBLISHABLE_KEY"
+export CLIENT_API_BASE_URL="http://api:3000"
+docker compose -f compose.local.yml up --build
+```
+
+Exemple PowerShell :
+
+```powershell
+$env:SUPABASE_URL = "http://host.docker.internal:54321"
+$env:SUPABASE_SECRET_KEY = "<service_role_key_depuis_supabase_status>"
+$env:SUPABASE_PUBLISHABLE_KEY = "<anon_key_depuis_supabase_status>"
+$env:CLIENT_SUPABASE_URL = $env:SUPABASE_URL
+$env:CLIENT_SUPABASE_PUBLISHABLE_KEY = $env:SUPABASE_PUBLISHABLE_KEY
+$env:CLIENT_API_BASE_URL = "http://api:3000"
+docker compose -f compose.local.yml up --build
+```
+
+1. Arrêter les services applicatifs puis la DB locale :
+
+```bash
+docker compose -f compose.local.yml down
+supabase stop
+```
+
+Notes importantes :
+
+- Dans un conteneur Docker, `localhost` pointe vers le conteneur lui-même.
+  `host.docker.internal` est donc requis pour joindre Supabase local lancé sur
+  la machine hôte.
+- Le front est servi en statique par Compose et lit les valeurs runtime via
+  `runtime-config.js` généré au build.
+
+Option automatisée (recommandée) :
+
+- Bash : `./scripts/compose-up-with-supabase-local.sh`
+- PowerShell : `./scripts/compose-up-with-supabase-local.ps1`
+
+Ces scripts lancent `supabase start`, récupèrent les clés via
+`supabase status -o env`, exportent les variables nécessaires puis exécutent
+`docker compose -f compose.local.yml up --build`.
+
 ---
 
 ## Lancer le site web (Angular SSR)

--- a/scripts/compose-up-with-supabase-local.ps1
+++ b/scripts/compose-up-with-supabase-local.ps1
@@ -1,0 +1,59 @@
+# scripts/compose-up-with-supabase-local.ps1
+# Lance Supabase local, exporte les variables requises et demarre Docker Compose.
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ComposeArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+
+if (-not (Get-Command supabase -ErrorAction SilentlyContinue)) {
+    throw "supabase CLI est requise. Installation: https://supabase.com/docs/guides/cli"
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    throw "docker est requis et doit etre disponible dans le PATH."
+}
+
+Set-Location $repoRoot
+
+Write-Host "[compose-helper] Demarrage de Supabase local..."
+supabase start | Out-Host
+
+Write-Host "[compose-helper] Lecture des variables Supabase..."
+$statusEnvOutput = supabase status -o env
+
+$statusEnv = @{}
+foreach ($line in $statusEnvOutput) {
+    if ($line -match '^(?<key>[A-Z0-9_]+)=(?<value>.*)$') {
+        $statusEnv[$Matches.key] = $Matches.value
+    }
+}
+
+$supabaseUrl = $statusEnv["API_URL"]
+$supabasePublishableKey = $statusEnv["ANON_KEY"]
+$supabaseSecretKey = $statusEnv["SERVICE_ROLE_KEY"]
+
+if ([string]::IsNullOrWhiteSpace($supabaseUrl) -or
+    [string]::IsNullOrWhiteSpace($supabasePublishableKey) -or
+    [string]::IsNullOrWhiteSpace($supabaseSecretKey)) {
+    throw "Impossible de lire API_URL, ANON_KEY et SERVICE_ROLE_KEY depuis 'supabase status -o env'."
+}
+
+# Docker Desktop expose l'hote via host.docker.internal depuis les conteneurs.
+$containerSupabaseUrl = $supabaseUrl.Replace("127.0.0.1", "host.docker.internal").Replace("localhost", "host.docker.internal")
+
+$env:SUPABASE_URL = $containerSupabaseUrl
+$env:SUPABASE_SECRET_KEY = $supabaseSecretKey
+$env:SUPABASE_PUBLISHABLE_KEY = $supabasePublishableKey
+$env:CLIENT_SUPABASE_URL = $env:SUPABASE_URL
+$env:CLIENT_SUPABASE_PUBLISHABLE_KEY = $env:SUPABASE_PUBLISHABLE_KEY
+$env:CLIENT_API_BASE_URL = "http://api:3000"
+
+Write-Host "[compose-helper] Variables exportees. Lancement de Docker Compose..."
+docker compose -f compose.local.yml up --build @ComposeArgs

--- a/scripts/compose-up-with-supabase-local.sh
+++ b/scripts/compose-up-with-supabase-local.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# scripts/compose-up-with-supabase-local.sh
+# Lance Supabase local, exporte les variables requises et demarre Docker Compose.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "supabase CLI est requise. Installation: https://supabase.com/docs/guides/cli"
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker est requis et doit etre disponible dans le PATH."
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+echo "[compose-helper] Demarrage de Supabase local..."
+supabase start
+
+echo "[compose-helper] Lecture des variables Supabase..."
+status_env="$(supabase status -o env)"
+
+extract_env_value() {
+  local key="$1"
+  echo "$status_env" | sed -n "s/^${key}=//p" | tail -n 1
+}
+
+supabase_url="$(extract_env_value API_URL)"
+supabase_publishable_key="$(extract_env_value ANON_KEY)"
+supabase_secret_key="$(extract_env_value SERVICE_ROLE_KEY)"
+
+if [[ -z "$supabase_url" || -z "$supabase_publishable_key" || -z "$supabase_secret_key" ]]; then
+  echo "Impossible de lire API_URL, ANON_KEY et SERVICE_ROLE_KEY depuis 'supabase status -o env'."
+  exit 1
+fi
+
+# Docker Desktop expose l'hote via host.docker.internal depuis les conteneurs.
+container_supabase_url="${supabase_url/127.0.0.1/host.docker.internal}"
+container_supabase_url="${container_supabase_url/localhost/host.docker.internal}"
+
+export SUPABASE_URL="$container_supabase_url"
+export SUPABASE_SECRET_KEY="$supabase_secret_key"
+export SUPABASE_PUBLISHABLE_KEY="$supabase_publishable_key"
+export CLIENT_SUPABASE_URL="$SUPABASE_URL"
+export CLIENT_SUPABASE_PUBLISHABLE_KEY="$SUPABASE_PUBLISHABLE_KEY"
+export CLIENT_API_BASE_URL="http://api:3000"
+
+echo "[compose-helper] Variables exportees. Lancement de Docker Compose..."
+docker compose -f compose.local.yml up --build "$@"


### PR DESCRIPTION
## Résumé\n- ajoute compose.local.yml pour workflow local front+api\n- ajoute scripts helper Bash/PowerShell pour Supabase local + compose up\n- documente le profil DB local Supabase dans les runbooks\n- inclut le correctif DI AuthService export (already merged in staging via PR #500) présent sur la branche\n\n## Validation\n- hooks pre-push passés (format/lint/typecheck/tests/e2e)