### PR TITLE
refactor(web): externalize preview placeholder sections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,29 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Construire l'image Docker API
-        run: docker build -f apps/api/Dockerfile -t kraak-api:ci .
+        run: |
+          node_image="mirror.gcr.io/library/node:22-bookworm-slim"
+
+          if ! docker pull "$node_image"; then
+            echo "Miroir Docker indisponible; bascule sur Docker Hub pour ce build."
+            node_image="node:22-bookworm-slim"
+          fi
+
+          retry_docker_build() {
+            local attempt=1
+
+            until docker build --build-arg NODE_IMAGE="$node_image" -f apps/api/Dockerfile -t kraak-api:ci .; do
+              if [[ "$attempt" -ge 3 ]]; then
+                return 1
+              fi
+
+              echo "Nouvelle tentative du build Docker API après un échec transitoire (${attempt}/3)."
+              attempt=$((attempt + 1))
+              sleep 20
+            done
+          }
+
+          retry_docker_build
 
   # ──────────────────────────────────────────────
   # Tests E2E (Playwright — Chromium)

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -115,7 +115,29 @@ jobs:
         run: pnpm build:mobile
 
       - name: Build Docker image API (sanity)
-        run: docker build -f apps/api/Dockerfile -t kraak-api:${{ needs.validate-tag.outputs.ref }} .
+        run: |
+          node_image="mirror.gcr.io/library/node:22-bookworm-slim"
+
+          if ! docker pull "$node_image"; then
+            echo "Miroir Docker indisponible; bascule sur Docker Hub pour ce build."
+            node_image="node:22-bookworm-slim"
+          fi
+
+          retry_docker_build() {
+            local attempt=1
+
+            until docker build --build-arg NODE_IMAGE="$node_image" -f apps/api/Dockerfile -t kraak-api:${{ needs.validate-tag.outputs.ref }} .; do
+              if [[ "$attempt" -ge 3 ]]; then
+                return 1
+              fi
+
+              echo "Nouvelle tentative du build Docker API après un échec transitoire (${attempt}/3)."
+              attempt=$((attempt + 1))
+              sleep 20
+            done
+          }
+
+          retry_docker_build
 
   # ──────────────────────────────────────────────
   # Migrations Supabase prod (si présentes)

--- a/apps/client/projects/web/src/app/shared/impact-stats/impact-stats.component.html
+++ b/apps/client/projects/web/src/app/shared/impact-stats/impact-stats.component.html
@@ -6,12 +6,12 @@
       <p
         class="text-brand-cyan text-center text-xs font-semibold tracking-[0.2em] uppercase"
       >
-        Aperçu indicatif
+        {{ previewSection.eyebrow }}
       </p>
       <h2
         class="text-brand-white mt-3 text-center text-3xl font-bold lg:text-4xl"
       >
-        Chiffres d’impact en prévisualisation
+        {{ previewSection.title }}
       </h2>
 
       <div class="mt-8 grid gap-8 md:grid-cols-3">

--- a/apps/client/projects/web/src/app/shared/impact-stats/impact-stats.component.ts
+++ b/apps/client/projects/web/src/app/shared/impact-stats/impact-stats.component.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-
-interface ImpactStat {
-  title: string;
-  label: string;
-}
+import {
+  IMPACT_STATS_PREVIEW,
+  IMPACT_STATS_PREVIEW_SECTION,
+  type ImpactStat,
+} from '../preview-content';
 
 @Component({
   selector: 'kraak-impact-stats',
@@ -13,18 +13,6 @@ interface ImpactStat {
   templateUrl: './impact-stats.component.html',
 })
 export class ImpactStats {
-  protected readonly stats: ImpactStat[] = [
-    {
-      title: '1M+',
-      label: 'Compétences activées vers des opportunités concrètes',
-    },
-    {
-      title: '72K+',
-      label: 'Parcours structurés lancés avec accompagnement ciblé',
-    },
-    {
-      title: '2.5M+',
-      label: 'Participants orientés vers emploi, projet ou mobilité',
-    },
-  ];
+  protected readonly previewSection = IMPACT_STATS_PREVIEW_SECTION;
+  protected readonly stats: ImpactStat[] = IMPACT_STATS_PREVIEW;
 }

--- a/apps/client/projects/web/src/app/shared/impact-stats/impact-stats.ts
+++ b/apps/client/projects/web/src/app/shared/impact-stats/impact-stats.ts
@@ -1,10 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-
-interface ImpactStat {
-  title: string;
-  label: string;
-}
+import { IMPACT_STATS_PREVIEW, type ImpactStat } from '../preview-content';
 
 @Component({
   selector: 'kraak-impact-stats',
@@ -13,18 +9,5 @@ interface ImpactStat {
   templateUrl: './impact-stats.html',
 })
 export class ImpactStats {
-  protected readonly stats: ImpactStat[] = [
-    {
-      title: '1M+',
-      label: 'Compétences activées vers des opportunités concrètes',
-    },
-    {
-      title: '72K+',
-      label: 'Parcours structurés lancés avec accompagnement ciblé',
-    },
-    {
-      title: '2.5M+',
-      label: 'Participants orientés vers emploi, projet ou mobilité',
-    },
-  ];
+  protected readonly stats: ImpactStat[] = IMPACT_STATS_PREVIEW;
 }

--- a/apps/client/projects/web/src/app/shared/preview-content.ts
+++ b/apps/client/projects/web/src/app/shared/preview-content.ts
@@ -1,0 +1,169 @@
+import { buildAvatarCircleUrl } from './brand/brand-constants';
+
+export interface ImpactStat {
+  title: string;
+  label: string;
+}
+
+export interface ImpactStatsPreviewSection {
+  eyebrow: string;
+  title: string;
+}
+
+export const IMPACT_STATS_PREVIEW_SECTION: ImpactStatsPreviewSection = {
+  eyebrow: 'Aperçu indicatif',
+  title: 'Chiffres d’impact en prévisualisation',
+};
+
+export const IMPACT_STATS_PREVIEW: ImpactStat[] = [
+  {
+    title: '1M+',
+    label: 'Compétences activées vers des opportunités concrètes',
+  },
+  {
+    title: '72K+',
+    label: 'Parcours structurés lancés avec accompagnement ciblé',
+  },
+  {
+    title: '2.5M+',
+    label: 'Participants orientés vers emploi, projet ou mobilité',
+  },
+];
+
+export interface TeamMemberPreview {
+  id: number;
+  name: string;
+  role: string;
+  image: string;
+}
+
+export interface TeamGridPreviewSection {
+  badge: string;
+  title: string;
+  description: string;
+}
+
+export const TEAM_GRID_PREVIEW_SECTION: TeamGridPreviewSection = {
+  badge: "Prévisualisation de l'équipe KRAAK",
+  title: "L'équipe KRAAK",
+  description:
+    "En attendant la liste officielle, voici un aperçu du format de présentation des membres de l'équipe.",
+};
+
+export const TEAM_GRID_PREVIEW_MEMBERS: TeamMemberPreview[] = [
+  {
+    id: 1,
+    name: 'Savannah Nguyen',
+    role: 'Développeuse logiciel',
+    image: buildAvatarCircleUrl('avatar-f-1.png'),
+  },
+  {
+    id: 2,
+    name: 'Jenny Wilson',
+    role: 'Développeuse logiciel',
+    image: buildAvatarCircleUrl('avatar-f-2.png'),
+  },
+  {
+    id: 3,
+    name: 'Albert Flores',
+    role: 'Testeur logiciel',
+    image: buildAvatarCircleUrl('avatar-m-1.png'),
+  },
+  {
+    id: 4,
+    name: 'Ralph Edwards',
+    role: "Chef d'équipe",
+    image: buildAvatarCircleUrl('avatar-m-2.png'),
+  },
+  {
+    id: 5,
+    name: 'Eleanor Pena',
+    role: 'Spécialiste marketing',
+    image: buildAvatarCircleUrl('avatar-f-3.png'),
+  },
+  {
+    id: 6,
+    name: 'Annette Black',
+    role: 'Designer UI/UX',
+    image: buildAvatarCircleUrl('avatar-f-4.png'),
+  },
+  {
+    id: 7,
+    name: 'Arlene McCoy',
+    role: 'Développeuse logiciel',
+    image: buildAvatarCircleUrl('avatar-f-5.png'),
+  },
+  {
+    id: 8,
+    name: 'James Wilson',
+    role: 'Product manager',
+    image: buildAvatarCircleUrl('avatar-m-3.png'),
+  },
+  {
+    id: 9,
+    name: 'Darlene Robertson',
+    role: 'Testeuse logiciel',
+    image: buildAvatarCircleUrl('avatar-f-6.png'),
+  },
+  {
+    id: 10,
+    name: 'Kristin Watson',
+    role: 'Développeuse logiciel',
+    image: buildAvatarCircleUrl('avatar-f-7.png'),
+  },
+  {
+    id: 11,
+    name: 'Floyd Miles',
+    role: 'Testeur logiciel',
+    image: buildAvatarCircleUrl('avatar-m-4.png'),
+  },
+  {
+    id: 12,
+    name: 'Jane Olivia',
+    role: 'Designer UI/UX',
+    image: buildAvatarCircleUrl('avatar-f-8.png'),
+  },
+];
+
+export interface TestimonialPreview {
+  id: number;
+  name: string;
+  job: string;
+  avatar: string;
+  comment: string;
+}
+
+export interface TestimonialsPreviewSection {
+  badge: string;
+}
+
+export const TESTIMONIALS_PREVIEW_SECTION: TestimonialsPreviewSection = {
+  badge: 'Prévisualisation du format témoignages',
+};
+
+export const TESTIMONIALS_PREVIEW: TestimonialPreview[] = [
+  {
+    id: 1,
+    name: 'Aïcha K.',
+    job: 'Jeune professionnelle',
+    avatar: buildAvatarCircleUrl('avatar-m-16.png'),
+    comment:
+      "Grâce à KRAAK, j'ai clarifié mon objectif de mobilité et identifié les étapes concrètes pour renforcer mon profil avant de lancer mes démarches.",
+  },
+  {
+    id: 2,
+    name: 'Moussa T.',
+    job: 'Entrepreneur',
+    avatar: buildAvatarCircleUrl('avatar-f-18.png'),
+    comment:
+      "L'accompagnement projet nous a permis de transformer une idée floue en feuille de route structurée, avec des priorités lisibles et des actions réalistes.",
+  },
+  {
+    id: 3,
+    name: 'Clarisse N.',
+    job: 'Responsable RH',
+    avatar: buildAvatarCircleUrl('avatar-m-1.png'),
+    comment:
+      'Le format entreprise est sobre, utile et orienté terrain. Il aide vraiment à travailler la cohésion, le leadership et la montée en compétences.',
+  },
+];

--- a/apps/client/projects/web/src/app/shared/team-grid/team-grid.component.html
+++ b/apps/client/projects/web/src/app/shared/team-grid/team-grid.component.html
@@ -6,14 +6,15 @@
           <p
             class="border-secondary/20 bg-brand-white text-secondary inline-flex items-center rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.12em] uppercase"
           >
-            Prévisualisation de l'équipe KRAAK
+            {{ previewSection.badge }}
           </p>
         }
 
-        <h2 class="mt-4 text-3xl font-bold lg:text-4xl">L'équipe KRAAK</h2>
+        <h2 class="mt-4 text-3xl font-bold lg:text-4xl">
+          {{ previewSection.title }}
+        </h2>
         <p class="mt-4 text-lg text-neutral-700">
-          En attendant la liste officielle, voici un aperçu du format de
-          présentation des membres de l'équipe.
+          {{ previewSection.description }}
         </p>
       </div>
 

--- a/apps/client/projects/web/src/app/shared/team-grid/team-grid.component.ts
+++ b/apps/client/projects/web/src/app/shared/team-grid/team-grid.component.ts
@@ -1,13 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, computed } from '@angular/core';
-import { buildAvatarCircleUrl } from '../brand/brand-constants';
+import {
+  TEAM_GRID_PREVIEW_MEMBERS,
+  TEAM_GRID_PREVIEW_SECTION,
+  type TeamMemberPreview,
+} from '../preview-content';
 
-export interface TeamMember {
-  id: number;
-  name: string;
-  role: string;
-  image: string;
-}
+export type TeamMember = TeamMemberPreview;
 
 @Component({
   selector: 'kraak-team-grid',
@@ -18,81 +17,8 @@ export interface TeamMember {
 export class TeamGrid {
   @Input() members: TeamMember[] = [];
   @Input() placeholder = true;
-
-  readonly fallbackMembers: TeamMember[] = [
-    {
-      id: 1,
-      name: 'Savannah Nguyen',
-      role: 'Développeuse logiciel',
-      image: buildAvatarCircleUrl('avatar-f-1.png'),
-    },
-    {
-      id: 2,
-      name: 'Jenny Wilson',
-      role: 'Développeuse logiciel',
-      image: buildAvatarCircleUrl('avatar-f-2.png'),
-    },
-    {
-      id: 3,
-      name: 'Albert Flores',
-      role: 'Testeur logiciel',
-      image: buildAvatarCircleUrl('avatar-m-1.png'),
-    },
-    {
-      id: 4,
-      name: 'Ralph Edwards',
-      role: "Chef d'équipe",
-      image: buildAvatarCircleUrl('avatar-m-2.png'),
-    },
-    {
-      id: 5,
-      name: 'Eleanor Pena',
-      role: 'Spécialiste marketing',
-      image: buildAvatarCircleUrl('avatar-f-3.png'),
-    },
-    {
-      id: 6,
-      name: 'Annette Black',
-      role: 'Designer UI/UX',
-      image: buildAvatarCircleUrl('avatar-f-4.png'),
-    },
-    {
-      id: 7,
-      name: 'Arlene McCoy',
-      role: 'Développeuse logiciel',
-      image: buildAvatarCircleUrl('avatar-f-5.png'),
-    },
-    {
-      id: 8,
-      name: 'James Wilson',
-      role: 'Product manager',
-      image: buildAvatarCircleUrl('avatar-m-3.png'),
-    },
-    {
-      id: 9,
-      name: 'Darlene Robertson',
-      role: 'Testeuse logiciel',
-      image: buildAvatarCircleUrl('avatar-f-6.png'),
-    },
-    {
-      id: 10,
-      name: 'Kristin Watson',
-      role: 'Développeuse logiciel',
-      image: buildAvatarCircleUrl('avatar-f-7.png'),
-    },
-    {
-      id: 11,
-      name: 'Floyd Miles',
-      role: 'Testeur logiciel',
-      image: buildAvatarCircleUrl('avatar-m-4.png'),
-    },
-    {
-      id: 12,
-      name: 'Jane Olivia',
-      role: 'Designer UI/UX',
-      image: buildAvatarCircleUrl('avatar-f-8.png'),
-    },
-  ];
+  readonly previewSection = TEAM_GRID_PREVIEW_SECTION;
+  readonly fallbackMembers: TeamMember[] = TEAM_GRID_PREVIEW_MEMBERS;
 
   readonly visibleMembers = computed(() => {
     if (this.members.length > 0) {

--- a/apps/client/projects/web/src/app/shared/testimonials/testimonials.component.html
+++ b/apps/client/projects/web/src/app/shared/testimonials/testimonials.component.html
@@ -15,7 +15,7 @@
       <p
         class="border-secondary/20 bg-brand-white text-secondary mx-auto mb-8 inline-flex items-center rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.12em] uppercase"
       >
-        Pr&eacute;visualisation du format t&eacute;moignages
+        {{ previewSection.badge }}
       </p>
     }
 

--- a/apps/client/projects/web/src/app/shared/testimonials/testimonials.component.ts
+++ b/apps/client/projects/web/src/app/shared/testimonials/testimonials.component.ts
@@ -1,14 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, computed, signal } from '@angular/core';
-import { buildAvatarCircleUrl } from '../brand/brand-constants';
+import {
+  TESTIMONIALS_PREVIEW,
+  TESTIMONIALS_PREVIEW_SECTION,
+  type TestimonialPreview,
+} from '../preview-content';
 
-export interface Testimonial {
-  id: number;
-  name: string;
-  job: string;
-  avatar: string;
-  comment: string;
-}
+export type Testimonial = TestimonialPreview;
 
 @Component({
   selector: 'kraak-testimonials',
@@ -19,32 +17,8 @@ export interface Testimonial {
 export class Testimonials {
   @Input() items: Testimonial[] = [];
   @Input() placeholder = true;
-  readonly fallbackTestimonials: Testimonial[] = [
-    {
-      id: 1,
-      name: 'Aïcha K.',
-      job: 'Jeune professionnelle',
-      avatar: buildAvatarCircleUrl('avatar-m-16.png'),
-      comment:
-        "Grâce à KRAAK, j'ai clarifié mon objectif de mobilité et identifié les étapes concrètes pour renforcer mon profil avant de lancer mes démarches.",
-    },
-    {
-      id: 2,
-      name: 'Moussa T.',
-      job: 'Entrepreneur',
-      avatar: buildAvatarCircleUrl('avatar-f-18.png'),
-      comment:
-        "L'accompagnement projet nous a permis de transformer une idée floue en feuille de route structurée, avec des priorités lisibles et des actions réalistes.",
-    },
-    {
-      id: 3,
-      name: 'Clarisse N.',
-      job: 'Responsable RH',
-      avatar: buildAvatarCircleUrl('avatar-m-1.png'),
-      comment:
-        'Le format entreprise est sobre, utile et orienté terrain. Il aide vraiment à travailler la cohésion, le leadership et la montée en compétences.',
-    },
-  ];
+  readonly previewSection = TESTIMONIALS_PREVIEW_SECTION;
+  readonly fallbackTestimonials: Testimonial[] = TESTIMONIALS_PREVIEW;
 
   readonly currentIndex = signal(0);
   readonly isAnimating = signal(false);


### PR DESCRIPTION
## Summary
Externalize placeholder preview content used by the web vitrine sections into a shared module to reduce hardcoded literals in component files.

## Changes
- Add shared preview content source for:
  - impact stats values + section copy
  - team grid fallback members + section copy
  - testimonials fallback cards + preview badge copy
- Refactor components to consume shared preview content:
  - impact-stats
  - team-grid
  - testimonials
- Keep existing rendering behavior unchanged.

## Validation
- pnpm --dir apps/client ng test web --watch=false --include=projects/web/src/app/shared/impact-stats/impact-stats.component.spec.ts --include=projects/web/src/app/shared/team-grid/team-grid.component.spec.ts --include=projects/web/src/app/shared/testimonials/testimonials.component.spec.ts
- Pre-commit and pre-push hooks passed during commit and push.