### PR TITLE
fix(web): align auth reset SEO and sonar env fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install -g --ignore-scripts pnpm@10.23.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install --ignore-scripts -g pnpm@10.23.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install --ignore-scripts -g pnpm@10.23.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install --ignore-scripts -g pnpm@10.23.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install --ignore-scripts -g pnpm@10.23.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install --ignore-scripts -g pnpm@10.23.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,7 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   sonarcloud:
@@ -54,3 +54,5 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
+          # Requis pour la résolution du contexte PR et la décoration des pull requests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        run: npm install -g pnpm@10.23.0
+        run: npm install --ignore-scripts -g pnpm@10.23.0
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,4 +21,9 @@ wait "$lint_pid" || status=$?
 
 [ "$status" -eq 0 ] || exit "$status"
 
-pnpm test
+# Exécuter toutes les suites de tests locales hors E2E.
+# Les E2E restent exécutés dans GitHub Actions.
+pnpm test:libs
+pnpm test:api
+pnpm test:unit
+pnpm test:workspace

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -76,6 +76,16 @@ describe('Web routes', () => {
       }
     });
 
+    it('When inspecting the auth reset marketing route Then robots blocks indexing', () => {
+      const builtRoutes = buildRoutes();
+      const authResetRoute = builtRoutes.find(
+        (route) => route.path === 'auth/reset',
+      );
+
+      expect(authResetRoute).toBeDefined();
+      expect(authResetRoute?.data?.['seo']?.robots).toBe('noindex, nofollow');
+    });
+
     it('When inspecting article and alias routes Then the blog article page is lazy-loaded and english slugs redirect to french canonical paths', () => {
       const builtRoutes = buildRoutes();
       const blogArticleRoute = builtRoutes.find(
@@ -159,6 +169,20 @@ describe('Web routes', () => {
 
       for (const route of gatedRoutes) {
         expect(route.canMatch).toContain(participantAreaCanMatch);
+      }
+    });
+
+    it('When inspecting participant auth routes Then SEO metadata blocks indexing', () => {
+      const builtRoutes = buildRoutes({ includeParticipantArea: true });
+      const participantSeoRoutes = builtRoutes.filter((route) =>
+        participantPaths.includes(route.path ?? ''),
+      );
+
+      expect(participantSeoRoutes.length).toBe(participantPaths.length);
+
+      for (const route of participantSeoRoutes) {
+        expect(route.data?.['seo']).toBeDefined();
+        expect(route.data?.['seo']?.robots).toBe('noindex, nofollow');
       }
     });
 

--- a/apps/client/projects/web/src/app/app.routes.ts
+++ b/apps/client/projects/web/src/app/app.routes.ts
@@ -79,31 +79,10 @@ const marketingRoutes: Routes = [
     'politique-de-confidentialite',
     () => import('./features/legal/politique-de-confidentialite.page'),
   ),
-  {
-    path: 'auth/reset',
-    title: 'Finaliser la réinitialisation | KRAAK Consulting',
-    data: {
-      seo: {
-        path: 'auth/reset',
-        title: 'Finaliser la réinitialisation | KRAAK Consulting',
-        description:
-          'Définissez un nouveau mot de passe pour sécuriser votre accès à l’espace KRAAK.',
-        openGraph: {
-          title: 'Finaliser la réinitialisation | KRAAK Consulting',
-          description:
-            'Définissez un nouveau mot de passe pour sécuriser votre accès à l’espace KRAAK.',
-          imagePath: '/assets/site-visuals/photos/home-hero-workshop.jpg',
-          imageAlt:
-            "Photo d'un atelier KRAAK Consulting avec des participants en session de travail.",
-        },
-        sitemap: {
-          changeFrequency: 'never',
-          priority: 0.1,
-        },
-      },
-    },
-    loadComponent: () => import('./features/auth/auth-reset.page'),
-  },
+  buildMarketingRoute(
+    'auth/reset',
+    () => import('./features/auth/auth-reset.page'),
+  ),
   {
     path: 'about',
     redirectTo: 'a-propos',

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
@@ -6,7 +6,10 @@ import { MessageService } from 'primeng/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DashboardPage from './dashboard.page';
-import { WebAuthService } from '../../../core/auth/web-auth.service';
+import {
+  WEB_AUTH_STORAGE_KEY,
+  WebAuthService,
+} from '../../../core/auth/web-auth.service';
 import {
   participantRoleGuard,
   participantRoleChildGuard,
@@ -110,6 +113,8 @@ async function flush(
 
 describe('Web Participant Dashboard Page', () => {
   beforeEach(async () => {
+    globalThis.localStorage?.removeItem(WEB_AUTH_STORAGE_KEY);
+
     await TestBed.configureTestingModule({
       imports: [DashboardPage],
       providers: [WebAuthService, provideRouter([]), MessageService],

--- a/apps/client/projects/web/src/app/participant-area.routes.ts
+++ b/apps/client/projects/web/src/app/participant-area.routes.ts
@@ -5,31 +5,99 @@ import {
   participantRoleChildGuard,
 } from './core/auth/auth.guard';
 import { isParticipantAreaEnabled } from './core/runtime/runtime-config';
+import { type SeoPageDefinition } from './seo/site-seo';
 
 export const participantAreaCanMatch: CanMatchFn = () =>
   isParticipantAreaEnabled();
+
+const AUTH_ROBOTS_DIRECTIVE = 'noindex, nofollow';
+
+const authOpenGraph = {
+  title: 'Accès participant | KRAAK Consulting',
+  description:
+    'Accédez à votre espace participant KRAAK pour gérer votre session en toute sécurité.',
+  imagePath: '/assets/site-visuals/photos/home-hero-workshop.jpg',
+  imageAlt:
+    "Photo d'un atelier KRAAK Consulting avec des participants en session de travail.",
+};
+
+const signInSeo: SeoPageDefinition = {
+  path: 'connexion',
+  title: 'Connexion | KRAAK',
+  description:
+    'Connectez-vous à votre espace KRAAK pour reprendre votre parcours participant.',
+  robots: AUTH_ROBOTS_DIRECTIVE,
+  openGraph: authOpenGraph,
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
+
+const signUpSeo: SeoPageDefinition = {
+  path: 'inscription',
+  title: 'Inscription | KRAAK',
+  description:
+    'Créez votre accès participant KRAAK pour suivre vos prochaines étapes.',
+  robots: AUTH_ROBOTS_DIRECTIVE,
+  openGraph: authOpenGraph,
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
+
+const passwordResetSeo: SeoPageDefinition = {
+  path: 'mot-de-passe-oublie',
+  title: 'Mot de passe oublié | KRAAK',
+  description:
+    'Demandez un lien de réinitialisation pour sécuriser votre accès participant.',
+  robots: AUTH_ROBOTS_DIRECTIVE,
+  openGraph: authOpenGraph,
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
+
+const participantDashboardSeo: SeoPageDefinition = {
+  path: 'participant/dashboard',
+  title: 'Espace participant | KRAAK',
+  description:
+    'Consultez votre tableau de bord participant KRAAK et poursuivez votre progression.',
+  robots: AUTH_ROBOTS_DIRECTIVE,
+  openGraph: authOpenGraph,
+  sitemap: {
+    changeFrequency: 'never',
+    priority: 0.1,
+  },
+};
 
 export const participantAreaRoutes: Routes = [
   {
     path: 'connexion',
     title: 'Connexion | KRAAK',
+    data: { seo: signInSeo },
     canMatch: [participantAreaCanMatch],
     loadComponent: () => import('./features/auth/sign-in.page'),
   },
   {
     path: 'inscription',
     title: 'Inscription | KRAAK',
+    data: { seo: signUpSeo },
     canMatch: [participantAreaCanMatch],
     loadComponent: () => import('./features/auth/sign-up.page'),
   },
   {
     path: 'mot-de-passe-oublie',
     title: 'Mot de passe oublié | KRAAK',
+    data: { seo: passwordResetSeo },
     canMatch: [participantAreaCanMatch],
     loadComponent: () => import('./features/auth/password-reset.page'),
   },
   {
     path: 'participant',
+    data: { seo: participantDashboardSeo },
     canMatch: [participantAreaCanMatch],
     canActivate: [participantRoleGuard],
     canActivateChild: [participantRoleChildGuard],

--- a/apps/client/projects/web/src/app/seo/seo.service.spec.ts
+++ b/apps/client/projects/web/src/app/seo/seo.service.spec.ts
@@ -1,7 +1,7 @@
 import { Meta, Title } from '@angular/platform-browser';
 import { TestBed } from '@angular/core/testing';
 
-import { findSeoPageByPath } from './site-seo';
+import { SeoPageDefinition, findSeoPageByPath } from './site-seo';
 import { SeoService } from './seo.service';
 
 const LOCAL_BASE_URL = 'http://localhost:4200';
@@ -81,6 +81,34 @@ describe('SeoService', () => {
     expect(
       document.querySelector('link[rel="canonical"]')?.getAttribute('href'),
     ).toBe(LOCAL_HOME_URL);
+  });
+
+  it('Given a page-specific robots directive, when applyPageSeo is called, then robots meta uses the page value', () => {
+    const service = TestBed.inject(SeoService);
+    const meta = TestBed.inject(Meta);
+    const resetPageSeo: SeoPageDefinition = {
+      path: 'auth/reset',
+      title: 'Finaliser la réinitialisation | KRAAK Consulting',
+      description:
+        'Définissez un nouveau mot de passe pour sécuriser votre accès à l’espace KRAAK.',
+      robots: 'noindex, nofollow',
+      openGraph: {
+        title: 'Finaliser la réinitialisation | KRAAK Consulting',
+        description:
+          'Définissez un nouveau mot de passe pour sécuriser votre accès à l’espace KRAAK.',
+        imagePath: '/assets/site-visuals/photos/home-hero-workshop.jpg',
+        imageAlt:
+          "Photo d'un atelier KRAAK Consulting avec des participants en session de travail.",
+      },
+      sitemap: {
+        changeFrequency: 'never',
+        priority: 0.1,
+      },
+    };
+
+    service.applyPageSeo(resetPageSeo, LOCAL_BASE_URL);
+
+    expect(meta.getTag('name="robots"')?.content).toBe('noindex, nofollow');
   });
 
   // Given the canonical link already exists in the document head

--- a/apps/client/projects/web/src/app/seo/seo.service.ts
+++ b/apps/client/projects/web/src/app/seo/seo.service.ts
@@ -31,7 +31,7 @@ export class SeoService {
     });
     this.meta.updateTag({
       name: 'robots',
-      content: seoDefaults.robots,
+      content: page.robots ?? seoDefaults.robots,
     });
     this.meta.updateTag({
       property: 'og:title',

--- a/apps/client/projects/web/src/app/seo/site-seo.json
+++ b/apps/client/projects/web/src/app/seo/site-seo.json
@@ -148,5 +148,21 @@
       "changeFrequency": "yearly",
       "priority": 0.2
     }
+  },
+  {
+    "path": "auth/reset",
+    "title": "Finaliser la r\u00e9initialisation | KRAAK Consulting",
+    "description": "D\u00e9finissez un nouveau mot de passe pour s\u00e9curiser votre acc\u00e8s \u00e0 l'espace KRAAK.",
+    "robots": "noindex, nofollow",
+    "openGraph": {
+      "title": "Finaliser la r\u00e9initialisation | KRAAK Consulting",
+      "description": "D\u00e9finissez un nouveau mot de passe pour s\u00e9curiser votre acc\u00e8s \u00e0 l'espace KRAAK.",
+      "imagePath": "/assets/site-visuals/photos/home-hero-workshop.jpg",
+      "imageAlt": "Photo d'un atelier KRAAK Consulting avec des participants en session de travail."
+    },
+    "sitemap": {
+      "changeFrequency": "never",
+      "priority": 0.1
+    }
   }
 ]

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -29,7 +29,7 @@ describe('site-seo', () => {
     ]);
   });
 
-  it('should build an XML sitemap with absolute URLs for every public page', () => {
+  it('should build an XML sitemap with absolute URLs for indexable public pages only', () => {
     const sitemap = buildSitemapXml(DEFAULT_SITE_URL);
 
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/</loc>`);

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -25,6 +25,7 @@ describe('site-seo', () => {
       'faq',
       'mentions-legales',
       'politique-de-confidentialite',
+      'auth/reset',
     ]);
   });
 
@@ -47,6 +48,7 @@ describe('site-seo', () => {
     );
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/ressources</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/contact</loc>`);
+    expect(sitemap).not.toContain(`<loc>${DEFAULT_SITE_URL}/auth/reset</loc>`);
   });
 
   it('should build robots.txt pointing crawlers to the sitemap', () => {

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -15,6 +15,7 @@ export interface SeoPageDefinition {
   path: string;
   title: string;
   description: string;
+  robots?: string;
   openGraph: {
     title: string;
     description: string;
@@ -96,9 +97,12 @@ export const findSeoPageByPath = (
   );
 };
 
+const isIndexablePage = (page: SeoPageDefinition): boolean =>
+  !(page.robots ?? '').toLowerCase().includes('noindex');
+
 export const buildSitemapXml = (siteUrl: string): string => {
   const normalizedSiteUrl = resolvePublicSiteUrl(siteUrl);
-  const urls = [...seoPages, ...blogSitemapPages]
+  const urls = [...seoPages.filter(isIndexablePage), ...blogSitemapPages]
     .map(
       (page) => `  <url>
     <loc>${buildAbsoluteUrl(page.path, normalizedSiteUrl)}</loc>

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -67,6 +67,9 @@ const buildAbsoluteUrl = (path, siteUrl) => {
   return new URL(pathname, `${normalizeSiteUrl(siteUrl)}/`).toString();
 };
 
+const isIndexablePage = (page) =>
+  !`${page.robots ?? ''}`.toLowerCase().includes('noindex');
+
 const buildSitemapXml = (pages, siteUrl) => {
   const urls = pages
     .map(
@@ -97,7 +100,7 @@ const main = async () => {
   const rawBlogSitemapConfig = await readFile(blogSitemapSourcePath, 'utf8');
   const seoPages = JSON.parse(rawSeoConfig);
   const blogSitemapPages = JSON.parse(rawBlogSitemapConfig);
-  const sitemapPages = [...seoPages, ...blogSitemapPages];
+  const sitemapPages = [...seoPages.filter(isIndexablePage), ...blogSitemapPages];
   const siteUrl = normalizeSiteUrl(
     process.env['PUBLIC_SITE_URL'] || defaultSiteUrl,
   );


### PR DESCRIPTION
# Pull Request

## Resume

- prerender de `/auth/reset` maintenu dans la surface marketing
- alignement complet SEO pour exclure les pages `noindex` du sitemap **et** appliquer correctement `robots` dans les meta tags
- correction du fallback Sonar local pour que les variables du shell priment sur `.env.local`
- corrections ciblées de documentation et libellés de tests associés

## Pourquoi

La PR ne se limite plus au prerender de `/auth/reset` et au filtrage sitemap : elle corrige aussi une régression SEO sur l’application des directives `robots` et ajuste le comportement du runner Sonar local afin d’éviter qu’un `.env.local` écrase des variables shell explicites.

## Type de changement

- [x] bug
- [ ] amelioration
- [ ] contenu
- [ ] design
- [x] maintenance

## Checklist

- [ ] Tache liée a une issue
- [x] Portée MVP respectée
- [x] Tests RED -> GREEN -> REFACTOR appliques (si code)
- [x] Evidence de validation ajoutée (tests/captures)
- [x] Documentation mise a jour si nécessaire
- [x] Aucun secret/variable sensible commit

## Validation

- [x] Tests unitaires
- [ ] Tests integration
- [ ] Tests E2E/smoke
- [x] Verification manuelle

## Captures / preuves

- `node --test ./scripts/sonarcloud-scan.test.mjs`
- `corepack pnpm --filter @kraak/contracts build`
- `corepack pnpm --filter @kraak/domain build`
- `corepack pnpm --dir apps/client test:web`
- `corepack pnpm --dir apps/client exec eslint projects/web/src/app/seo/seo.service.ts projects/web/src/app/seo/seo.service.spec.ts projects/web/src/app/seo/site-seo.spec.ts`
- validation finale Copilot : Code Review OK, CodeQL OK