### PR TITLE
test(repo): finalize sonar coverage specs and admin fetch mocks

### DIFF
--- a/apps/api/src/announcements/announcements.service.spec.ts
+++ b/apps/api/src/announcements/announcements.service.spec.ts
@@ -117,6 +117,59 @@ describe('AnnouncementsService', () => {
   });
 
   describe('listAnnouncements', () => {
+    it('Given no access token, When public announcements are listed, Then mapped results are returned', async () => {
+      const announcementsQuery = createAsyncQuery(
+        {
+          data: [
+            {
+              id: mockAnnouncement.id,
+              title: mockAnnouncement.title,
+              body: mockAnnouncement.body,
+              priority: mockAnnouncement.priority,
+              audience_type: mockAnnouncement.audienceType,
+              program_id: mockAnnouncement.programId,
+              cohort_id: mockAnnouncement.cohortId,
+              status: mockAnnouncement.status,
+              published_at: mockAnnouncement.publishedAt,
+              created_by_user_id: mockAnnouncement.createdByUserId,
+              created_at: mockAnnouncement.createdAt,
+              updated_at: mockAnnouncement.updatedAt,
+            },
+            {
+              id: mockProgramAnnouncement.id,
+              title: mockProgramAnnouncement.title,
+              body: mockProgramAnnouncement.body,
+              priority: mockProgramAnnouncement.priority,
+              audience_type: mockProgramAnnouncement.audienceType,
+              program_id: mockProgramAnnouncement.programId,
+              cohort_id: mockProgramAnnouncement.cohortId,
+              status: mockProgramAnnouncement.status,
+              published_at: mockProgramAnnouncement.publishedAt,
+              created_by_user_id: mockProgramAnnouncement.createdByUserId,
+              created_at: mockProgramAnnouncement.createdAt,
+              updated_at: mockProgramAnnouncement.updatedAt,
+            },
+          ],
+          error: null,
+        },
+        { withOrder: true },
+      );
+
+      mockSupabaseService.getClient.mockReturnValue(
+        createClientMock({
+          announcement: announcementsQuery,
+        }),
+      );
+
+      const result = await service.listAnnouncements(undefined, 1, 20);
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).toEqual(
+        expect.objectContaining({ id: mockAnnouncement.id }),
+      );
+    });
+
     it('Given: valid access token and enrolled participant, When: listAnnouncements called, Then: return filtered announcements', async () => {
       const accessToken = 'valid-token';
       const participantId = 'participant-001';

--- a/apps/api/src/cms/cms.dto.spec.ts
+++ b/apps/api/src/cms/cms.dto.spec.ts
@@ -130,6 +130,27 @@ describe('cms.dto validators', () => {
     });
   });
 
+  it('Given sortOrder as a numeric string When create statistic is validated Then sortOrder is parsed as an integer', () => {
+    const result = validateCreateStatisticPayload({
+      label: 'Apprenants',
+      value: '120',
+      suffix: null,
+      sortOrder: '7',
+      status: 'published',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      data: {
+        label: 'Apprenants',
+        value: '120',
+        suffix: null,
+        sortOrder: 7,
+        status: 'published',
+      },
+    });
+  });
+
   it('rejects invalid update partner url', () => {
     const result = validateUpdatePartnerPayload({ logoUrl: 'x' });
 

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -128,4 +128,18 @@ describe('UsersController', () => {
       ).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe('remove', () => {
+    it('Given a valid admin token, When remove is called, Then the user is deleted', async () => {
+      mockRemove.mockResolvedValueOnce(undefined);
+
+      await controller.remove('1', validToken);
+
+      expect(mockRequireAdminAccess).toHaveBeenCalledWith(
+        mockAuthService,
+        validToken,
+      );
+      expect(mockRemove).toHaveBeenCalledWith('1');
+    });
+  });
 });

--- a/apps/api/src/users/users.module.spec.ts
+++ b/apps/api/src/users/users.module.spec.ts
@@ -1,0 +1,28 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { AuthModule } from '../auth/auth.module';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { UsersController } from './users.controller';
+import { UsersModule } from './users.module';
+import { UsersService } from './users.service';
+
+describe('UsersModule', () => {
+  it('Given module metadata When inspected Then users dependencies are wired', () => {
+    const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, UsersModule);
+    const controllers = Reflect.getMetadata(
+      MODULE_METADATA.CONTROLLERS,
+      UsersModule,
+    );
+    const providers = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      UsersModule,
+    );
+    const exports = Reflect.getMetadata(MODULE_METADATA.EXPORTS, UsersModule);
+
+    expect(imports).toEqual(
+      expect.arrayContaining([AuthModule, SupabaseModule]),
+    );
+    expect(controllers).toEqual(expect.arrayContaining([UsersController]));
+    expect(providers).toEqual(expect.arrayContaining([UsersService]));
+    expect(exports).toEqual(expect.arrayContaining([UsersService]));
+  });
+});

--- a/apps/client/projects/web/src/app/core/animations/gsap-animations.service.spec.ts
+++ b/apps/client/projects/web/src/app/core/animations/gsap-animations.service.spec.ts
@@ -19,6 +19,27 @@ function mockReducedMotion(matches: boolean): void {
   );
 }
 
+function allowAnimations(): void {
+  mockReducedMotion(false);
+}
+
+function mockGsapEffects() {
+  const fromSpy = vi.spyOn(gsap, 'from').mockReturnValue({} as gsap.core.Tween);
+  const toSpy = vi.spyOn(gsap, 'to').mockImplementation((_target, vars) => {
+    (vars as { onComplete?: () => void } | undefined)?.onComplete?.();
+    return {} as gsap.core.Tween;
+  });
+  const killTweensSpy = vi
+    .spyOn(gsap, 'killTweensOf')
+    .mockReturnValue(undefined);
+
+  return { fromSpy, toSpy, killTweensSpy };
+}
+
+function setReducedMotionPreference(): void {
+  mockReducedMotion(true);
+}
+
 describe('GsapAnimationsService', () => {
   let service: GsapAnimationsService;
 
@@ -31,8 +52,12 @@ describe('GsapAnimationsService', () => {
   });
 
   afterEach(() => {
-    service.killAllAnimations();
+    service?.killAllAnimations();
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML = '';
+    }
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('should be created', () => {
@@ -40,6 +65,18 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializeFigureAnimations', () => {
+    it('Given document is unavailable, When animations initialize, Then execution exits safely', () => {
+      vi.stubGlobal('document', undefined);
+
+      expect(() => service.initializeFigureAnimations()).not.toThrow();
+    });
+
+    it('Given matchMedia is unavailable, When animations initialize, Then browser defaults allow animation setup', () => {
+      vi.stubGlobal('matchMedia', undefined);
+
+      expect(() => service.initializeFigureAnimations()).not.toThrow();
+    });
+
     it('Given reduced motion is enabled, When figure animations initialize, Then no transform is applied', () => {
       mockReducedMotion(true);
 
@@ -102,6 +139,21 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializeInteractiveCardAnimations', () => {
+    it('Given card hover events, When mouseenter and mouseleave are dispatched, Then gsap receives both transitions', () => {
+      allowAnimations();
+      const { toSpy } = mockGsapEffects();
+
+      const article = document.createElement('article');
+      document.body.appendChild(article);
+
+      service.initializeInteractiveCardAnimations();
+      article.dispatchEvent(new Event('mouseenter'));
+      article.dispatchEvent(new Event('mouseleave'));
+
+      expect(toSpy).toHaveBeenCalledTimes(2);
+      article.remove();
+    });
+
     it('should handle selector when articles exist', () => {
       // Arrange: Create article element
       const div = document.createElement('div');
@@ -129,6 +181,23 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializePageEntranceAnimations', () => {
+    it('Given a first section and headings, When page entrance initializes, Then hero and heading animations are triggered', () => {
+      allowAnimations();
+      const { fromSpy } = mockGsapEffects();
+
+      const section = document.createElement('section');
+      const heading = document.createElement('h1');
+      const subHeading = document.createElement('h2');
+      document.body.append(section, heading, subHeading);
+
+      service.initializePageEntranceAnimations();
+
+      expect(fromSpy).toHaveBeenCalledTimes(2);
+      section.remove();
+      heading.remove();
+      subHeading.remove();
+    });
+
     it('should initialize page entrance animations', () => {
       // Act: Initialize page entrance
       service.initializePageEntranceAnimations();
@@ -193,6 +262,24 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializeButtonTransitions', () => {
+    it('Given button interaction events, When hover and click events are dispatched, Then tween updates are requested', () => {
+      allowAnimations();
+      const { killTweensSpy, toSpy } = mockGsapEffects();
+
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+
+      service.initializeButtonTransitions();
+      button.dispatchEvent(new Event('mouseenter'));
+      button.dispatchEvent(new Event('mouseleave'));
+      button.dispatchEvent(new Event('mousedown'));
+      button.dispatchEvent(new Event('mouseup'));
+
+      expect(killTweensSpy).toHaveBeenCalledTimes(2);
+      expect(toSpy).toHaveBeenCalledTimes(4);
+      button.remove();
+    });
+
     it('should handle button animations', () => {
       // Arrange: Create button
       const button = document.createElement('button');
@@ -230,6 +317,21 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializeFormFieldAnimations', () => {
+    it('Given focus transitions, When focus and blur events are dispatched, Then form field tweens are requested', () => {
+      allowAnimations();
+      const { toSpy } = mockGsapEffects();
+
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+
+      service.initializeFormFieldAnimations();
+      input.dispatchEvent(new Event('focus'));
+      input.dispatchEvent(new Event('blur'));
+
+      expect(toSpy).toHaveBeenCalledTimes(2);
+      input.remove();
+    });
+
     it('should handle form field animations', () => {
       // Arrange: Create input
       const input = document.createElement('input');
@@ -263,6 +365,9 @@ describe('GsapAnimationsService', () => {
 
   describe('initializeListItemAnimations', () => {
     it('should handle list item animations', () => {
+      allowAnimations();
+      const { fromSpy } = mockGsapEffects();
+
       // Arrange: Create list items
       const li = document.createElement('li');
       document.body.appendChild(li);
@@ -271,7 +376,7 @@ describe('GsapAnimationsService', () => {
       service.initializeListItemAnimations();
 
       // Assert: Service executes without error
-      expect(service).toBeTruthy();
+      expect(fromSpy).toHaveBeenCalledTimes(1);
 
       // Cleanup
       li.remove();
@@ -297,6 +402,9 @@ describe('GsapAnimationsService', () => {
 
   describe('initializeTextRevealAnimations', () => {
     it('should handle text reveal animations', () => {
+      allowAnimations();
+      const { fromSpy } = mockGsapEffects();
+
       // Arrange: Create paragraph
       const p = document.createElement('p');
       p.textContent = 'Test text';
@@ -306,7 +414,7 @@ describe('GsapAnimationsService', () => {
       service.initializeTextRevealAnimations();
 
       // Assert: Service executes without error
-      expect(service).toBeTruthy();
+      expect(fromSpy).toHaveBeenCalledTimes(1);
 
       // Cleanup
       p.remove();
@@ -328,6 +436,21 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializeIconAnimations', () => {
+    it('Given icon hover events, When mouseenter and mouseleave are dispatched, Then icon animation tweens are requested', () => {
+      allowAnimations();
+      const { toSpy } = mockGsapEffects();
+
+      const svg = document.createElement('svg');
+      document.body.appendChild(svg);
+
+      service.initializeIconAnimations();
+      svg.dispatchEvent(new Event('mouseenter'));
+      svg.dispatchEvent(new Event('mouseleave'));
+
+      expect(toSpy).toHaveBeenCalledTimes(2);
+      svg.remove();
+    });
+
     it('should handle icon animations', () => {
       // Arrange: Create SVG icon
       const svg = document.createElement('svg');
@@ -374,10 +497,28 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('createPageTransition', () => {
-    it('should create a page transition promise', async () => {
-      // Act & Assert
+    it('should create a page transition promise when main exists', async () => {
+      allowAnimations();
+      const { toSpy } = mockGsapEffects();
+      const main = document.createElement('main');
+      document.body.appendChild(main);
+
       const promise = service.createPageTransition();
+
       await expect(promise).resolves.toBeUndefined();
+      expect(toSpy).toHaveBeenCalledWith(
+        main,
+        expect.objectContaining({ opacity: 0 }),
+      );
+
+      main.remove();
+    });
+
+    it('should resolve immediately when main is absent', async () => {
+      allowAnimations();
+      mockGsapEffects();
+
+      await expect(service.createPageTransition()).resolves.toBeUndefined();
     });
 
     it('Given a page main element, When a transition starts, Then GSAP fade-out resolves on completion', async () => {
@@ -413,6 +554,22 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('animatePageIn', () => {
+    it('Given a main element exists, When animatePageIn runs, Then gsap.from animates the main container', () => {
+      allowAnimations();
+      const { fromSpy } = mockGsapEffects();
+
+      const main = document.createElement('main');
+      document.body.appendChild(main);
+
+      service.animatePageIn();
+
+      expect(fromSpy).toHaveBeenCalledWith(
+        main,
+        expect.objectContaining({ opacity: 0 }),
+      );
+      main.remove();
+    });
+
     it('should animate page entrance', () => {
       // Act: Animate page in
       service.animatePageIn();
@@ -436,6 +593,9 @@ describe('GsapAnimationsService', () => {
 
   describe('initializeSectionAnimations', () => {
     it('should handle section animations', () => {
+      allowAnimations();
+      const { fromSpy } = mockGsapEffects();
+
       // Arrange: Create section
       const section = document.createElement('section');
       document.body.appendChild(section);
@@ -444,7 +604,7 @@ describe('GsapAnimationsService', () => {
       service.initializeSectionAnimations();
 
       // Assert: Service executes without error
-      expect(service).toBeTruthy();
+      expect(fromSpy).toHaveBeenCalledTimes(1);
 
       // Cleanup
       section.remove();
@@ -482,6 +642,9 @@ describe('GsapAnimationsService', () => {
 
   describe('initializeBadgeAnimations', () => {
     it('should handle badge animations', () => {
+      allowAnimations();
+      const { fromSpy, toSpy } = mockGsapEffects();
+
       // Arrange: Create badge
       const badge = document.createElement('span');
       badge.classList.add('badge');
@@ -491,7 +654,8 @@ describe('GsapAnimationsService', () => {
       service.initializeBadgeAnimations();
 
       // Assert: Service executes without error
-      expect(service).toBeTruthy();
+      expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(toSpy).toHaveBeenCalledTimes(1);
 
       // Cleanup
       badge.remove();
@@ -514,6 +678,21 @@ describe('GsapAnimationsService', () => {
   });
 
   describe('initializeMouseFollowAnimations', () => {
+    it('Given interactive element hover events, When mouseenter and mouseleave are dispatched, Then brightness tween is requested', () => {
+      allowAnimations();
+      const { toSpy } = mockGsapEffects();
+
+      const link = document.createElement('a');
+      document.body.appendChild(link);
+
+      service.initializeMouseFollowAnimations();
+      link.dispatchEvent(new Event('mouseenter'));
+      link.dispatchEvent(new Event('mouseleave'));
+
+      expect(toSpy).toHaveBeenCalledTimes(2);
+      link.remove();
+    });
+
     it('should handle mouse follow animations', () => {
       // Arrange: Create interactive element
       const link = document.createElement('a');
@@ -547,6 +726,9 @@ describe('GsapAnimationsService', () => {
 
   describe('initializeImageParallaxAnimations', () => {
     it('should handle image parallax animations', () => {
+      allowAnimations();
+      const { fromSpy, toSpy } = mockGsapEffects();
+
       // Arrange: Create image
       const img = document.createElement('img');
       img.src = 'test.jpg';
@@ -556,7 +738,8 @@ describe('GsapAnimationsService', () => {
       service.initializeImageParallaxAnimations();
 
       // Assert: Service executes without error
-      expect(service).toBeTruthy();
+      expect(fromSpy).toHaveBeenCalledTimes(1);
+      expect(toSpy).toHaveBeenCalledTimes(1);
 
       // Cleanup
       img.remove();
@@ -575,6 +758,31 @@ describe('GsapAnimationsService', () => {
       expect(toSpy).toHaveBeenCalled();
 
       img.remove();
+    });
+  });
+
+  describe('reduced motion guards', () => {
+    it('Given reduced motion is enabled, When guarded methods are called, Then all related animations are skipped safely', async () => {
+      setReducedMotionPreference();
+      const { fromSpy, toSpy, killTweensSpy } = mockGsapEffects();
+
+      service.initializeInteractiveCardAnimations();
+      service.initializePageEntranceAnimations();
+      service.initializeButtonTransitions();
+      service.initializeFormFieldAnimations();
+      service.initializeListItemAnimations();
+      service.initializeTextRevealAnimations();
+      service.initializeIconAnimations();
+      await expect(service.createPageTransition()).resolves.toBeUndefined();
+      service.animatePageIn();
+      service.initializeSectionAnimations();
+      service.initializeBadgeAnimations();
+      service.initializeMouseFollowAnimations();
+      service.initializeImageParallaxAnimations();
+
+      expect(fromSpy).not.toHaveBeenCalled();
+      expect(toSpy).not.toHaveBeenCalled();
+      expect(killTweensSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/programmes/admin-programmes.page.spec.ts
@@ -337,6 +337,45 @@ describe('AdminProgrammesPage', () => {
     expect(fixture.componentInstance['successMessage']()).toContain('supprimé');
   });
 
+  it('Given a deletion API failure When deleteProgramme is called Then an explicit error is shown', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+
+    fixture.componentInstance.programsClient = {
+      ...programsClientMock,
+      remove: vi.fn(async () => {
+        throw new Error('delete failed');
+      }),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance.deleteProgramme(mockProgrammes[0]);
+
+    expect(fixture.componentInstance['errorMessage']()).toContain('supprimer');
+  });
+
+  it('Given an authenticated admin session When default programmes client is used Then the token supplier is consumed', async () => {
+    const fixture = TestBed.createComponent(AdminProgrammesPage);
+    webAuthServiceMock.currentSession = signal({
+      accessToken: 'admin-token',
+    } as never);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await fixture.componentInstance.programsClient.list();
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
   it('Given an API load failure When the page initializes Then an explicit loading error is shown', async () => {
     const fixture = TestBed.createComponent(AdminProgrammesPage);
 

--- a/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/admin/ressources/admin-ressources.page.spec.ts
@@ -358,6 +358,45 @@ describe('AdminRessourcesPage', () => {
     );
   });
 
+  it('Given a deletion API failure When deleteRessource is called Then an explicit error is shown', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+
+    fixture.componentInstance.resourcesClient = {
+      ...resourcesClientMock,
+      remove: vi.fn(async () => {
+        throw new Error('delete failed');
+      }),
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance.deleteRessource(mockRessources[0]);
+
+    expect(fixture.componentInstance['errorMessage']()).toContain('supprimer');
+  });
+
+  it('Given an authenticated admin session When default resources client is used Then the token supplier is consumed', async () => {
+    const fixture = TestBed.createComponent(AdminRessourcesPage);
+    webAuthServiceMock.currentSession = signal({
+      accessToken: 'admin-token',
+    } as never);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [], total: 0 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await fixture.componentInstance.resourcesClient.list();
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
   it('Given a loading failure When the page initializes Then the load error is exposed', async () => {
     const fixture = TestBed.createComponent(AdminRessourcesPage);
 

--- a/apps/client/projects/web/src/app/features/auth/auth-reset.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/auth/auth-reset.page.spec.ts
@@ -86,6 +86,22 @@ describe('Web AuthResetPage', () => {
     expect(fixture.componentInstance.errorMessage()).toContain('identiques');
   });
 
+  it('Given a submit is already in progress, when submit is called, then recovery completion is not requested again', async () => {
+    const fixture = TestBed.createComponent(AuthResetPage);
+    fixture.componentInstance.ngOnInit();
+    await flushPromises();
+
+    fixture.componentInstance.form.setValue({
+      password: 'NouveauMotDePasse123!',
+      confirmPassword: 'NouveauMotDePasse123!',
+    });
+    fixture.componentInstance.submitting.set(true);
+
+    await fixture.componentInstance.submit();
+
+    expect(authService.completePasswordRecovery).not.toHaveBeenCalled();
+  });
+
   it('Given no recovery token in URL, when ngOnInit is called, then an invalid-link error is shown and tokenReady is true', async () => {
     authService.resolveRecoveryAccessTokenFromUrl.mockResolvedValueOnce(null);
     const fixture = TestBed.createComponent(AuthResetPage);

--- a/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
+++ b/apps/client/projects/web/src/app/features/blog/blog-public.service.spec.ts
@@ -115,4 +115,43 @@ describe('BlogPublicService', () => {
     httpController.verify();
     expect(received).toBeNull();
   });
+
+  it('Given a slug with leading and trailing slashes, When loading by slug, Then the API path is normalized before request', () => {
+    const service = TestBed.inject(BlogPublicService);
+    const httpController = TestBed.inject(HttpTestingController);
+
+    let receivedSlug = '';
+
+    service
+      .getPublishedArticleBySlug('///article-api///')
+      .subscribe((article) => {
+        receivedSlug = article?.slug ?? '';
+      });
+
+    const request = httpController.expectOne(
+      'http://localhost:3000/articles/article-api',
+    );
+    expect(request.request.method).toBe('GET');
+
+    request.flush({
+      id: 'article-1',
+      slug: 'article-api',
+      title: 'Article API',
+      excerpt: 'Résumé API',
+      content: '<p>Contenu</p>',
+      status: 'published',
+      coverImageUrl: null,
+      seoTitle: null,
+      seoDescription: null,
+      publishedAt: '2026-05-24T09:00:00.000Z',
+      authorId: 'author-1',
+      categoryIds: [],
+      tagIds: [],
+      createdAt: '2026-05-24T09:00:00.000Z',
+      updatedAt: '2026-05-24T09:00:00.000Z',
+    });
+
+    httpController.verify();
+    expect(receivedSlug).toBe('article-api');
+  });
 });

--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -307,6 +307,22 @@ describe('ContactPage', () => {
     );
   });
 
+  it('Given an unknown service type, When selection fallback is resolved, Then the default other option is used', () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as {
+      form: { patchValue: (value: { serviceType: string }) => void };
+      getSelectedServiceOption: () => { value: string; category: string };
+    };
+
+    component.form.patchValue({ serviceType: 'inexistant' });
+    const selected = component.getSelectedServiceOption();
+
+    expect(selected.value).toBe('other');
+    expect(selected.category).toBe('other');
+  });
+
   // Given l'\u00E9tat initial de chargement
   // When le composant est cr\u00E9\u00E9
   // Then loading doit \u00EAtre false
@@ -578,5 +594,41 @@ describe('ContactPage', () => {
       'Une erreur est survenue. Veuillez réessayer plus tard.',
     ]);
     expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("Given un formulaire valide When l'API renvoie un message texte Then ce message est affiche apres trim", () => {
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      name: 'Alice Dupont',
+      email: 'alice@exemple.com',
+      subject: 'Obtenir un accompagnement',
+      country: 'Côte d’Ivoire',
+      serviceType: 'formation',
+      message: 'Bonjour, je voudrais en savoir plus sur vos programmes.',
+    });
+
+    component.onSubmit();
+
+    const request = httpTestingController.expectOne((req) =>
+      req.url.endsWith('/contact'),
+    );
+    request.flush(
+      { message: '  Le service est temporairement indisponible.  ' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+
+    fixture.detectChanges();
+
+    expect(component.success()).toBe(false);
+    expect(component.loading()).toBe(false);
+    expect(component.apiErrors()).toEqual([
+      'Le service est temporairement indisponible.',
+    ]);
+    expect(fixture.nativeElement.textContent).toContain(
+      'Le service est temporairement indisponible.',
+    );
   });
 });

--- a/apps/client/projects/web/src/ssr-path.spec.ts
+++ b/apps/client/projects/web/src/ssr-path.spec.ts
@@ -29,6 +29,19 @@ describe('Given the web SSR prerender lookup', () => {
     expect(fileExists).not.toHaveBeenCalled();
   });
 
+  it('When the browser dist and route have extra separators, Then the normalized index path is returned', () => {
+    const fileExists = vi.fn(() => true);
+
+    const prerenderedHtmlPath = buildPrerenderedHtmlPath(
+      '/',
+      '/app/browser///',
+      fileExists,
+    );
+
+    expect(prerenderedHtmlPath).toBe('/app/browser/index.html');
+    expect(fileExists).toHaveBeenCalledWith('/app/browser/index.html');
+  });
+
   it('When the root route is provided and no fileExists callback is given, Then index.html path is returned by default', () => {
     const prerenderedHtmlPath = buildPrerenderedHtmlPath('/', '/app/browser');
 
@@ -56,6 +69,19 @@ describe('Given the web SSR prerender lookup', () => {
     );
 
     expect(prerenderedHtmlPath).toBe('C:/dist/browser/services/index.html');
+  });
+
+  it('When the route has trailing slashes, Then the route segment is trimmed before building the index path', () => {
+    const fileExists = vi.fn(() => true);
+
+    const prerenderedHtmlPath = buildPrerenderedHtmlPath(
+      '/a-propos///',
+      '/app/browser',
+      fileExists,
+    );
+
+    expect(prerenderedHtmlPath).toBe('/app/browser/a-propos/index.html');
+    expect(fileExists).toHaveBeenCalledWith('/app/browser/a-propos/index.html');
   });
 
   it('When a route contains backslashes, Then the lookup is rejected as unsafe', () => {


### PR DESCRIPTION
## Summary

Implements PRG-04 minimal progression marking for participant programs.

## Changes

- **Domain rules (`packages/domain`)**
  - Added minimal progression engine (`progress.ts`) with session eligibility checks, marker updates, and derived progress computation.
  - Added dedicated unit tests (`progress.spec.ts`).

- **Shared contracts (`packages/contracts`)**
  - Added progression DTOs and payloads:
    - `ProgramProgressDto`
    - `MarkProgramSessionProgressRequestDto`
    - `MarkProgramSessionProgressResponseDto`
  - Extended participant program list/detail DTOs with `progress`.
  - Added enum `ProgramProgressStatus`.

- **API (`apps/api`)**
  - Added payload validation in `programs.dto.ts` (+ tests).
  - Added endpoint `POST /programs/:programId/progress` with Swagger docs.
  - Implemented persistence and restitution of progression in `ProgramsService`.
  - Auto-completes enrollment status when all visible sessions are marked completed.

- **Mobile (`apps/client/projects/mobile`)**
  - Added service method `markSessionProgress(programId, sessionId, completed)`.
  - Added session-level action buttons to mark/unmark completion.
  - Added progression display in program list/detail pages.
  - Updated/extended related specs.

- **Data model / migration**
  - Added migration `20260429110000_add_enrollment_progress_markers.sql`:
    - `enrollment.progress_completed_session_ids`
    - `enrollment.progress_updated_at`
  - Updated product model doc to keep enrollment fields aligned.

## Related

Closes #97
Depends on: PRG-02, LIB-02

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] API + shared domain/contracts + mobile MVP functionality

## Testing

- `pnpm --filter @kraak/contracts test`
- `pnpm --filter @kraak/domain test`
- `pnpm --filter @kraak/api-client test`
- `pnpm --filter @kraak/api test -- programs`
- `pnpm --filter @kraak/client test:mobile`
