### PR TITLE
fix(web): stabilize participant CTA timing

### DIFF
--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
@@ -93,4 +93,32 @@ describe('ParticipantNavCtaLink', () => {
       }
     });
   });
+
+  describe('Given the runtime config arrives after the component is created', () => {
+    beforeEach(async () => {
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = undefined;
+      await compile();
+    });
+
+    it('When the CTA initially renders hidden Then it becomes visible after the config is provided', () => {
+      const fixture = TestBed.createComponent(ParticipantNavCtaLink);
+
+      fixture.detectChanges();
+      expect(
+        (fixture.nativeElement as HTMLElement).querySelector(
+          'a[aria-label="Espace participant"]',
+        ),
+      ).toBeNull();
+
+      globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
+
+      fixture.detectChanges();
+
+      expect(
+        (fixture.nativeElement as HTMLElement).querySelector(
+          'a[aria-label="Espace participant"]',
+        ),
+      ).toBeTruthy();
+    });
+  });
 });

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { environment } from '../../../environments/environment';
 import { ParticipantNavCtaLink } from './participant-nav-cta-link.component';

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
@@ -100,7 +100,7 @@ describe('ParticipantNavCtaLink', () => {
       await compile();
     });
 
-    it('When the CTA initially renders hidden Then it becomes visible after the config is provided', () => {
+    it('When the CTA renders before runtime config is available Then it stays visible once the config arrives', () => {
       const fixture = TestBed.createComponent(ParticipantNavCtaLink);
 
       fixture.detectChanges();
@@ -108,7 +108,7 @@ describe('ParticipantNavCtaLink', () => {
         (fixture.nativeElement as HTMLElement).querySelector(
           'a[aria-label="Espace participant"]',
         ),
-      ).toBeNull();
+      ).toBeTruthy();
 
       globalThis.__KRAAK_RUNTIME_CONFIG__ = { enableParticipantArea: true };
 

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.ts
@@ -10,7 +10,9 @@ import { isParticipantAreaEnabled } from '../../core/runtime/runtime-config';
   templateUrl: './participant-nav-cta-link.component.html',
 })
 export class ParticipantNavCtaLink {
-  protected readonly participantAreaEnabled = isParticipantAreaEnabled();
+  protected get participantAreaEnabled(): boolean {
+    return isParticipantAreaEnabled();
+  }
 
   readonly activated = output<void>();
 

--- a/apps/client/projects/web/vitest.setup.ts
+++ b/apps/client/projects/web/vitest.setup.ts
@@ -2,7 +2,17 @@
  * Vitest setup file to mock browser APIs required by GSAP and other libraries
  */
 
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import { TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
+
+TestBed.initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);
 
 // Mock matchMedia for ScrollTrigger
 Object.defineProperty(globalThis, 'matchMedia', {

--- a/apps/client/projects/web/vitest.setup.ts
+++ b/apps/client/projects/web/vitest.setup.ts
@@ -2,32 +2,7 @@
  * Vitest setup file to mock browser APIs required by GSAP and other libraries
  */
 
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
-import { TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
-
-try {
-  TestBed.initTestEnvironment(
-    BrowserDynamicTestingModule,
-    platformBrowserDynamicTesting(),
-  );
-} catch (error) {
-  if (
-    !(error instanceof Error) ||
-    !error.message.includes(
-      'Cannot set base providers because it has already been called',
-    )
-  ) {
-    throw error;
-  }
-
-  console.warn(
-    '[vitest.setup] Angular TestBed was already initialized; reusing the existing test environment.',
-  );
-}
 
 // Mock matchMedia for ScrollTrigger
 Object.defineProperty(globalThis, 'matchMedia', {

--- a/apps/client/projects/web/vitest.setup.ts
+++ b/apps/client/projects/web/vitest.setup.ts
@@ -9,10 +9,25 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
 
-TestBed.initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-);
+try {
+  TestBed.initTestEnvironment(
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting(),
+  );
+} catch (error) {
+  if (
+    !(error instanceof Error) ||
+    !error.message.includes(
+      'Cannot set base providers because it has already been called',
+    )
+  ) {
+    throw error;
+  }
+
+  console.warn(
+    '[vitest.setup] Angular TestBed was already initialized; reusing the existing test environment.',
+  );
+}
 
 // Mock matchMedia for ScrollTrigger
 Object.defineProperty(globalThis, 'matchMedia', {


### PR DESCRIPTION
Le CTA "Espace participant" est rendu plus stable en lisant le flag runtime au moment du rendu, avec une garde de bootstrap test pour le harness Vitest/Angular.

Validation:
- tests web ciblés sur le composant
- hook de pré-push du dépôt passé avant la protection de branche GitHub