### PR TITLE
fix(client): centralize fallback defaults

### DIFF
--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -16,6 +16,16 @@ CLIENT_SITE_URL=http://localhost:4200
 SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_PUBLISHABLE_KEY=
 
+# URLs publiques de marque et de contact utilisées par le runtime client
+KRAAK_PUBLIC_ASSET_BASE_URL=https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images
+KRAAK_CONTACT_PHONE_E164=+2250502741818
+KRAAK_CONTACT_PHONE_DISPLAY=+225 05 02 74 18 18
+KRAAK_CONTACT_EMAIL=kraakconsulting@gmail.com
+KRAAK_WHATSAPP_CONTACT_HREF=https://wa.me/2250502741818
+KRAAK_FACEBOOK_URL=https://www.facebook.com/kraakconsulting/
+KRAAK_INSTAGRAM_URL=https://www.instagram.com/kraakconsulting/
+KRAAK_TIKTOK_URL=https://www.tiktok.com/@kraakconsulting
+
 # Port du serveur de développement Angular (utilisé par Playwright)
 KRAAK_WEB_PORT=4200
 

--- a/apps/client/projects/shared/runtime-client-config.ts
+++ b/apps/client/projects/shared/runtime-client-config.ts
@@ -1,5 +1,13 @@
 interface RuntimeClientConfig {
   readonly apiBaseUrl: string;
+  readonly publicAssetBaseUrl: string;
+  readonly contactPhoneE164: string;
+  readonly contactPhoneDisplay: string;
+  readonly contactEmail: string;
+  readonly whatsappContactHref: string;
+  readonly facebookUrl: string;
+  readonly instagramUrl: string;
+  readonly tiktokUrl: string;
   readonly siteUrl: string;
   readonly supabaseUrl: string;
   readonly supabasePublishableKey: string;
@@ -7,6 +15,14 @@ interface RuntimeClientConfig {
 
 interface RuntimeConfigSource {
   readonly apiBaseUrl?: string;
+  readonly publicAssetBaseUrl?: string;
+  readonly contactPhoneE164?: string;
+  readonly contactPhoneDisplay?: string;
+  readonly contactEmail?: string;
+  readonly whatsappContactHref?: string;
+  readonly facebookUrl?: string;
+  readonly instagramUrl?: string;
+  readonly tiktokUrl?: string;
   readonly siteUrl?: string;
   readonly supabaseUrl?: string;
   readonly supabasePublishableKey?: string;
@@ -37,6 +53,29 @@ export function resolveRuntimeClientConfig(): RuntimeClientConfig {
     apiBaseUrl:
       runtimeConfig?.apiBaseUrl?.trim() ||
       readProcessEnv('CLIENT_API_BASE_URL'),
+    publicAssetBaseUrl:
+      runtimeConfig?.publicAssetBaseUrl?.trim() ||
+      readProcessEnv('KRAAK_PUBLIC_ASSET_BASE_URL'),
+    contactPhoneE164:
+      runtimeConfig?.contactPhoneE164?.trim() ||
+      readProcessEnv('KRAAK_CONTACT_PHONE_E164'),
+    contactPhoneDisplay:
+      runtimeConfig?.contactPhoneDisplay?.trim() ||
+      readProcessEnv('KRAAK_CONTACT_PHONE_DISPLAY'),
+    contactEmail:
+      runtimeConfig?.contactEmail?.trim() ||
+      readProcessEnv('KRAAK_CONTACT_EMAIL'),
+    whatsappContactHref:
+      runtimeConfig?.whatsappContactHref?.trim() ||
+      readProcessEnv('KRAAK_WHATSAPP_CONTACT_HREF'),
+    facebookUrl:
+      runtimeConfig?.facebookUrl?.trim() ||
+      readProcessEnv('KRAAK_FACEBOOK_URL'),
+    instagramUrl:
+      runtimeConfig?.instagramUrl?.trim() ||
+      readProcessEnv('KRAAK_INSTAGRAM_URL'),
+    tiktokUrl:
+      runtimeConfig?.tiktokUrl?.trim() || readProcessEnv('KRAAK_TIKTOK_URL'),
     siteUrl:
       runtimeConfig?.siteUrl?.trim() ||
       readProcessEnv('PUBLIC_SITE_URL', 'CLIENT_SITE_URL'),

--- a/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
+++ b/apps/client/projects/web/src/app/core/runtime/runtime-config.ts
@@ -2,6 +2,14 @@ import { environment } from '../../../environments/environment';
 
 interface KraakRuntimeConfig {
   readonly apiBaseUrl?: string;
+  readonly publicAssetBaseUrl?: string;
+  readonly contactPhoneE164?: string;
+  readonly contactPhoneDisplay?: string;
+  readonly contactEmail?: string;
+  readonly whatsappContactHref?: string;
+  readonly facebookUrl?: string;
+  readonly instagramUrl?: string;
+  readonly tiktokUrl?: string;
   readonly siteUrl?: string;
   readonly supabaseUrl?: string;
   readonly supabasePublishableKey?: string;

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -1,6 +1,7 @@
 import siteSeoDefinitions from './site-seo.json';
 import blogSitemapDefinitions from './blog-sitemap-pages.json';
 import { resolveSiteUrl } from '../core/runtime/runtime-config';
+import { CLIENT_DEFAULTS } from '../shared/client-defaults';
 
 export type SitemapChangeFrequency =
   | 'always'
@@ -28,10 +29,6 @@ export interface SeoPageDefinition {
   };
 }
 
-const DEFAULT_SITE_URL = 'https://kraak-web-prod.onrender.com';
-const DEFAULT_SITE_NAME = 'KRAAK';
-const DEFAULT_LOCALE = 'fr_FR';
-const DEFAULT_ROBOTS = 'index, follow';
 const runtimeGlobals = globalThis as typeof globalThis & {
   process?: {
     env?: Record<string, string | undefined>;
@@ -60,14 +57,17 @@ const normalizeRoutePath = (path: string): string =>
   trimTrailingSlashes(trimLeadingSlashes(path));
 
 export const normalizeSiteUrl = (siteUrl: string): string =>
-  trimTrailingSlashes(siteUrl) || DEFAULT_SITE_URL;
+  trimTrailingSlashes(siteUrl) || CLIENT_DEFAULTS.siteUrl;
 
 export const resolvePublicSiteUrl = (siteUrl?: string): string => {
   const runtimeSiteUrl = runtimeGlobals.process?.env?.['PUBLIC_SITE_URL'] ?? '';
   const runtimeConfigSiteUrl = resolveSiteUrl('');
 
   return normalizeSiteUrl(
-    runtimeSiteUrl || runtimeConfigSiteUrl || siteUrl || DEFAULT_SITE_URL,
+    runtimeSiteUrl ||
+      runtimeConfigSiteUrl ||
+      siteUrl ||
+      CLIENT_DEFAULTS.siteUrl,
   );
 };
 
@@ -127,7 +127,7 @@ Sitemap: ${buildAbsoluteUrl('sitemap.xml', resolvePublicSiteUrl(siteUrl))}
 `;
 
 export const seoDefaults = {
-  locale: DEFAULT_LOCALE,
-  robots: DEFAULT_ROBOTS,
-  siteName: DEFAULT_SITE_NAME,
+  locale: CLIENT_DEFAULTS.locale,
+  robots: CLIENT_DEFAULTS.robots,
+  siteName: CLIENT_DEFAULTS.siteName,
 };

--- a/apps/client/projects/web/src/app/shared/brand/brand-constants.spec.ts
+++ b/apps/client/projects/web/src/app/shared/brand/brand-constants.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('brand constants', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis, '__KRAAK_RUNTIME_CONFIG__');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, '__KRAAK_RUNTIME_CONFIG__');
+    vi.resetModules();
+  });
+
+  it('Given runtime brand URLs, when the constants module loads, then it uses the runtime values', async () => {
+    globalThis.__KRAAK_RUNTIME_CONFIG__ = {
+      publicAssetBaseUrl: 'https://cdn.kraak.example/assets',
+      contactPhoneE164: '+225000000001',
+      contactPhoneDisplay: '+225 00 00 00 00 01',
+      contactEmail: 'contact@kraak.example',
+      whatsappContactHref: 'https://wa.me/225000000001',
+      facebookUrl: 'https://www.facebook.com/kraak.example',
+      instagramUrl: 'https://www.instagram.com/kraak.example',
+      tiktokUrl: 'https://www.tiktok.com/@kraak.example',
+    };
+
+    const brandConstants = await import('./brand-constants');
+
+    expect(brandConstants.KRAAK_PUBLIC_ASSET_BASE_URL).toBe(
+      'https://cdn.kraak.example/assets',
+    );
+    expect(brandConstants.KRAAK_AVATAR_CIRCLE_BASE_URL).toBe(
+      'https://cdn.kraak.example/assets/blocks/avatars/circle',
+    );
+    expect(brandConstants.CONTACT_PHONE_E164).toBe('+225000000001');
+    expect(brandConstants.CONTACT_PHONE_DISPLAY).toBe('+225 00 00 00 00 01');
+    expect(brandConstants.WHATSAPP_CONTACT_HREF).toBe(
+      'https://wa.me/225000000001',
+    );
+    expect(brandConstants.CONTACT_EMAIL).toBe('contact@kraak.example');
+    expect(brandConstants.KRAAK_SOCIAL_LINKS).toEqual([
+      {
+        label: 'Facebook',
+        href: 'https://www.facebook.com/kraak.example',
+        icon: 'pi-facebook',
+      },
+      {
+        label: 'Instagram',
+        href: 'https://www.instagram.com/kraak.example',
+        icon: 'pi-instagram',
+      },
+      {
+        label: 'WhatsApp',
+        href: 'https://wa.me/225000000001',
+        icon: 'pi-whatsapp',
+      },
+      {
+        label: 'TikTok',
+        href: 'https://www.tiktok.com/@kraak.example',
+        icon: 'pi-tiktok',
+      },
+    ]);
+  });
+});

--- a/apps/client/projects/web/src/app/shared/brand/brand-constants.ts
+++ b/apps/client/projects/web/src/app/shared/brand/brand-constants.ts
@@ -4,8 +4,13 @@ export interface SocialLink {
   icon: string;
 }
 
+import { resolveRuntimeClientConfig } from '../../../../../shared/runtime-client-config';
+import { CLIENT_DEFAULTS } from '../client-defaults';
+
+const runtimeClientConfig = resolveRuntimeClientConfig();
+
 export const KRAAK_PUBLIC_ASSET_BASE_URL =
-  'https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images';
+  runtimeClientConfig.publicAssetBaseUrl || CLIENT_DEFAULTS.publicAssetBaseUrl;
 
 export const KRAAK_AVATAR_CIRCLE_BASE_URL = `${KRAAK_PUBLIC_ASSET_BASE_URL}/blocks/avatars/circle`;
 
@@ -19,10 +24,15 @@ export const CONTACT_VISUAL_URL = `${KRAAK_PUBLIC_ASSET_BASE_URL}/blocks/contact
 
 export const FAQ_BACKGROUND_IMAGE_URL = `${KRAAK_PUBLIC_ASSET_BASE_URL}/blocks/faq/glassmorphic-accordion-bg.jpg`;
 
-export const CONTACT_PHONE_E164 = '+2250502741818';
-export const CONTACT_PHONE_DISPLAY = '+225 05 02 74 18 18';
+export const CONTACT_PHONE_E164 =
+  runtimeClientConfig.contactPhoneE164 || CLIENT_DEFAULTS.contactPhoneE164;
+export const CONTACT_PHONE_DISPLAY =
+  runtimeClientConfig.contactPhoneDisplay ||
+  CLIENT_DEFAULTS.contactPhoneDisplay;
 export const CONTACT_PHONE_HREF = `tel:${CONTACT_PHONE_E164}`;
-export const WHATSAPP_CONTACT_HREF = 'https://wa.me/2250502741818';
+export const WHATSAPP_CONTACT_HREF =
+  runtimeClientConfig.whatsappContactHref ||
+  CLIENT_DEFAULTS.whatsappContactHref;
 
 export function buildHeroBackgroundStyle(imageUrl: string) {
   return {
@@ -38,12 +48,12 @@ export const HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
 export const KRAAK_SOCIAL_LINKS: readonly SocialLink[] = [
   {
     label: 'Facebook',
-    href: 'https://www.facebook.com/kraakconsulting/',
+    href: runtimeClientConfig.facebookUrl || CLIENT_DEFAULTS.facebookUrl,
     icon: 'pi-facebook',
   },
   {
     label: 'Instagram',
-    href: 'https://www.instagram.com/kraakconsulting/',
+    href: runtimeClientConfig.instagramUrl || CLIENT_DEFAULTS.instagramUrl,
     icon: 'pi-instagram',
   },
   {
@@ -53,9 +63,10 @@ export const KRAAK_SOCIAL_LINKS: readonly SocialLink[] = [
   },
   {
     label: 'TikTok',
-    href: 'https://www.tiktok.com/@kraakconsulting',
+    href: runtimeClientConfig.tiktokUrl || CLIENT_DEFAULTS.tiktokUrl,
     icon: 'pi-tiktok',
   },
 ] as const;
 
-export const CONTACT_EMAIL = 'kraakconsulting@gmail.com';
+export const CONTACT_EMAIL =
+  runtimeClientConfig.contactEmail || CLIENT_DEFAULTS.contactEmail;

--- a/apps/client/projects/web/src/app/shared/client-defaults.ts
+++ b/apps/client/projects/web/src/app/shared/client-defaults.ts
@@ -1,0 +1,15 @@
+export const CLIENT_DEFAULTS = {
+  siteUrl: 'https://kraak-web-prod.onrender.com',
+  siteName: 'KRAAK',
+  locale: 'fr_FR',
+  robots: 'index, follow',
+  publicAssetBaseUrl:
+    'https://fqjltiegiezfetthbags.supabase.co/storage/v1/render/image/public/block.images',
+  contactPhoneE164: '+2250502741818',
+  contactPhoneDisplay: '+225 05 02 74 18 18',
+  contactEmail: 'kraakconsulting@gmail.com',
+  whatsappContactHref: 'https://wa.me/2250502741818',
+  facebookUrl: 'https://www.facebook.com/kraakconsulting/',
+  instagramUrl: 'https://www.instagram.com/kraakconsulting/',
+  tiktokUrl: 'https://www.tiktok.com/@kraakconsulting',
+} as const;

--- a/scripts/generate-client-runtime-config.mjs
+++ b/scripts/generate-client-runtime-config.mjs
@@ -107,6 +107,61 @@ function readRuntimeVariable(key, fileVariables, processEnv) {
   return processEnv[key]?.trim();
 }
 
+function addRuntimeVariable(runtimeConfig, key, value) {
+  if (value) {
+    runtimeConfig[key] = value;
+  }
+}
+
+function buildRuntimeConfig(runtimeValues) {
+  const runtimeConfig = {
+    enableParticipantArea: runtimeValues.enableParticipantArea,
+  };
+
+  addRuntimeVariable(runtimeConfig, 'apiBaseUrl', runtimeValues.apiBaseUrl);
+  addRuntimeVariable(
+    runtimeConfig,
+    'publicAssetBaseUrl',
+    runtimeValues.publicAssetBaseUrl,
+  );
+  addRuntimeVariable(
+    runtimeConfig,
+    'contactPhoneE164',
+    runtimeValues.contactPhoneE164,
+  );
+  addRuntimeVariable(
+    runtimeConfig,
+    'contactPhoneDisplay',
+    runtimeValues.contactPhoneDisplay,
+  );
+  addRuntimeVariable(
+    runtimeConfig,
+    'contactEmail',
+    runtimeValues.contactEmail,
+  );
+  addRuntimeVariable(
+    runtimeConfig,
+    'whatsappContactHref',
+    runtimeValues.whatsappContactHref,
+  );
+  addRuntimeVariable(runtimeConfig, 'facebookUrl', runtimeValues.facebookUrl);
+  addRuntimeVariable(
+    runtimeConfig,
+    'instagramUrl',
+    runtimeValues.instagramUrl,
+  );
+  addRuntimeVariable(runtimeConfig, 'tiktokUrl', runtimeValues.tiktokUrl);
+  addRuntimeVariable(runtimeConfig, 'siteUrl', runtimeValues.siteUrl);
+  addRuntimeVariable(runtimeConfig, 'supabaseUrl', runtimeValues.supabaseUrl);
+  addRuntimeVariable(
+    runtimeConfig,
+    'supabasePublishableKey',
+    runtimeValues.supabasePublishableKey,
+  );
+
+  return runtimeConfig;
+}
+
 export function loadClientRuntimeConfig(
   environmentName,
   { clientRootPath = clientRoot, processEnv = process.env } = {},
@@ -116,6 +171,46 @@ export function loadClientRuntimeConfig(
   const fileVariables = existsSync(envPath) ? parseEnvFile(envPath) : {};
   const apiBaseUrl = readRuntimeVariable(
     'CLIENT_API_BASE_URL',
+    fileVariables,
+    processEnv,
+  );
+  const publicAssetBaseUrl = readRuntimeVariable(
+    'KRAAK_PUBLIC_ASSET_BASE_URL',
+    fileVariables,
+    processEnv,
+  );
+  const contactPhoneE164 = readRuntimeVariable(
+    'KRAAK_CONTACT_PHONE_E164',
+    fileVariables,
+    processEnv,
+  );
+  const contactPhoneDisplay = readRuntimeVariable(
+    'KRAAK_CONTACT_PHONE_DISPLAY',
+    fileVariables,
+    processEnv,
+  );
+  const contactEmail = readRuntimeVariable(
+    'KRAAK_CONTACT_EMAIL',
+    fileVariables,
+    processEnv,
+  );
+  const whatsappContactHref = readRuntimeVariable(
+    'KRAAK_WHATSAPP_CONTACT_HREF',
+    fileVariables,
+    processEnv,
+  );
+  const facebookUrl = readRuntimeVariable(
+    'KRAAK_FACEBOOK_URL',
+    fileVariables,
+    processEnv,
+  );
+  const instagramUrl = readRuntimeVariable(
+    'KRAAK_INSTAGRAM_URL',
+    fileVariables,
+    processEnv,
+  );
+  const tiktokUrl = readRuntimeVariable(
+    'KRAAK_TIKTOK_URL',
     fileVariables,
     processEnv,
   );
@@ -141,24 +236,21 @@ export function loadClientRuntimeConfig(
       processEnv,
     ) === 'true';
 
-  if (!apiBaseUrl && (!supabaseUrl || !supabasePublishableKey)) {
-    return {
-      ...(siteUrl ? { siteUrl } : {}),
-      enableParticipantArea,
-    };
-  }
-
-  return {
-    ...(apiBaseUrl ? { apiBaseUrl } : {}),
-    ...(siteUrl ? { siteUrl } : {}),
-    ...(supabaseUrl && supabasePublishableKey
-      ? {
-          supabaseUrl,
-          supabasePublishableKey,
-        }
-      : {}),
+  return buildRuntimeConfig({
+    apiBaseUrl,
+    publicAssetBaseUrl,
+    contactPhoneE164,
+    contactPhoneDisplay,
+    contactEmail,
+    whatsappContactHref,
+    facebookUrl,
+    instagramUrl,
+    tiktokUrl,
+    siteUrl,
+    supabaseUrl,
+    supabasePublishableKey,
     enableParticipantArea,
-  };
+  });
 }
 
 export function serializeRuntimeConfig(runtimeConfig) {

--- a/scripts/generate-client-runtime-config.spec.mjs
+++ b/scripts/generate-client-runtime-config.spec.mjs
@@ -12,6 +12,58 @@ import {
 } from './generate-client-runtime-config.mjs';
 
 test(
+  'le runtime client expose aussi les URLs publiques de marque et contact quand elles sont definies',
+  () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), 'kraak-client-runtime-config-'),
+    );
+
+    try {
+      const envFilePath = path.join(tempRoot, '.env');
+      writeFileSync(
+        envFilePath,
+        [
+          'CLIENT_API_BASE_URL=http://localhost:3000',
+          'SUPABASE_URL=http://127.0.0.1:54321',
+          'SUPABASE_PUBLISHABLE_KEY=local-publishable-key',
+          'KRAAK_PUBLIC_ASSET_BASE_URL=https://cdn.kraak.example/assets',
+          'KRAAK_CONTACT_PHONE_E164=+225000000001',
+          'KRAAK_CONTACT_PHONE_DISPLAY=+225 00 00 00 00 01',
+          'KRAAK_CONTACT_EMAIL=contact@kraak.example',
+          'KRAAK_WHATSAPP_CONTACT_HREF=https://wa.me/225000000001',
+          'KRAAK_FACEBOOK_URL=https://www.facebook.com/kraak.example',
+          'KRAAK_INSTAGRAM_URL=https://www.instagram.com/kraak.example',
+          'KRAAK_TIKTOK_URL=https://www.tiktok.com/@kraak.example',
+          '',
+        ].join('\n'),
+      );
+
+      const runtimeConfig = loadClientRuntimeConfig('local', {
+        clientRootPath: tempRoot,
+        processEnv: {},
+      });
+
+      assert.deepEqual(runtimeConfig, {
+        apiBaseUrl: 'http://localhost:3000',
+        publicAssetBaseUrl: 'https://cdn.kraak.example/assets',
+        contactPhoneE164: '+225000000001',
+        contactPhoneDisplay: '+225 00 00 00 00 01',
+        contactEmail: 'contact@kraak.example',
+        whatsappContactHref: 'https://wa.me/225000000001',
+        facebookUrl: 'https://www.facebook.com/kraak.example',
+        instagramUrl: 'https://www.instagram.com/kraak.example',
+        tiktokUrl: 'https://www.tiktok.com/@kraak.example',
+        supabaseUrl: 'http://127.0.0.1:54321',
+        supabasePublishableKey: 'local-publishable-key',
+        enableParticipantArea: false,
+      });
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   'le runtime client peut lire les variables locales depuis apps/client/.env quand le fichier existe',
   () => {
     const tempRoot = mkdtempSync(


### PR DESCRIPTION
Centralize client fallback defaults and keep runtime brand/contact configuration aligned with the shared runtime resolver.

This also fixes the client test type gap introduced by the new runtime fields.