### PR TITLE
chore(repo): ignore scannerwork isolated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ tmp/
 
 # SonarQube / SonarLint (cache local, ne pas committer)
 .scannerwork/
+.scannerwork-isolated-*/
 .sonarlint/connectedMode.local.json
 
 


### PR DESCRIPTION
Ajout de la règle `.scannerwork-isolated-*/` dans `.gitignore` pour éviter le versionnement des artefacts Sonar isolés.

Contexte:
- le push direct sur `staging` est protégé
- passage par PR requis par la politique de branche