### PR TITLE
chore(repo): supprimer le job CI Tests E2E et aligner la doc

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,9 @@
 # Variables locales uniquement (jamais committees).
 # Copier ce fichier vers .env.local puis renseigner les valeurs.
 
+# Feature flags
 CLIENT_FEATURE_PARTICIPANT_AREA=
+
+# Sonar (token utilisateur uniquement)
 SONAR_TOKEN=
-SONAR_HOST_URL=https://sonarcloud.io
+SONAR_HOST_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Pipeline CI — kraak-group monorepo
 # Déclenché sur push vers main et sur les pull requests ciblant main.
-# Couvre : format, lint, build, tests unitaires, tests E2E.
+# Couvre : format, lint, build, tests unitaires.
 
 name: CI
 
@@ -133,101 +133,6 @@ jobs:
 
       - name: Construire l'image Docker API
         run: docker build -f apps/api/Dockerfile -t kraak-api:ci .
-
-  # ──────────────────────────────────────────────
-  # Tests E2E (Playwright — Chromium)
-  # ──────────────────────────────────────────────
-  e2e:
-    name: Tests E2E
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 45
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
-      PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: 120000
-      KRAAK_WEB_PORT: "4200"
-      KRAAK_E2E_BASE_URL: http://localhost:4200
-      KRAAK_E2E_WEB_SERVER_URL: http://localhost:4200
-      KRAAK_E2E_START_WEB_SERVER: "true"
-      KRAAK_E2E_WEB_SERVER_COMMAND: >-
-        node ../../scripts/generate-client-runtime-config.mjs --env local
-        && node -e "require('node:fs').rmSync('.angular/cache', { recursive: true, force: true })"
-        && npx ng serve web --port 4200 --prebundle=false --live-reload=false
-      CLIENT_API_BASE_URL: http://localhost:4200
-      CLIENT_SITE_URL: http://localhost:4200
-    steps:
-      - name: Désactiver les E2E longs sur PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: echo "E2E désactivés sur pull_request pour éviter les timeouts CI."
-
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        if: ${{ github.event_name != 'pull_request' }}
-
-      - name: Install pnpm
-        if: ${{ github.event_name != 'pull_request' }}
-        run: npm install --ignore-scripts -g pnpm@10.23.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        if: ${{ github.event_name != 'pull_request' }}
-        with:
-          node-version-file: package.json
-          cache: pnpm
-
-      - if: ${{ github.event_name != 'pull_request' }}
-        run: pnpm install --ignore-scripts --frozen-lockfile
-
-      - name: Construire les packages workspace
-        if: ${{ github.event_name != 'pull_request' }}
-        run: pnpm -r --filter "./packages/**" build
-
-      - name: Calculer la clé de cache Playwright du jour
-        if: ${{ github.event_name != 'pull_request' }}
-        id: playwright-cache-date
-        run: echo "value=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
-
-      - name: Restaurer le cache des navigateurs Playwright
-        if: ${{ github.event_name != 'pull_request' }}
-        id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-cache-date.outputs.value }}-${{ hashFiles('pnpm-lock.yaml', 'apps/client/package.json') }}
-
-      - name: Installer les navigateurs Playwright
-        if: ${{ github.event_name != 'pull_request' }}
-        # Note: playwright install exécute une commande officielle Playwright (non pnpm install),
-        # donc --ignore-scripts ne s'applique pas. En CI PR, on exécute la matrice
-        # E2E allégée (Chromium headless shell), pour réduire fortement
-        # les téléchargements et limiter les timeouts intermittents.
-        # NOSONAR
-        run: |
-          ./apps/client/node_modules/.bin/playwright --version
-          if [[ "${{ steps.playwright-cache.outputs.cache-hit }}" != "true" ]]; then
-            install_playwright() {
-              # Timeout strict pour éviter les téléchargements Playwright bloqués en CI.
-              timeout 15m ./apps/client/node_modules/.bin/playwright install --only-shell chromium
-            }
-
-            if ! install_playwright; then
-              echo "Premier essai d'installation Playwright échoué; nettoyage du cache partiel puis nouvelle tentative."
-              rm -rf ~/.cache/ms-playwright/*
-              install_playwright
-            fi
-          fi
-
-      - name: Exécuter les tests E2E
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          pnpm --filter @kraak/client exec playwright test --project=chromium
-          pnpm --filter @kraak/client exec playwright test --config=playwright.mobile.config.ts --project=chrome-android
-
-      - name: Sauvegarder les rapports Playwright
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: playwright-report
-          path: apps/client/playwright-report/
-          retention-days: 14
 
   # ──────────────────────────────────────────────
   # Build debug APK Android (Capacitor + Gradle)

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,13 @@ out/
 
 # Environnement
 .env
-.env.staging
-.env.prod
+.env.*
+.envrc
+.envrc.local
+!.env.example
+!.env.*.example
+!**/.env.example
+!**/.env.*.example
 
 # IDE / Éditeurs
 .idea/
@@ -75,3 +80,15 @@ apps/client/android/
 
 .vercel
 .env*.local
+
+# Secrets / credentials
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cert
+
+# Local security scan outputs
+hardcoded-audit*.txt
+*secrets*.txt

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,9 +21,4 @@ wait "$lint_pid" || status=$?
 
 [ "$status" -eq 0 ] || exit "$status"
 
-# Exécuter toutes les suites de tests locales hors E2E.
-# Les E2E restent exécutés dans GitHub Actions.
-pnpm test:libs
-pnpm test:api
-pnpm test:unit
-pnpm test:workspace
+pnpm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,9 +21,23 @@ wait "$lint_pid" || status=$?
 
 [ "$status" -eq 0 ] || exit "$status"
 
-# Exécuter toutes les suites de tests locales hors E2E.
-# Les E2E restent exécutés manuellement selon le contexte d'environnement.
-pnpm test:libs
-pnpm test:api
-pnpm test:unit
-pnpm test:workspace
+# Force des defaults stables pour éviter qu'un shell local (ex: profile=local)
+# fausse des tests SEO sensibles au profil runtime.
+: "${KRAAK_E2E_BASE_URL:=http://localhost:4200}"
+: "${KRAAK_E2E_START_WEB_SERVER:=true}"
+: "${KRAAK_E2E_WEB_SERVER_URL:=http://localhost:4200}"
+: "${CLIENT_API_BASE_URL:=http://localhost:3000}"
+: "${CLIENT_SITE_URL:=http://localhost:4200}"
+if [[ -z "${KRAAK_E2E_WEB_SERVER_COMMAND:-}" ]]; then
+	KRAAK_E2E_WEB_SERVER_COMMAND='node ../../scripts/generate-client-runtime-config.mjs --env local && npx ng serve web --port 4200 --prebundle=false --live-reload=false'
+fi
+
+KRAAK_DEFAULTS_PROFILE=production \
+CLIENT_RUNTIME_ENV=production \
+KRAAK_E2E_BASE_URL="$KRAAK_E2E_BASE_URL" \
+KRAAK_E2E_START_WEB_SERVER="$KRAAK_E2E_START_WEB_SERVER" \
+KRAAK_E2E_WEB_SERVER_URL="$KRAAK_E2E_WEB_SERVER_URL" \
+CLIENT_API_BASE_URL="$CLIENT_API_BASE_URL" \
+CLIENT_SITE_URL="$CLIENT_SITE_URL" \
+KRAAK_E2E_WEB_SERVER_COMMAND="$KRAAK_E2E_WEB_SERVER_COMMAND" \
+pnpm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,4 +21,9 @@ wait "$lint_pid" || status=$?
 
 [ "$status" -eq 0 ] || exit "$status"
 
-pnpm test
+# Exécuter toutes les suites de tests locales hors E2E.
+# Les E2E restent exécutés manuellement selon le contexte d'environnement.
+pnpm test:libs
+pnpm test:api
+pnpm test:unit
+pnpm test:workspace

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Remplir les valeurs manquantes — voir
 Le provider email/password local et les templates email du MVP sont versionnés
 dans [`supabase/config.toml`](supabase/config.toml) et documentés dans
 [`docs/runbooks/SUPABASE_AUTH_SETUP.md`](docs/runbooks/SUPABASE_AUTH_SETUP.md).
+La procédure de rotation manuelle des clés secrètes Supabase est documentée dans
+[`docs/runbooks/SUPABASE_SECRET_ROTATION.md`](docs/runbooks/SUPABASE_SECRET_ROTATION.md).
+La finalisation manuelle des variables d'environnement Render est documentée
+dans [`docs/runbooks/RENDER_ENV_FINALIZATION.md`](docs/runbooks/RENDER_ENV_FINALIZATION.md).
 
 ### Lancer en mode développement
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -6,6 +6,8 @@
 
 NODE_ENV=local
 PORT=3000
+# Optionnel: clé alternative utilisée par certains scripts/outils locaux.
+API_PORT=3000
 
 # Supabase
 SUPABASE_URL=http://127.0.0.1:54321

--- a/apps/api/.env.local.example
+++ b/apps/api/.env.local.example
@@ -1,0 +1,24 @@
+# ===========================
+# Variables d'environnement — API (local)
+# ===========================
+# Copier ce fichier vers .env puis renseigner les valeurs.
+# Ne jamais commiter de secrets dans le dépôt.
+
+NODE_ENV=local
+PORT=3000
+
+# Supabase
+SUPABASE_URL=
+SUPABASE_PUBLISHABLE_KEY=
+SUPABASE_SECRET_KEY=
+
+# Resend (envoi d'e-mails)
+RESEND_API_KEY=
+CONTACT_FROM_EMAIL=
+CONTACT_TO_EMAIL=
+
+# CORS
+# Origines autorisées exactes (séparées par des virgules).
+CORS_ALLOWED_ORIGINS=http://localhost:4200,http://localhost:4300
+# Optionnel : expressions régulières (séparées par des virgules).
+CORS_ALLOWED_ORIGIN_PATTERNS=

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,4 +1,5 @@
 # Environnement
 .env
-.env.staging
-.env.prod
+.env.*
+!.env.example
+!.env.*.example

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,17 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { buildCorsOptions } from './cors';
 
+function resolvePort(): number {
+  const rawPort = process.env['PORT'] ?? process.env['API_PORT'] ?? '3000';
+  const parsed = Number.parseInt(rawPort, 10);
+
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 65535) {
+    return parsed;
+  }
+
+  return 3000;
+}
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
@@ -71,7 +82,7 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('api-docs', app, document);
 
-  const port = process.env['PORT'] ?? 3000;
+  const port = resolvePort();
   await app.listen(port);
 }
 

--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -12,6 +12,8 @@
 CLIENT_API_BASE_URL=http://localhost:3000
 CLIENT_SITE_URL=http://localhost:4200
 CLIENT_MOBILE_SITE_URL=http://localhost:4300
+CLIENT_RUNTIME_ENV=local
+KRAAK_DEFAULTS_PROFILE=local
 
 # Supabase public côté client
 SUPABASE_URL=http://127.0.0.1:54321

--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -11,6 +11,7 @@
 # API publique consommée par le client
 CLIENT_API_BASE_URL=http://localhost:3000
 CLIENT_SITE_URL=http://localhost:4200
+CLIENT_MOBILE_SITE_URL=http://localhost:4300
 
 # Supabase public côté client
 SUPABASE_URL=http://127.0.0.1:54321
@@ -28,6 +29,7 @@ KRAAK_TIKTOK_URL=https://www.tiktok.com/@kraakconsulting
 
 # Port du serveur de développement Angular (utilisé par Playwright)
 KRAAK_WEB_PORT=4200
+KRAAK_MOBILE_PORT=4300
 
 # Feature flag — Espace participant (auth + dashboard)
 # - true : routes /participant, /connexion, /inscription, /mot-de-passe-oublie

--- a/apps/client/.gitignore
+++ b/apps/client/.gitignore
@@ -2,8 +2,9 @@
 
 # Environnement
 .env
-.env.staging
-.env.prod
+.env.*
+!.env.example
+!.env.*.example
 
 # Capacitor — artefacts de build natifs
 android/app/build/

--- a/apps/client/projects/mobile/src/environments/environment.local.ts
+++ b/apps/client/projects/mobile/src/environments/environment.local.ts
@@ -1,4 +1,23 @@
-const defaultSiteUrl = 'http://localhost:4300';
+const runtimeGlobals = globalThis as typeof globalThis & {
+  process?: {
+    env?: Record<string, string | undefined>;
+  };
+};
+
+function readEnv(...keys: string[]): string {
+  for (const key of keys) {
+    const value = runtimeGlobals.process?.env?.[key]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+const defaultSiteUrl =
+  readEnv('CLIENT_MOBILE_SITE_URL', 'MOBILE_SITE_URL') ||
+  'http://localhost:4300';
 const runtimeOrigin =
   typeof globalThis !== 'undefined' &&
   'location' in globalThis &&
@@ -10,10 +29,10 @@ export const environment = {
   environmentName: 'local',
   production: false,
   siteUrl: runtimeOrigin,
-  apiBaseUrl: 'http://localhost:3000',
+  apiBaseUrl: readEnv('CLIENT_API_BASE_URL') || 'http://localhost:3000',
   pushNotificationsEnabled: true,
   pushNotificationsProvider: 'fcm',
-  supabaseUrl: 'http://127.0.0.1:54321',
+  supabaseUrl: readEnv('SUPABASE_URL') || 'http://127.0.0.1:54321',
   supabasePublishableKey: '',
   ga4Id: '',
 };

--- a/apps/client/projects/web/src/app/features/support/faq.page.ts
+++ b/apps/client/projects/web/src/app/features/support/faq.page.ts
@@ -32,8 +32,7 @@ export default class FaqPage {
     },
     {
       question: 'Comment démarrer avec KRAAK ?',
-      answer:
-        `Vous pouvez envoyer une demande via le formulaire de contact, écrire à ${CONTACT_EMAIL} ou ouvrir un premier échange sur WhatsApp. Pour accélérer l'orientation, indiquez votre objectif, votre pays, votre calendrier et le type d'appui recherché.`,
+      answer: `Vous pouvez envoyer une demande via le formulaire de contact, écrire à ${CONTACT_EMAIL} ou ouvrir un premier échange sur WhatsApp. Pour accélérer l'orientation, indiquez votre objectif, votre pays, votre calendrier et le type d'appui recherché.`,
     },
     {
       question: 'Les accompagnements KRAAK sont-ils disponibles à distance ?',

--- a/apps/client/projects/web/src/app/features/support/faq.page.ts
+++ b/apps/client/projects/web/src/app/features/support/faq.page.ts
@@ -2,7 +2,10 @@ import { Component } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
-import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
+import {
+  CONTACT_EMAIL,
+  buildHeroBackgroundStyle,
+} from '../../shared/brand/brand-constants';
 import {
   FaqAccordion,
   type FaqItem,
@@ -30,7 +33,7 @@ export default class FaqPage {
     {
       question: 'Comment démarrer avec KRAAK ?',
       answer:
-        "Vous pouvez envoyer une demande via le formulaire de contact, écrire à kraakconsulting@gmail.com ou ouvrir un premier échange sur WhatsApp. Pour accélérer l'orientation, indiquez votre objectif, votre pays, votre calendrier et le type d'appui recherché.",
+        `Vous pouvez envoyer une demande via le formulaire de contact, écrire à ${CONTACT_EMAIL} ou ouvrir un premier échange sur WhatsApp. Pour accélérer l'orientation, indiquez votre objectif, votre pays, votre calendrier et le type d'appui recherché.`,
     },
     {
       question: 'Les accompagnements KRAAK sont-ils disponibles à distance ?',

--- a/apps/client/projects/web/src/app/shared/client-defaults.ts
+++ b/apps/client/projects/web/src/app/shared/client-defaults.ts
@@ -81,6 +81,4 @@ const DEFAULTS_BY_PROFILE: Record<DefaultsProfile, ClientDefaults> = {
   },
 };
 
-export const CLIENT_DEFAULTS = DEFAULTS_BY_PROFILE[
-  resolveDefaultsProfile()
-] as const;
+export const CLIENT_DEFAULTS = DEFAULTS_BY_PROFILE[resolveDefaultsProfile()];

--- a/apps/client/projects/web/src/app/shared/client-defaults.ts
+++ b/apps/client/projects/web/src/app/shared/client-defaults.ts
@@ -1,5 +1,57 @@
-export const CLIENT_DEFAULTS = {
-  siteUrl: 'https://kraak-web-prod.onrender.com',
+type ClientDefaults = {
+  siteUrl: string;
+  siteName: string;
+  locale: string;
+  robots: string;
+  publicAssetBaseUrl: string;
+  contactPhoneE164: string;
+  contactPhoneDisplay: string;
+  contactEmail: string;
+  whatsappContactHref: string;
+  facebookUrl: string;
+  instagramUrl: string;
+  tiktokUrl: string;
+};
+
+type DefaultsProfile = 'local' | 'staging' | 'production';
+
+const runtimeGlobals = globalThis as typeof globalThis & {
+  process?: {
+    env?: Record<string, string | undefined>;
+  };
+};
+
+function readEnv(...keys: string[]): string {
+  for (const key of keys) {
+    const value = runtimeGlobals.process?.env?.[key]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+function resolveDefaultsProfile(): DefaultsProfile {
+  const profile = readEnv(
+    'KRAAK_DEFAULTS_PROFILE',
+    'CLIENT_RUNTIME_ENV',
+    'NODE_ENV',
+  ).toLowerCase();
+
+  if (profile === 'local' || profile === 'development' || profile === 'dev') {
+    return 'local';
+  }
+
+  if (profile === 'staging' || profile === 'stage') {
+    return 'staging';
+  }
+
+  // Fallback production pour éviter toute régression sur les builds publics.
+  return 'production';
+}
+
+const BASE_DEFAULTS: Omit<ClientDefaults, 'siteUrl'> = {
   siteName: 'KRAAK',
   locale: 'fr_FR',
   robots: 'index, follow',
@@ -12,4 +64,22 @@ export const CLIENT_DEFAULTS = {
   facebookUrl: 'https://www.facebook.com/kraakconsulting/',
   instagramUrl: 'https://www.instagram.com/kraakconsulting/',
   tiktokUrl: 'https://www.tiktok.com/@kraakconsulting',
-} as const;
+};
+
+const DEFAULTS_BY_PROFILE: Record<DefaultsProfile, ClientDefaults> = {
+  local: {
+    ...BASE_DEFAULTS,
+    siteUrl: 'http://localhost:4200',
+  },
+  staging: {
+    ...BASE_DEFAULTS,
+    siteUrl: 'https://kraak-web-staging.onrender.com',
+  },
+  production: {
+    ...BASE_DEFAULTS,
+    siteUrl: 'https://kraak-web-prod.onrender.com',
+  },
+};
+
+export const CLIENT_DEFAULTS =
+  DEFAULTS_BY_PROFILE[resolveDefaultsProfile()] as const;

--- a/apps/client/projects/web/src/app/shared/client-defaults.ts
+++ b/apps/client/projects/web/src/app/shared/client-defaults.ts
@@ -1,4 +1,4 @@
-type ClientDefaults = {
+interface ClientDefaults {
   siteUrl: string;
   siteName: string;
   locale: string;
@@ -11,7 +11,7 @@ type ClientDefaults = {
   facebookUrl: string;
   instagramUrl: string;
   tiktokUrl: string;
-};
+}
 
 type DefaultsProfile = 'local' | 'staging' | 'production';
 
@@ -81,5 +81,6 @@ const DEFAULTS_BY_PROFILE: Record<DefaultsProfile, ClientDefaults> = {
   },
 };
 
-export const CLIENT_DEFAULTS =
-  DEFAULTS_BY_PROFILE[resolveDefaultsProfile()] as const;
+export const CLIENT_DEFAULTS = DEFAULTS_BY_PROFILE[
+  resolveDefaultsProfile()
+] as const;

--- a/apps/client/projects/web/src/environments/environment.local.ts
+++ b/apps/client/projects/web/src/environments/environment.local.ts
@@ -1,4 +1,22 @@
-const defaultSiteUrl = 'http://localhost:4200';
+const runtimeGlobals = globalThis as typeof globalThis & {
+  process?: {
+    env?: Record<string, string | undefined>;
+  };
+};
+
+function readEnv(...keys: string[]): string {
+  for (const key of keys) {
+    const value = runtimeGlobals.process?.env?.[key]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+const defaultSiteUrl =
+  readEnv('CLIENT_SITE_URL', 'PUBLIC_SITE_URL') || 'http://localhost:4200';
 const runtimeOrigin =
   typeof globalThis !== 'undefined' &&
   'location' in globalThis &&
@@ -10,8 +28,8 @@ export const environment = {
   production: false,
   enableParticipantArea: true,
   siteUrl: runtimeOrigin,
-  apiBaseUrl: 'http://localhost:3000',
-  supabaseUrl: 'http://127.0.0.1:54321',
+  apiBaseUrl: readEnv('CLIENT_API_BASE_URL') || 'http://localhost:3000',
+  supabaseUrl: readEnv('SUPABASE_URL') || 'http://127.0.0.1:54321',
   supabasePublishableKey: '',
   ga4Id: '',
   tfjsBackend: 'wasm' as const,

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: apps/api/Dockerfile
     environment:
       NODE_ENV: production
-      PORT: "3000"
+      PORT: "${API_PORT:-3000}"
       APP_VERSION: ${APP_VERSION:-local}
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:-}
@@ -15,10 +15,10 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       CONTACT_FROM_EMAIL: ${CONTACT_FROM_EMAIL:-}
       CONTACT_TO_EMAIL: ${CONTACT_TO_EMAIL:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:4200}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:${WEB_PORT:-4200}}
       CORS_ALLOWED_ORIGIN_PATTERNS: ${CORS_ALLOWED_ORIGIN_PATTERNS:-}
     ports:
-      - "3000:3000"
+      - "${API_PORT:-3000}:${API_PORT:-3000}"
     restart: unless-stopped
 
   web:
@@ -29,17 +29,17 @@ services:
       corepack prepare pnpm@10.23.0 --activate &&
       pnpm install --frozen-lockfile &&
       pnpm --filter @kraak/client run build:web:local &&
-      npx --yes serve apps/client/dist/web/browser -l 4200"
+      npx --yes serve apps/client/dist/web/browser -l ${WEB_PORT:-4200}"
     environment:
       NODE_ENV: production
-      CLIENT_API_BASE_URL: ${CLIENT_API_BASE_URL:-http://api:3000}
+      CLIENT_API_BASE_URL: ${CLIENT_API_BASE_URL:-http://api:${API_PORT:-3000}}
       SUPABASE_URL: ${CLIENT_SUPABASE_URL:-}
       SUPABASE_PUBLISHABLE_KEY: ${CLIENT_SUPABASE_PUBLISHABLE_KEY:-}
       CLIENT_FEATURE_PARTICIPANT_AREA: ${CLIENT_FEATURE_PARTICIPANT_AREA:-true}
-      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-http://localhost:4200}
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-http://localhost:${WEB_PORT:-4200}}
       PUBLIC_GA4_ID: ${PUBLIC_GA4_ID:-}
     ports:
-      - "4200:4200"
+      - "${WEB_PORT:-4200}:${WEB_PORT:-4200}"
     depends_on:
       - api
     volumes:

--- a/docs/runbooks/ENVIRONMENT_VARIABLES.md
+++ b/docs/runbooks/ENVIRONMENT_VARIABLES.md
@@ -140,7 +140,8 @@ sont déclarées directement dans `apps/api/.env` et `apps/client/.env`.
 La configuration Auth email/password versionnée du MVP ne vit pas dans ces
 fichiers `.env` mais dans `supabase/config.toml`, avec ses templates email
 locaux dans `supabase/templates/auth/`. Voir aussi
-[`SUPABASE_AUTH_SETUP.md`](SUPABASE_AUTH_SETUP.md).
+[`SUPABASE_AUTH_SETUP.md`](SUPABASE_AUTH_SETUP.md) et
+[`SUPABASE_SECRET_ROTATION.md`](SUPABASE_SECRET_ROTATION.md).
 
 Variables attendues :
 
@@ -180,6 +181,9 @@ Le fichier `render.yaml` déclare les variables d'environnement de production
 pour l'API : `NODE_ENV`, `PORT`, `APP_VERSION`, `SUPABASE_URL`,
 `SUPABASE_SECRET_KEY`, `RESEND_API_KEY`, `CONTACT_FROM_EMAIL`,
 `CONTACT_TO_EMAIL`, `CORS_ALLOWED_ORIGINS`, `CORS_ALLOWED_ORIGIN_PATTERNS`.
+La procédure de vérification et de finalisation manuelle dans le dashboard
+Render est documentée dans
+[`RENDER_ENV_FINALIZATION.md`](RENDER_ENV_FINALIZATION.md).
 
 ## Convention de gestion
 

--- a/docs/runbooks/INCIDENT_SECRET_ROTATION_COMMENT_TEMPLATE.md
+++ b/docs/runbooks/INCIDENT_SECRET_ROTATION_COMMENT_TEMPLATE.md
@@ -1,0 +1,84 @@
+# Modèle de commentaire d'incident — rotation secrets Supabase + Render
+
+Copier-coller ce bloc dans un ticket ou un commentaire d'incident pour suivre
+une rotation manuelle des secrets Supabase et la finalisation Render associée.
+
+```text
+## Incident — rotation secrets Supabase + finalisation Render
+
+Date: YYYY-MM-DD
+Opérateur: @Ange230700
+Dépôt: Ange230700/kraak-consulting
+
+### Supabase
+
+Supabase dashboard > projet > Settings > API Keys
+
+[ ] Staging (`kraak` / `qgttdsnupelohowwkkwb`)
+[ ] Créer une nouvelle Secret key
+[ ] Remplacer `SUPABASE_SECRET_KEY` dans `apps/api/.env`, `apps/api/.env.staging`, Render staging, secrets CI si présents
+[ ] Vérifier `SUPABASE_URL=https://qgttdsnupelohowwkkwb.supabase.co` + cohérence avec `SUPABASE_PUBLISHABLE_KEY`
+[ ] Vérifier l'API staging + logs
+[ ] Supprimer l'ancienne Secret key compromise
+
+[ ] Production (`kraak-prod` / `pwuivkqnmjpxxpppmnvu`)
+[ ] Créer une nouvelle Secret key
+[ ] Remplacer `SUPABASE_SECRET_KEY` dans `apps/api/.env.prod`, Render prod, secrets CI prod si présents
+[ ] Vérifier `SUPABASE_URL=https://pwuivkqnmjpxxpppmnvu.supabase.co` + cohérence avec `SUPABASE_PUBLISHABLE_KEY`
+[ ] Vérifier l'API prod + logs
+[ ] Supprimer l'ancienne Secret key compromise
+
+[ ] Ne pas faire tourner `sb_publishable_*` sauf décision explicite d'incident plus large
+
+### Render
+
+Render dashboard > service > Environment > Environment Variables
+
+[ ] API staging (`kraak-api-staging`)
+[ ] Vérifier / remplacer : SUPABASE_URL, SUPABASE_SECRET_KEY, SUPABASE_PUBLISHABLE_KEY, RESEND_API_KEY, CONTACT_FROM_EMAIL, CONTACT_TO_EMAIL, CORS_ALLOWED_ORIGINS, CORS_ALLOWED_ORIGIN_PATTERNS
+[ ] Save and deploy
+[ ] Vérifier https://kraak-api-staging.onrender.com/health + logs
+
+[ ] Web staging (`kraak-web-staging`) si impact front
+[ ] Vérifier / remplacer : CLIENT_API_BASE_URL, CLIENT_FEATURE_PARTICIPANT_AREA, CLIENT_SITE_URL
+[ ] Save, rebuild, and deploy
+[ ] Vérifier la home + appels API
+
+[ ] API prod (`kraak-api-prod`)
+[ ] Vérifier / remplacer : SUPABASE_URL, SUPABASE_SECRET_KEY, SUPABASE_PUBLISHABLE_KEY, RESEND_API_KEY, CONTACT_FROM_EMAIL, CONTACT_TO_EMAIL, CORS_ALLOWED_ORIGINS, CORS_ALLOWED_ORIGIN_PATTERNS
+[ ] Save and deploy
+[ ] Vérifier https://kraak-api-prod.onrender.com/health + logs
+
+[ ] Web prod (`kraak-web-prod`) si impact front
+[ ] Vérifier / remplacer : CLIENT_API_BASE_URL, CLIENT_FEATURE_PARTICIPANT_AREA, CLIENT_SITE_URL
+[ ] Save, rebuild, and deploy
+[ ] Vérifier la home + appels API
+
+### Résultat
+
+[ ] Rotation staging terminée
+[ ] Rotation production terminée
+[ ] Render staging finalisé
+[ ] Render production finalisé
+[ ] Anciennes Secret keys Supabase révoquées
+[ ] Vérifications `/health` et logs OK
+
+### Références
+
+- Supabase : `docs/runbooks/SUPABASE_SECRET_ROTATION.md`
+- Render : `docs/runbooks/RENDER_ENV_FINALIZATION.md`
+
+## Post-mortem court
+Cause:
+- <cause racine confirmée ou hypothèse la plus probable>
+Impact:
+- <services touchés>
+- <utilisateurs / flux touchés>
+Fenêtre:
+- Début: YYYY-MM-DD HH:MM TZ
+- Fin: YYYY-MM-DD HH:MM TZ
+Actions restantes:
+- [ ] <action 1>
+- [ ] <action 2>
+- [ ] <action 3>
+```

--- a/docs/runbooks/RELEASE_PROD.md
+++ b/docs/runbooks/RELEASE_PROD.md
@@ -55,7 +55,6 @@ des étapes migration ou smoke test.
   - `Format & Lint`
   - `Build`
   - `Tests unitaires`
-  - `Tests E2E`
   - `Workspace Checks`
 - Linear history (rebase only — déjà aligné avec le workflow Git du repo)
 - Restrict who can push : mainteneurs uniquement

--- a/docs/runbooks/RENDER_ENV_FINALIZATION.md
+++ b/docs/runbooks/RENDER_ENV_FINALIZATION.md
@@ -1,0 +1,247 @@
+# Finalisation manuelle des variables Render
+
+Ce runbook décrit la procédure manuelle dans le dashboard Render pour finaliser
+une mise à jour d'environnement après rotation de secret, changement d'URL, ou
+correction de configuration.
+
+Contexte KRAAK au 2 juin 2026 :
+
+- API staging : `kraak-api-staging`
+- API production : `kraak-api-prod`
+- Web staging : `kraak-web-staging`
+- Web production : `kraak-web-prod`
+
+## Chemin exact dans le dashboard
+
+Pour modifier les variables d'un service Render :
+
+1. Ouvrir `https://dashboard.render.com/`
+2. Sélectionner le service concerné
+3. Cliquer sur `Environment` dans le panneau de gauche
+4. Aller à la section `Environment Variables`
+5. Modifier ou ajouter la variable
+6. Choisir l'option de sauvegarde adaptée
+
+Options de sauvegarde à utiliser :
+
+- service API Docker : `Save and deploy`
+- site web statique : `Save, rebuild, and deploy`
+- `Save only` uniquement si l'on prépare une vague de changements sans cutover immédiat
+
+## Ordre d'exécution recommandé
+
+1. Finaliser `kraak-api-staging`
+2. Vérifier `/health` et les logs staging
+3. Finaliser `kraak-web-staging` si une variable web a changé
+4. Reproduire ensuite sur `kraak-api-prod`
+5. Finaliser `kraak-web-prod` si une variable web a changé
+
+## Version ultra courte pour ticket d'incident
+
+Version fusionnée avec Supabase disponible dans
+[`INCIDENT_SECRET_ROTATION_COMMENT_TEMPLATE.md`](INCIDENT_SECRET_ROTATION_COMMENT_TEMPLATE.md).
+
+```text
+Render dashboard > service > Environment > Environment Variables
+
+[ ] API staging (`kraak-api-staging`)
+[ ] Vérifier / remplacer : SUPABASE_URL, SUPABASE_SECRET_KEY, SUPABASE_PUBLISHABLE_KEY, RESEND_API_KEY, CONTACT_FROM_EMAIL, CONTACT_TO_EMAIL, CORS_ALLOWED_ORIGINS, CORS_ALLOWED_ORIGIN_PATTERNS
+[ ] Save and deploy
+[ ] Vérifier https://kraak-api-staging.onrender.com/health + logs
+
+[ ] Web staging (`kraak-web-staging`) si impact front
+[ ] Vérifier / remplacer : CLIENT_API_BASE_URL, CLIENT_FEATURE_PARTICIPANT_AREA, CLIENT_SITE_URL
+[ ] Save, rebuild, and deploy
+[ ] Vérifier la home + appels API
+
+[ ] API prod (`kraak-api-prod`)
+[ ] Vérifier / remplacer : SUPABASE_URL, SUPABASE_SECRET_KEY, SUPABASE_PUBLISHABLE_KEY, RESEND_API_KEY, CONTACT_FROM_EMAIL, CONTACT_TO_EMAIL, CORS_ALLOWED_ORIGINS, CORS_ALLOWED_ORIGIN_PATTERNS
+[ ] Save and deploy
+[ ] Vérifier https://kraak-api-prod.onrender.com/health + logs
+
+[ ] Web prod (`kraak-web-prod`) si impact front
+[ ] Vérifier / remplacer : CLIENT_API_BASE_URL, CLIENT_FEATURE_PARTICIPANT_AREA, CLIENT_SITE_URL
+[ ] Save, rebuild, and deploy
+[ ] Vérifier la home + appels API
+```
+
+## API staging
+
+### Service cible API staging
+
+- `kraak-api-staging`
+- Dashboard : `Render Dashboard` > `kraak-api-staging` > `Environment`
+
+### Variables à vérifier pour l'API staging
+
+Variables déclarées dans `render.yaml` pour ce service :
+
+- `NODE_ENV=production`
+- `PORT=3000`
+- `APP_VERSION`
+- `SUPABASE_URL`
+- `SUPABASE_SECRET_KEY`
+- `SUPABASE_PUBLISHABLE_KEY`
+- `RESEND_API_KEY`
+- `CONTACT_FROM_EMAIL`
+- `CONTACT_TO_EMAIL`
+- `CORS_ALLOWED_ORIGINS`
+- `CORS_ALLOWED_ORIGIN_PATTERNS`
+
+### Valeurs à contrôler en priorité pour l'API staging
+
+- `SUPABASE_URL` pointe vers le projet staging attendu
+- `SUPABASE_SECRET_KEY` est la nouvelle valeur active staging
+- `SUPABASE_PUBLISHABLE_KEY` correspond au même projet Supabase que l'URL
+- `RESEND_API_KEY` est la nouvelle clé active staging
+- `CONTACT_FROM_EMAIL` et `CONTACT_TO_EMAIL` restent cohérents avec l'exploitation KRAAK
+- `CORS_ALLOWED_ORIGINS` contient au minimum les surfaces web réellement utilisées
+- `CORS_ALLOWED_ORIGIN_PATTERNS` couvre les previews Vercel si elles restent autorisées
+
+### Validation après sauvegarde pour l'API staging
+
+1. Attendre le redeploy de `kraak-api-staging`
+2. Vérifier `https://kraak-api-staging.onrender.com/health`
+3. Vérifier les logs de démarrage Render
+4. Confirmer l'absence d'erreurs `401`, `403`, `Invalid API key`, `CORS` ou `Missing env`
+
+## API production
+
+### Service cible API production
+
+- `kraak-api-prod`
+- Dashboard : `Render Dashboard` > `kraak-api-prod` > `Environment`
+
+### Variables à vérifier pour l'API production
+
+Variables déclarées dans `render.yaml` pour ce service :
+
+- `NODE_ENV=production`
+- `PORT=3000`
+- `APP_VERSION`
+- `SUPABASE_URL`
+- `SUPABASE_SECRET_KEY`
+- `SUPABASE_PUBLISHABLE_KEY`
+- `RESEND_API_KEY`
+- `CONTACT_FROM_EMAIL`
+- `CONTACT_TO_EMAIL`
+- `CORS_ALLOWED_ORIGINS`
+- `CORS_ALLOWED_ORIGIN_PATTERNS`
+
+### Valeurs à contrôler en priorité pour l'API production
+
+- `SUPABASE_URL` pointe vers le projet production attendu
+- `SUPABASE_SECRET_KEY` est la nouvelle valeur active production
+- `SUPABASE_PUBLISHABLE_KEY` correspond au projet Supabase prod
+- `RESEND_API_KEY` est la nouvelle clé active production
+- `CONTACT_FROM_EMAIL` et `CONTACT_TO_EMAIL` sont conformes à la prod
+- `CORS_ALLOWED_ORIGINS` n'autorise que les origines publiques attendues
+- `CORS_ALLOWED_ORIGIN_PATTERNS` reste volontairement limité ou vide si inutile
+
+### Validation après sauvegarde pour l'API production
+
+1. Attendre le redeploy de `kraak-api-prod`
+2. Vérifier `https://kraak-api-prod.onrender.com/health`
+3. Vérifier les logs de démarrage Render
+4. Confirmer l'absence d'erreurs d'auth Supabase, d'email transactionnel, ou de CORS
+
+## Web staging
+
+### Service cible web staging
+
+- `kraak-web-staging`
+- Dashboard : `Render Dashboard` > `kraak-web-staging` > `Environment`
+
+### Variables à vérifier pour le web staging
+
+Variables déclarées dans `render.yaml` pour ce service :
+
+- `CLIENT_API_BASE_URL=https://kraak-api-staging.onrender.com`
+- `CLIENT_FEATURE_PARTICIPANT_AREA=true`
+- `CLIENT_SITE_URL`
+
+### Valeurs à contrôler en priorité pour le web staging
+
+- `CLIENT_API_BASE_URL` pointe bien vers `https://kraak-api-staging.onrender.com`
+- `CLIENT_FEATURE_PARTICIPANT_AREA` reste aligné avec la stratégie staging
+- `CLIENT_SITE_URL` correspond à l'URL publique réellement exposée
+
+### Validation après sauvegarde pour le web staging
+
+1. Lancer `Save, rebuild, and deploy`
+2. Ouvrir la home staging
+3. Vérifier que les appels API partent vers la bonne base URL
+4. Vérifier qu'aucun écran critique ne casse au chargement
+
+## Web production
+
+### Service cible web production
+
+- `kraak-web-prod`
+- Dashboard : `Render Dashboard` > `kraak-web-prod` > `Environment`
+
+### Variables à vérifier pour le web production
+
+Variables déclarées dans `render.yaml` pour ce service :
+
+- `CLIENT_API_BASE_URL=https://kraak-api-prod.onrender.com`
+- `CLIENT_FEATURE_PARTICIPANT_AREA=false`
+- `CLIENT_SITE_URL`
+
+### Valeurs à contrôler en priorité pour le web production
+
+- `CLIENT_API_BASE_URL` pointe bien vers `https://kraak-api-prod.onrender.com`
+- `CLIENT_FEATURE_PARTICIPANT_AREA` reste aligné avec le périmètre public prod
+- `CLIENT_SITE_URL` correspond à l'URL publique de production
+
+### Validation après sauvegarde pour le web production
+
+1. Lancer `Save, rebuild, and deploy`
+2. Ouvrir la home production
+3. Vérifier que les appels API partent vers la bonne base URL
+4. Vérifier l'absence d'erreurs console bloquantes
+
+## Check-list exécutable
+
+### Check-list API staging
+
+- [ ] Service `kraak-api-staging` ouvert dans `Environment`
+- [ ] `SUPABASE_SECRET_KEY` vérifiée ou remplacée
+- [ ] `RESEND_API_KEY` vérifiée ou remplacée
+- [ ] `SUPABASE_URL` et `SUPABASE_PUBLISHABLE_KEY` cohérents
+- [ ] `CORS_ALLOWED_ORIGINS` et `CORS_ALLOWED_ORIGIN_PATTERNS` vérifiés
+- [ ] `Save and deploy` exécuté
+- [ ] `/health` et logs OK
+
+### Check-list API production
+
+- [ ] Service `kraak-api-prod` ouvert dans `Environment`
+- [ ] `SUPABASE_SECRET_KEY` vérifiée ou remplacée
+- [ ] `RESEND_API_KEY` vérifiée ou remplacée
+- [ ] `SUPABASE_URL` et `SUPABASE_PUBLISHABLE_KEY` cohérents
+- [ ] `CORS_ALLOWED_ORIGINS` et `CORS_ALLOWED_ORIGIN_PATTERNS` vérifiés
+- [ ] `Save and deploy` exécuté
+- [ ] `/health` et logs OK
+
+### Check-list web staging
+
+- [ ] Service `kraak-web-staging` ouvert dans `Environment`
+- [ ] `CLIENT_API_BASE_URL` vérifiée
+- [ ] `CLIENT_SITE_URL` vérifiée
+- [ ] `Save, rebuild, and deploy` exécuté si nécessaire
+- [ ] Contrôle manuel de la home OK
+
+### Check-list web production
+
+- [ ] Service `kraak-web-prod` ouvert dans `Environment`
+- [ ] `CLIENT_API_BASE_URL` vérifiée
+- [ ] `CLIENT_SITE_URL` vérifiée
+- [ ] `Save, rebuild, and deploy` exécuté si nécessaire
+- [ ] Contrôle manuel de la home OK
+
+## Points d'attention
+
+- Les variables `sync: false` de `render.yaml` ne se remettent pas à jour toutes seules sur un service existant ; elles doivent être contrôlées manuellement dans le dashboard.
+- Pour l'API, un changement de variable d'environnement ne nécessite pas de rebuild d'image ; un redeploy suffit.
+- Pour le web statique, préférer un rebuild complet si la variable influence le build ou le runtime-config généré.
+- Ne jamais coller une ancienne valeur par commodité sans vérifier qu'elle correspond bien au bon environnement staging ou production.

--- a/docs/runbooks/SUPABASE_SECRET_ROTATION.md
+++ b/docs/runbooks/SUPABASE_SECRET_ROTATION.md
@@ -1,0 +1,183 @@
+# Rotation des clés Supabase
+
+Ce runbook décrit la procédure de finalisation manuelle dans le dashboard
+Supabase quand une `sb_secret_*` a été exposée localement.
+
+Contexte KRAAK au 2 juin 2026 :
+
+- staging : projet `kraak` (`qgttdsnupelohowwkkwb`)
+- production : projet `kraak-prod` (`pwuivkqnmjpxxpppmnvu`)
+
+## Ce qui doit être tourné
+
+À faire immédiatement :
+
+1. créer une nouvelle `secret key` sur chaque projet
+2. remplacer la valeur dans les environnements qui l'utilisent
+3. supprimer l'ancienne `secret key` en la marquant compromise
+
+À ne pas traiter comme incident prioritaire :
+
+- `sb_publishable_*` : clé publique, conçue pour être exposée côté client
+- `anon` : clé legacy publique, à surveiller mais pas prioritaire dans ce cas
+
+## Préparation
+
+Avant d'ouvrir le dashboard, préparer ces emplacements de remplacement :
+
+- local API : `apps/api/.env`
+- local staging : `apps/api/.env.staging`
+- local production : `apps/api/.env.prod`
+- Render staging : variables du service API staging
+- Render production : variables du service API production
+- GitHub Actions / environnements si une `SUPABASE_SECRET_KEY` y existe
+
+Ne supprimer aucune ancienne clé avant d'avoir propagé la nouvelle partout.
+
+## Version ultra courte pour ticket d'incident
+
+Version fusionnée avec Render disponible dans
+[`INCIDENT_SECRET_ROTATION_COMMENT_TEMPLATE.md`](INCIDENT_SECRET_ROTATION_COMMENT_TEMPLATE.md).
+
+```text
+Supabase dashboard > projet > Settings > API Keys
+
+[ ] Staging (`kraak` / `qgttdsnupelohowwkkwb`)
+[ ] Créer une nouvelle Secret key
+[ ] Remplacer `SUPABASE_SECRET_KEY` dans `apps/api/.env`, `apps/api/.env.staging`, Render staging, secrets CI si présents
+[ ] Vérifier `SUPABASE_URL=https://qgttdsnupelohowwkkwb.supabase.co` + cohérence avec `SUPABASE_PUBLISHABLE_KEY`
+[ ] Vérifier l'API staging + logs
+[ ] Supprimer l'ancienne Secret key compromise
+
+[ ] Production (`kraak-prod` / `pwuivkqnmjpxxpppmnvu`)
+[ ] Créer une nouvelle Secret key
+[ ] Remplacer `SUPABASE_SECRET_KEY` dans `apps/api/.env.prod`, Render prod, secrets CI prod si présents
+[ ] Vérifier `SUPABASE_URL=https://pwuivkqnmjpxxpppmnvu.supabase.co` + cohérence avec `SUPABASE_PUBLISHABLE_KEY`
+[ ] Vérifier l'API prod + logs
+[ ] Supprimer l'ancienne Secret key compromise
+
+[ ] Ne pas faire tourner `sb_publishable_*` sauf décision explicite d'incident plus large
+```
+
+## Staging
+
+### 1. Créer la nouvelle clé secrète staging
+
+1. Ouvrir le dashboard Supabase.
+2. Sélectionner le projet `kraak`.
+3. Aller dans `Settings` > `API Keys`.
+4. Dans la section des clés modernes, créer une nouvelle clé de type `Secret`.
+5. Nom conseillé : `kraak-staging-2026-06-02-rotation`.
+6. Copier immédiatement la valeur complète, visible une seule fois.
+
+### 2. Remplacer la clé dans les cibles staging
+
+Remplacer `SUPABASE_SECRET_KEY` dans :
+
+1. `apps/api/.env`
+2. `apps/api/.env.staging`
+3. le service Render API staging
+4. tout secret GitHub ou workflow qui consomme la clé staging
+
+Valeurs associées à vérifier sans les changer sauf besoin :
+
+- `SUPABASE_URL=https://qgttdsnupelohowwkkwb.supabase.co`
+- `SUPABASE_PUBLISHABLE_KEY=sb_publishable_...`
+
+### 3. Vérifier staging avant suppression
+
+Contrôles minimaux :
+
+1. l'API staging démarre avec la nouvelle clé
+2. un endpoint backend qui lit Supabase répond correctement
+3. aucun log Render ne montre `401`, `403` ou `Invalid API key`
+
+### 4. Révoquer l'ancienne clé staging
+
+1. Revenir dans `Settings` > `API Keys` du projet `kraak`.
+2. Identifier l'ancienne `secret key` par son préfixe.
+3. Supprimer la clé.
+4. Si le dashboard le propose, renseigner que la clé a été compromise.
+5. Confirmer la suppression.
+
+## Production
+
+### 1. Créer la nouvelle clé secrète production
+
+1. Ouvrir le projet `kraak-prod`.
+2. Aller dans `Settings` > `API Keys`.
+3. Créer une nouvelle clé `Secret`.
+4. Nom conseillé : `kraak-production-2026-06-02-rotation`.
+5. Copier immédiatement la valeur complète.
+
+### 2. Remplacer la clé dans les cibles production
+
+Remplacer `SUPABASE_SECRET_KEY` dans :
+
+1. `apps/api/.env.prod`
+2. le service Render API production
+3. les secrets GitHub / environnements de release production si présents
+
+Valeurs associées à vérifier sans les changer sauf besoin :
+
+- `SUPABASE_URL=https://pwuivkqnmjpxxpppmnvu.supabase.co`
+- `SUPABASE_PUBLISHABLE_KEY=sb_publishable_...`
+
+### 3. Vérifier production avant suppression
+
+Contrôles minimaux :
+
+1. l'API production démarre avec la nouvelle clé
+2. le ou les endpoints backend branchés sur Supabase restent opérationnels
+3. aucun log Render ne montre d'erreur d'auth Supabase
+
+### 4. Révoquer l'ancienne clé production
+
+1. Revenir dans `Settings` > `API Keys` du projet `kraak-prod`.
+2. Identifier l'ancienne `secret key` par son préfixe.
+3. Supprimer la clé.
+4. Si disponible, la marquer compromise.
+5. Confirmer.
+
+## Vérification finale
+
+Après les deux rotations :
+
+1. confirmer que les anciennes clés n'existent plus dans `Settings` > `API Keys`
+2. confirmer que les fichiers locaux n'ont plus l'ancienne valeur
+3. confirmer que Render staging et production portent la nouvelle valeur
+4. relancer une vérification backend simple sur staging puis production
+5. surveiller les logs Supabase et Render pendant quelques minutes
+
+## Check-list exécutable
+
+### Check-list staging
+
+- [ ] Nouvelle `secret key` créée sur `kraak`
+- [ ] `apps/api/.env` mis à jour
+- [ ] `apps/api/.env.staging` mis à jour
+- [ ] Render staging mis à jour
+- [ ] Secrets CI staging mis à jour si présents
+- [ ] Vérification fonctionnelle OK
+- [ ] Ancienne clé supprimée
+
+### Check-list production
+
+- [ ] Nouvelle `secret key` créée sur `kraak-prod`
+- [ ] `apps/api/.env.prod` mis à jour
+- [ ] Render production mis à jour
+- [ ] Secrets CI production mis à jour si présents
+- [ ] Vérification fonctionnelle OK
+- [ ] Ancienne clé supprimée
+
+## Après action
+
+Documenter dans le ticket ou le journal d'incident :
+
+1. les préfixes des anciennes clés révoquées
+2. la date et l'heure de rotation
+3. les systèmes mis à jour
+4. le résultat des vérifications staging et production
+
+Ne jamais consigner la valeur complète d'une clé dans le dépôt, un ticket, ou un
+message de chat.

--- a/scripts/dev-all.mjs
+++ b/scripts/dev-all.mjs
@@ -8,6 +8,24 @@ const portInUsePattern = /Port \d+ is already in use/i;
 const addressInUsePattern = /EADDRINUSE|address already in use/i;
 const maxViteCacheLockLineLength = 16_384;
 
+function parsePortFromEnv(key, fallbackPort) {
+  const rawValue = process.env[key]?.trim();
+  if (!rawValue) {
+    return fallbackPort;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+    return fallbackPort;
+  }
+
+  return parsed;
+}
+
+const webPort = parsePortFromEnv('KRAAK_WEB_PORT', 4200);
+const mobilePort = parsePortFromEnv('KRAAK_MOBILE_PORT', 4300);
+const apiPort = parsePortFromEnv('API_PORT', 3000);
+
 function isViteCacheLockLine(line) {
   if (typeof line !== 'string') {
     return false;
@@ -40,7 +58,7 @@ const services = [
   {
     name: 'web',
     color: '\x1b[36m',
-    preferredPort: 4200,
+    preferredPort: webPort,
     cwd: process.cwd(),
     command: ['pnpm.cmd', '--filter', '@kraak/client', 'run', 'dev:web'],
     portArg: true,
@@ -48,7 +66,7 @@ const services = [
   {
     name: 'mobile',
     color: '\x1b[35m',
-    preferredPort: 4300,
+    preferredPort: mobilePort,
     cwd: process.cwd(),
     command: ['pnpm.cmd', '--filter', '@kraak/client', 'run', 'dev:mobile'],
     portArg: true,
@@ -57,7 +75,7 @@ const services = [
   {
     name: 'api',
     color: '\x1b[32m',
-    preferredPort: 3000,
+    preferredPort: apiPort,
     cwd: process.cwd(),
     command: ['pnpm.cmd', '--filter', '@kraak/api', 'run', 'dev'],
     portArg: false,


### PR DESCRIPTION
## Résumé\n- suppression du job GitHub Actions `Tests E2E` dans la CI\n- alignement de la protection de branche et de la documentation release\n- ajout/liaison des runbooks de rotation secrets Supabase + finalisation Render\n- ajustement du hook pre-push pour éviter le blocage E2E sans variables\n- correction TypeScript sur `client-defaults`\n\n## Validation\n- hooks pre-push exécutés localement (typecheck, format, lint, tests hors E2E)\n- vérification des fichiers workflow et runbooks mis à jour\n\n## Contexte\nLe push direct vers `staging` est protégé dans ce dépôt; cette PR permet de finaliser le flux de merge.