### PR TITLE
chore(ci): optimize affected checks and integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Pipeline CI — kraak-group monorepo
 # Déclenché sur push vers main et sur les pull requests ciblant main.
-# Couvre : format, lint, build, tests unitaires.
+# Couvre : format, lint, build, tests unitaires et integration.
 
 name: CI
 
@@ -13,6 +13,9 @@ on:
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  GIT_EXECUTABLE: /usr/bin/git
 
 jobs:
   # ──────────────────────────────────────────────
@@ -33,6 +36,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --ignore-scripts --frozen-lockfile
 
@@ -45,7 +49,7 @@ jobs:
         run: pnpm format:check
 
       - name: Lint (ESLint)
-        run: pnpm -r lint
+        run: pnpm affected:lint
 
       - name: Lint Supabase lié
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -79,17 +83,12 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --ignore-scripts --frozen-lockfile
 
-      - name: Construire les packages workspace
-        run: pnpm -r --filter "./packages/**" build
-
-      - name: Build web (production SSR)
-        run: pnpm build:web
-
-      - name: Build mobile (production)
-        run: pnpm build:mobile
+      - name: Construire les workspaces affectés
+        run: pnpm affected:build
 
   # ──────────────────────────────────────────────
   # Tests unitaires (Vitest via Angular builder)
@@ -110,14 +109,41 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --ignore-scripts --frozen-lockfile
 
-      - name: Construire les packages workspace
-        run: pnpm -r --filter "./packages/**" build
+      - name: Construire les workspaces affectés
+        run: pnpm affected:build
 
       - name: Exécuter les tests unitaires
-        run: pnpm test:unit
+        run: pnpm affected:test
+
+  # ──────────────────────────────────────────────
+  # Tests integration API
+  # ──────────────────────────────────────────────
+  integration:
+    name: Tests integration
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Install pnpm
+        run: npm install --ignore-scripts -g pnpm@10.23.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: package.json
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: Exécuter les tests integration
+        run: pnpm test:integration
 
   # ──────────────────────────────────────────────
   # Check E2E requis par la protection de branche
@@ -158,6 +184,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --ignore-scripts --frozen-lockfile
 
@@ -198,16 +225,17 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: '21'
 
       - run: pnpm install --ignore-scripts --frozen-lockfile
 
-      - name: Construire les packages workspace
-        run: pnpm -r --filter "./packages/**" build
+      - name: Construire les workspaces affectés
+        run: pnpm affected:build
 
       - name: Build mobile & sync Android
         run: pnpm build:debug:android

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,20 @@
 command -v pnpm >/dev/null 2>&1 || exit 0
-pnpm format
-pnpm lint:fix
-# Restage les fichiers corrigés par les auto-fixers avant de créer le commit.
-git update-index --again
+
+if [ -z "${GIT_EXECUTABLE:-}" ]; then
+	if [ -x "/usr/bin/git" ]; then
+		export GIT_EXECUTABLE="/usr/bin/git"
+	elif [ -x "/usr/local/bin/git" ]; then
+		export GIT_EXECUTABLE="/usr/local/bin/git"
+	elif [ -x "/opt/homebrew/bin/git" ]; then
+		export GIT_EXECUTABLE="/opt/homebrew/bin/git"
+	elif [ -x "/c/Program Files/Git/cmd/git.exe" ]; then
+		export GIT_EXECUTABLE="/c/Program Files/Git/cmd/git.exe"
+	elif [ -x "/c/Program Files/Git/bin/git.exe" ]; then
+		export GIT_EXECUTABLE="/c/Program Files/Git/bin/git.exe"
+	else
+		echo "[husky] GIT_EXECUTABLE introuvable. Définissez la variable avec un chemin absolu vers git." >&2
+		exit 1
+	fi
+fi
+
+pnpm precommit:staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,29 +1,20 @@
 command -v pnpm >/dev/null 2>&1 || exit 0
-set -e
 
-pnpm exec validate-branch-name
+if [ -z "${GIT_EXECUTABLE:-}" ]; then
+	if [ -x "/usr/bin/git" ]; then
+		export GIT_EXECUTABLE="/usr/bin/git"
+	elif [ -x "/usr/local/bin/git" ]; then
+		export GIT_EXECUTABLE="/usr/local/bin/git"
+	elif [ -x "/opt/homebrew/bin/git" ]; then
+		export GIT_EXECUTABLE="/opt/homebrew/bin/git"
+	elif [ -x "/c/Program Files/Git/cmd/git.exe" ]; then
+		export GIT_EXECUTABLE="/c/Program Files/Git/cmd/git.exe"
+	elif [ -x "/c/Program Files/Git/bin/git.exe" ]; then
+		export GIT_EXECUTABLE="/c/Program Files/Git/bin/git.exe"
+	else
+		echo "[husky] GIT_EXECUTABLE introuvable. Définissez la variable avec un chemin absolu vers git." >&2
+		exit 1
+	fi
+fi
 
-# Les contrôles statiques sont indépendants: on les lance en parallèle
-# pour réduire le temps mur du hook sans baisser le niveau de vérification.
-pnpm typecheck &
-typecheck_pid=$!
-
-pnpm format:check &
-format_pid=$!
-
-pnpm lint &
-lint_pid=$!
-
-status=0
-wait "$typecheck_pid" || status=$?
-wait "$format_pid" || status=$?
-wait "$lint_pid" || status=$?
-
-[ "$status" -eq 0 ] || exit "$status"
-
-# Exécuter toutes les suites de tests locales, y compris E2E.
-pnpm test:libs
-pnpm test:api
-pnpm test:unit
-pnpm test:e2e:web
-pnpm test:workspace
+pnpm prepush:smart

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
 shamefully-hoist=false
 strict-peer-dependencies=true
 auto-install-peers=true
+prefer-workspace-packages=true
+save-workspace-protocol=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,20 +235,20 @@ Ces réglages sont déjà appliqués dans le `.git/config` du dépôt. Si vous c
 
 Des vérifications automatiques s'exécutent à chaque étape :
 
-| Moment       | Vérification                                                                | Effet si échec |
-| ------------ | --------------------------------------------------------------------------- | -------------- |
-| `commit-msg` | Format Conventional Commits (commitlint)                                    | Commit rejeté  |
-| `pre-commit` | `pnpm format` + `pnpm lint:fix` + restage automatique des fichiers modifiés | Commit rejeté  |
-| `pre-push`   | Nom de branche valide + `pnpm typecheck` + `pnpm test:api` + tests client   | Push rejeté    |
+| Moment       | Vérification                                                         | Effet si échec |
+| ------------ | -------------------------------------------------------------------- | -------------- |
+| `commit-msg` | Format Conventional Commits (commitlint)                             | Commit rejeté  |
+| `pre-commit` | `lint-staged` (formatage/lint uniquement sur les fichiers indexés)   | Commit rejeté  |
+| `pre-push`   | Nom de branche valide + contrôles ciblés selon les fichiers modifiés | Push rejeté    |
 
 ### Si un hook échoue
 
-- **Formatage** : le hook applique déjà `pnpm format` et restage les fichiers corrigés ; si l'échec persiste, corriger le blocage signalé puis recommiter
+- **Formatage / lint pre-commit** : corriger les erreurs remontées par `lint-staged` puis recommiter
 - **Lint** : corriger les erreurs signalées par ESLint
-- **Typecheck** : corriger les erreurs TypeScript signalées par `pnpm typecheck`
+- **Typecheck** : corriger les erreurs TypeScript signalées par le contrôle ciblé (API, web, mobile, ou global)
 - **Nom de branche** : renommer avec `git branch -m <nouveau-nom>`
 - **Message de commit** : relancer `pnpm commit` et choisir un scope autorisé
-- **Tests** : corriger les tests cassés avant de pousser
+- **Tests** : corriger les tests cassés avant de pousser (les tests E2E exhaustifs restent pilotés par la CI)
 
 ---
 
@@ -281,7 +281,17 @@ pnpm format
 pnpm format:check
 ```
 
-> Le hook `pre-commit` applique automatiquement `pnpm format` et `pnpm lint:fix`, puis restage les fichiers corrigés avant le commit.
+Le hook `pre-commit` s'appuie maintenant sur `lint-staged` pour n'exécuter formatage et lint que sur les fichiers indexés. Le hook `pre-push` exécute `pnpm affected:lint`, `pnpm affected:test` et `pnpm test:integration` sur les zones modifiées, puis garde `pnpm test:workspace` uniquement quand les scripts du dépôt changent, ce qui évite les E2E locales et les checks globaux inutiles.
+
+Les hooks définissent `GIT_EXECUTABLE` avec un chemin absolu vers `git` (ou utilisent une valeur déjà fournie par l'environnement) pour verrouiller le binaire appelé. En CI, `GIT_EXECUTABLE` est fixé globalement à `/usr/bin/git`.
+
+Pour accélérer les vérifications locales sur une branche de travail, utiliser d'abord les scripts ciblés suivants quand la portée est limitée :
+
+- `pnpm affected:lint`
+- `pnpm affected:test`
+- `pnpm affected:build`
+
+En CI, conserver le cache pnpm déjà configuré via `actions/setup-node` et, si un nouveau workflow est ajouté, garder `cache: pnpm` avec `cache-dependency-path: pnpm-lock.yaml` pour stabiliser les temps d'installation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ publique de contenu. Voir
 | `pnpm build:mobile:local`   | Builder l'app mobile avec l'environnement local           |
 | `pnpm build:mobile:staging` | Builder l'app mobile avec l'environnement staging         |
 | `pnpm test:api`             | Tests unitaires API                                       |
+| `pnpm test:api:unit`        | Tests unitaires API hors intégration                      |
+| `pnpm test:integration`     | Tests d'intégration API                                   |
 | `pnpm splinter:local`       | Lancer Splinter (Supabase Advisors) sur la DB locale      |
 | `pnpm splinter:linked`      | Lancer Splinter (Supabase Advisors) sur le projet lié     |
 | `pnpm splinter:sec`         | Lancer les checks sécurité Splinter sur le projet lié     |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,8 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "test": "jest",
+    "test:unit": "jest --testPathIgnorePatterns=src/integration/ --runInBand",
+    "test:integration": "jest src/integration --runInBand",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage"
   },

--- a/apps/api/src/integration/critical-modules.integration.spec.ts
+++ b/apps/api/src/integration/critical-modules.integration.spec.ts
@@ -18,9 +18,14 @@ import { ProgramsController } from '../programs/programs.controller';
 import { ProgramsService } from '../programs/programs.service';
 import { ResourcesController } from '../resources/resources.controller';
 import { ResourcesService } from '../resources/resources.service';
+import { ServicesController } from '../services/services.controller';
+import { ServicesService } from '../services/services.service';
 import { SupportController } from '../support/support.controller';
 import { SupportRequestsController } from '../support/support-requests.controller';
 import { SupportService } from '../support/support.service';
+import { DashboardController } from '../dashboard/dashboard.controller';
+import { DashboardService } from '../dashboard/dashboard.service';
+import { ArticlesPublicController } from '../articles/articles-public.controller';
 
 async function buildHttpApp(options: {
   controllers: Array<Type<unknown>>;
@@ -196,9 +201,13 @@ describe('Critical API Modules Integration', () => {
     let app: INestApplication;
 
     const resourcesServiceMock: jest.Mocked<
-      Pick<ResourcesService, 'listResources' | 'trackResourceConsultation'>
+      Pick<
+        ResourcesService,
+        'listResources' | 'getResourceById' | 'trackResourceConsultation'
+      >
     > = {
       listResources: jest.fn(),
+      getResourceById: jest.fn(),
       trackResourceConsultation: jest.fn(),
     };
 
@@ -221,6 +230,22 @@ describe('Critical API Modules Integration', () => {
       resourcesServiceMock.listResources.mockResolvedValue({
         data: [],
         total: 0,
+      });
+      resourcesServiceMock.getResourceById.mockResolvedValue({
+        id: 'resource-1',
+        programId: 'program-1',
+        cohortId: null,
+        title: 'Fiche pratique',
+        description: 'Document utile',
+        resourceType: 'document',
+        resourceTheme: 'training',
+        resourceAudience: 'all',
+        url: null,
+        filePath: '/files/resource-1.pdf',
+        status: 'published',
+        publishedAt: '2026-01-06T10:00:00.000Z',
+        createdAt: '2026-01-06T10:00:00.000Z',
+        updatedAt: '2026-01-06T10:00:00.000Z',
       });
       resourcesServiceMock.trackResourceConsultation.mockResolvedValue(
         undefined,
@@ -258,6 +283,33 @@ describe('Critical API Modules Integration', () => {
       expect(
         resourcesServiceMock.trackResourceConsultation,
       ).toHaveBeenCalledWith('resource-1');
+    });
+
+    it('Given a published resource exists, When loading it by id, Then it returns 200 and forwards the identifier', async () => {
+      const response = await (request(app.getHttpServer())
+        .get('/resources/resource-1')
+        .expect(200) as unknown as Promise<{ body: { id: string } }>);
+
+      expect(response.body.id).toBe('resource-1');
+      expect(resourcesServiceMock.getResourceById).toHaveBeenCalledWith(
+        'resource-1',
+      );
+    });
+
+    it('Given a published resource is missing, When loading it by id, Then it returns 404', async () => {
+      resourcesServiceMock.getResourceById.mockRejectedValueOnce(
+        new NotFoundException(
+          'Resource with ID resource-404 not found or is not published.',
+        ),
+      );
+
+      await (request(app.getHttpServer())
+        .get('/resources/resource-404')
+        .expect(404) as unknown as Promise<void>);
+
+      expect(resourcesServiceMock.getResourceById).toHaveBeenCalledWith(
+        'resource-404',
+      );
     });
   });
 
@@ -319,6 +371,213 @@ describe('Critical API Modules Integration', () => {
         'participant-token',
         '1',
         '10',
+      );
+    });
+  });
+
+  describe('SVC-02 Public services endpoints', () => {
+    let app: INestApplication;
+
+    const servicesServiceMock: jest.Mocked<
+      Pick<ServicesService, 'listServices' | 'getServiceById'>
+    > = {
+      listServices: jest.fn(),
+      getServiceById: jest.fn(),
+    };
+
+    const authServiceMock: jest.Mocked<Pick<AuthService, 'getSession'>> = {
+      getSession: jest.fn(),
+    };
+
+    const serviceFixture = {
+      id: 'service-1',
+      title: 'Formation',
+      description: 'Accompagner les apprenants',
+      icon: 'graduation-cap',
+      sortOrder: 1,
+      createdAt: '2026-01-03T10:00:00.000Z',
+      updatedAt: '2026-01-03T10:00:00.000Z',
+    };
+
+    const serviceWithDetailsFixture = {
+      ...serviceFixture,
+      details: [
+        {
+          id: 'detail-1',
+          serviceId: 'service-1',
+          title: 'Ateliers',
+          description: 'Ateliers pratiques et ciblés',
+          sortOrder: 1,
+          createdAt: '2026-01-03T10:00:00.000Z',
+          updatedAt: '2026-01-03T10:00:00.000Z',
+        },
+      ],
+    };
+
+    beforeAll(async () => {
+      app = await buildHttpApp({
+        controllers: [ServicesController],
+        providers: [
+          { provide: ServicesService, useValue: servicesServiceMock },
+          { provide: AuthService, useValue: authServiceMock },
+        ],
+      });
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      servicesServiceMock.listServices.mockResolvedValue([serviceFixture]);
+      servicesServiceMock.getServiceById.mockResolvedValue(
+        serviceWithDetailsFixture,
+      );
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('Given public services exist, When listing services, Then it returns 200 and forwards the list', async () => {
+      const response = await (request(app.getHttpServer())
+        .get('/services')
+        .expect(200) as unknown as Promise<{ body: unknown[] }>);
+
+      expect(response.body).toHaveLength(1);
+      expect(servicesServiceMock.listServices).toHaveBeenCalledTimes(1);
+    });
+
+    it('Given a public service exists, When loading the service detail, Then it returns 200 with the details', async () => {
+      const response = await (request(app.getHttpServer())
+        .get('/services/service-1')
+        .expect(200) as unknown as Promise<{ body: { details: unknown[] } }>);
+
+      expect(response.body.details).toHaveLength(1);
+      expect(servicesServiceMock.getServiceById).toHaveBeenCalledWith(
+        'service-1',
+      );
+    });
+  });
+
+  describe('ART-01 Public articles endpoints', () => {
+    let app: INestApplication;
+
+    const articlesServiceMock: jest.Mocked<
+      Pick<ArticlesService, 'listPublicArticles' | 'getPublicArticleBySlug'>
+    > = {
+      listPublicArticles: jest.fn(),
+      getPublicArticleBySlug: jest.fn(),
+    };
+
+    const articleFixture = {
+      id: 'article-public-1',
+      slug: 'integration-in-public',
+      title: 'Intégration en pratique',
+      excerpt: 'Apprendre à intégrer les parcours',
+      content: '<p>Contenu public</p>',
+      status: 'published' as const,
+      coverImageUrl: null,
+      seoTitle: 'Intégration en pratique',
+      seoDescription: 'Article public de démonstration',
+      publishedAt: '2026-01-04T10:00:00.000Z',
+      authorId: 'author-1',
+      categories: [],
+      tags: [],
+      createdAt: '2026-01-04T10:00:00.000Z',
+      updatedAt: '2026-01-04T10:00:00.000Z',
+    };
+
+    beforeAll(async () => {
+      app = await buildHttpApp({
+        controllers: [ArticlesPublicController],
+        providers: [
+          { provide: ArticlesService, useValue: articlesServiceMock },
+        ],
+      });
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      articlesServiceMock.listPublicArticles.mockResolvedValue([
+        articleFixture,
+      ]);
+      articlesServiceMock.getPublicArticleBySlug.mockResolvedValue(
+        articleFixture,
+      );
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('Given public articles exist, When listing articles, Then it returns 200 and forwards the list', async () => {
+      const response = await (request(app.getHttpServer())
+        .get('/articles')
+        .expect(200) as unknown as Promise<{ body: unknown[] }>);
+
+      expect(response.body).toHaveLength(1);
+      expect(articlesServiceMock.listPublicArticles).toHaveBeenCalledTimes(1);
+    });
+
+    it('Given a public article exists, When loading it by slug, Then it returns 200 and forwards the slug', async () => {
+      const response = await (request(app.getHttpServer())
+        .get('/articles/integration-in-public')
+        .expect(200) as unknown as Promise<{ body: { slug: string } }>);
+
+      expect(response.body.slug).toBe('integration-in-public');
+      expect(articlesServiceMock.getPublicArticleBySlug).toHaveBeenCalledWith(
+        'integration-in-public',
+      );
+    });
+  });
+
+  describe('DSH-03 Dashboard participant endpoint', () => {
+    let app: INestApplication;
+
+    const dashboardServiceMock: jest.Mocked<
+      Pick<DashboardService, 'getAggregate'>
+    > = {
+      getAggregate: jest.fn(),
+    };
+
+    beforeAll(async () => {
+      app = await buildHttpApp({
+        controllers: [DashboardController],
+        providers: [
+          { provide: DashboardService, useValue: dashboardServiceMock },
+        ],
+      });
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      dashboardServiceMock.getAggregate.mockResolvedValue({
+        generatedAt: '2026-01-05T10:00:00.000Z',
+        programs: [],
+        upcomingSessions: [],
+        recentAnnouncements: [],
+      });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('Given a missing authorization header, When loading the dashboard, Then it returns 401', async () => {
+      await (request(app.getHttpServer())
+        .get('/dashboard')
+        .expect(401) as unknown as Promise<void>);
+
+      expect(dashboardServiceMock.getAggregate).not.toHaveBeenCalled();
+    });
+
+    it('Given a valid access token, When loading the dashboard, Then it returns 200 and forwards the token', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/dashboard')
+        .set('authorization', 'Bearer participant-token')
+        .expect(200);
+
+      expect(response.body.generatedAt).toBe('2026-01-05T10:00:00.000Z');
+      expect(dashboardServiceMock.getAggregate).toHaveBeenCalledWith(
+        'participant-token',
       );
     });
   });

--- a/package.json
+++ b/package.json
@@ -50,16 +50,22 @@
     "splinter:perf": "pnpm splinter:performance:linked",
     "build:api": "pnpm --filter @kraak/api build",
     "check:observability": "node ./scripts/check-observability.mjs",
-    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/setup-android-env.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs ./scripts/angular-web-build-config.test.mjs ./scripts/finalize-web-prerender.test.mjs ./scripts/sonarcloud-scan.test.mjs",
+    "test:workspace": "node --test ./scripts/workspace-commands.test.mjs ./scripts/ensure-capacitor-platform.test.mjs ./scripts/setup-android-env.test.mjs ./scripts/verify-supabase-auth-config.test.mjs ./scripts/verify-mobile-dev-server-config.test.mjs ./scripts/verify-capacitor-android-plugins.test.mjs ./scripts/check-observability.test.mjs ./scripts/vercel-config.test.mjs ./scripts/angular-web-build-config.test.mjs ./scripts/finalize-web-prerender.test.mjs ./scripts/sonarcloud-scan.test.mjs ./scripts/affected-workspaces.test.mjs",
     "test:api": "pnpm --filter @kraak/api test",
     "test:api:journey": "npx newman run test-results/postman/api-user-journey.collection.json --reporters cli,json --reporter-json-export test-results/postman/api-user-journey.report.json",
     "test:api:journey:strict": "npx newman run test-results/postman/api-user-journey.collection.json --reporters cli,json --reporter-json-export test-results/postman/api-user-journey.report.json --env-var strictAuth=true",
     "test:api:journey:strict:staging": "npx newman run test-results/postman/api-user-journey.collection.json --reporters cli,json --reporter-json-export test-results/postman/api-user-journey.report.json --env-var strictAuth=true --env-var baseUrl=https://kraak-api-staging.onrender.com",
     "test:libs": "pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test",
+    "test:api:unit": "pnpm --filter @kraak/api test:unit",
+    "test:integration": "pnpm --filter @kraak/api test:integration",
     "test:coverage": "pnpm --filter @kraak/api test:cov && pnpm --filter @kraak/client test:coverage && pnpm -r --filter @kraak/contracts --filter @kraak/domain --filter @kraak/api-client --filter @kraak/tokens test:coverage",
     "lint:api": "pnpm --filter @kraak/api lint",
     "lint": "pnpm -r lint && pnpm splinter:linked",
+    "lint:code": "pnpm -r lint",
     "lint:fix": "pnpm -r lint:fix",
+    "affected:lint": "node ./scripts/affected-workspaces.mjs lint",
+    "affected:test": "node ./scripts/affected-workspaces.mjs test",
+    "affected:build": "node ./scripts/affected-workspaces.mjs build",
     "typecheck:web": "pnpm --filter @kraak/client exec tsc --noEmit -p projects/web/tsconfig.app.json",
     "typecheck:mobile": "pnpm --filter @kraak/client exec tsc --noEmit -p projects/mobile/tsconfig.app.json",
     "typecheck:api": "pnpm --filter @kraak/api exec tsc --noEmit -p tsconfig.build.json",
@@ -72,6 +78,8 @@
     "check:prepilot:web": "pnpm --filter @kraak/client e2e:prepilot",
     "format": "prettier --write \"**/*.{ts,html,scss,css,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,html,scss,css,json,md}\"",
+    "precommit:staged": "lint-staged --concurrent true",
+    "prepush:smart": "node ./scripts/husky-pre-push.mjs",
     "commit": "git-cz",
     "prepare": "husky",
     "save": "git add . && pnpm commit && git push origin HEAD",
@@ -86,6 +94,17 @@
     "commitizen": {
       "path": "cz-git"
     }
+  },
+  "lint-staged": {
+    "apps/api/src/**/*.ts": [
+      "pnpm --filter @kraak/api exec eslint --fix --cache --cache-location .cache/eslint/.eslintcache --max-warnings=0"
+    ],
+    "apps/client/**/*.{ts,html}": [
+      "pnpm --filter @kraak/client exec eslint --fix --cache --cache-location .cache/eslint/.eslintcache --max-warnings=0"
+    ],
+    "**/*.{ts,js,mjs,cjs,html,scss,css,json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   },
   "cz-git": {
     "disableEmoji": true,
@@ -118,6 +137,7 @@
     "commitizen": "^4.3.1",
     "cz-git": "^1.12.0",
     "husky": "^9.1.7",
+    "lint-staged": "^16.2.6",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "sharp": "^0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      lint-staged:
+        specifier: ^16.2.6
+        version: 16.4.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -249,7 +252,7 @@ importers:
         version: 21.3.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       '@angular/build':
         specifier: 21.2.11
-        version: 21.2.11(bfefb54524d36c8d89865e35f7ad2fae)
+        version: 21.2.11(f41801f63592db3e58ee8df1bae34e3b)
       '@angular/cli':
         specifier: 21.2.11
         version: 21.2.11(@types/node@20.19.39)
@@ -321,7 +324,7 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
 
   packages/api-client:
     dependencies:
@@ -355,7 +358,7 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
 
   packages/contracts:
     dependencies:
@@ -380,7 +383,7 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
 
   packages/domain:
     dependencies:
@@ -405,7 +408,7 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
 
   packages/tokens:
     devDependencies:
@@ -426,7 +429,7 @@ importers:
         version: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+        version: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
 
 packages:
 
@@ -3562,6 +3565,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -4945,6 +4952,11 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
@@ -5977,6 +5989,10 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -6576,6 +6592,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -6915,7 +6936,7 @@ snapshots:
       '@angular/core': 21.2.11(@angular/compiler@21.2.11)(rxjs@7.8.2)(zone.js@0.16.1)
       tslib: 2.8.1
 
-  '@angular/build@21.2.11(bfefb54524d36c8d89865e35f7ad2fae)':
+  '@angular/build@21.2.11(f41801f63592db3e58ee8df1bae34e3b)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.11
@@ -6925,7 +6946,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.21(@types/node@20.19.39)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
       beasties: 0.4.1
       browserslist: 4.28.2
       esbuild: 0.27.3
@@ -6946,7 +6967,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
       undici: 7.24.4
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.11(@angular/compiler@21.2.11)(rxjs@7.8.2)(zone.js@0.16.1)
@@ -6956,7 +6977,7 @@ snapshots:
       lmdb: 3.5.1
       postcss: 8.5.9
       tailwindcss: 4.2.2
-      vitest: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9418,9 +9439,9 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))':
+  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -9434,7 +9455,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -9445,13 +9466,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))':
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -10035,6 +10056,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@12.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -11646,6 +11669,15 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.9.0
+
   listr2@9.0.5:
     dependencies:
       cli-truncate: 5.2.0
@@ -12740,6 +12772,8 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  string-argv@0.3.2: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -13099,7 +13133,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1):
+  vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -13114,11 +13148,12 @@ snapshots:
       lightningcss: 1.32.0
       sass: 1.97.3
       terser: 5.46.1
+      yaml: 2.9.0
 
-  vitest@4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)):
+  vitest@4.1.4(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1))
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -13135,7 +13170,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
@@ -13282,6 +13317,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/scripts/affected-workspaces.mjs
+++ b/scripts/affected-workspaces.mjs
@@ -257,13 +257,14 @@ function getCommandPlan(mode, affectedWorkspaceNames) {
 function runCommand(commandParts, label) {
   console.info(`[affected] ${label}`);
 
+  const useShell = process.platform === 'win32';
   const commandExecutable =
     process.platform === 'win32' && commandParts[0] === 'pnpm'
-      ? 'pnpm.cmd'
+      ? 'pnpm'
       : commandParts[0];
   const result = spawnSync(commandExecutable, commandParts.slice(1), {
     stdio: 'inherit',
-    shell: false,
+    shell: useShell,
   });
 
   if (result.status !== 0) {

--- a/scripts/affected-workspaces.mjs
+++ b/scripts/affected-workspaces.mjs
@@ -1,0 +1,331 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+const rootSensitivePaths = [
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  '.npmrc',
+  'tsconfig.base.json',
+  'scripts/',
+  '.github/',
+];
+
+const workspaceDefinitions = [
+  {
+    name: 'api',
+    prefixes: ['apps/api/'],
+    commands: {
+      lint: ['pnpm', 'lint:api'],
+      test: ['pnpm', 'test:api:unit'],
+      build: ['pnpm', 'build:api'],
+    },
+  },
+  {
+    name: 'client-web',
+    prefixes: ['apps/client/projects/web/'],
+    commands: {
+      lint: ['pnpm', '--filter', '@kraak/client', 'lint'],
+      test: ['pnpm', '--filter', '@kraak/client', 'test:web'],
+      build: ['pnpm', 'build:web'],
+    },
+  },
+  {
+    name: 'client-mobile',
+    prefixes: ['apps/client/projects/mobile/'],
+    commands: {
+      lint: ['pnpm', '--filter', '@kraak/client', 'lint'],
+      test: ['pnpm', '--filter', '@kraak/client', 'test:mobile'],
+      build: ['pnpm', 'build:mobile'],
+    },
+  },
+  {
+    name: 'contracts',
+    prefixes: ['packages/contracts/'],
+    commands: {
+      lint: ['pnpm', '--filter', '@kraak/contracts', 'lint'],
+      test: ['pnpm', '--filter', '@kraak/contracts', 'test'],
+      build: ['pnpm', '--filter', '@kraak/contracts', 'build'],
+    },
+  },
+  {
+    name: 'domain',
+    prefixes: ['packages/domain/'],
+    commands: {
+      lint: ['pnpm', '--filter', '@kraak/domain', 'lint'],
+      test: ['pnpm', '--filter', '@kraak/domain', 'test'],
+      build: ['pnpm', '--filter', '@kraak/domain', 'build'],
+    },
+  },
+  {
+    name: 'api-client',
+    prefixes: ['packages/api-client/'],
+    commands: {
+      lint: ['pnpm', '--filter', '@kraak/api-client', 'lint'],
+      test: ['pnpm', '--filter', '@kraak/api-client', 'test'],
+    },
+  },
+  {
+    name: 'tokens',
+    prefixes: ['packages/tokens/'],
+    commands: {
+      lint: ['pnpm', '--filter', '@kraak/tokens', 'lint'],
+      test: ['pnpm', '--filter', '@kraak/tokens', 'test'],
+    },
+  },
+];
+
+const workspaceNameByDefinition = new Map(
+  workspaceDefinitions.map((definition) => [definition.name, definition]),
+);
+
+function resolveGitExecutable() {
+  const candidates = [];
+
+  if (process.env.GIT_EXECUTABLE) {
+    candidates.push(process.env.GIT_EXECUTABLE);
+  }
+
+  if (process.platform === 'win32') {
+    candidates.push(
+      String.raw`C:\Program Files\Git\cmd\git.exe`,
+      String.raw`C:\Program Files\Git\bin\git.exe`,
+    );
+  } else {
+    candidates.push(
+      '/usr/bin/git',
+      '/usr/local/bin/git',
+      '/opt/homebrew/bin/git',
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    '[affected] Exécutable git introuvable. Définissez GIT_EXECUTABLE avec un chemin absolu fiable.',
+  );
+}
+
+const gitExecutable = resolveGitExecutable();
+
+function runGit(args) {
+  return spawnSync(gitExecutable, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function getGitOutput(args) {
+  const result = runGit(args);
+
+  if (result.status !== 0) {
+    return '';
+  }
+
+  return result.stdout.trim();
+}
+
+function refExists(ref) {
+  const result = runGit([
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `${ref}^{commit}`,
+  ]);
+  return result.status === 0;
+}
+
+function resolveBaseRef() {
+  const upstream = getGitOutput([
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{upstream}',
+  ]);
+
+  if (upstream && refExists(upstream)) {
+    return upstream;
+  }
+
+  const candidates = [
+    'origin/staging',
+    'origin/main',
+    'staging',
+    'main',
+    'HEAD~1',
+  ];
+
+  for (const candidate of candidates) {
+    if (refExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return 'HEAD~1';
+}
+
+function getChangedFiles(baseRef) {
+  const result = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMRTUXB',
+    `${baseRef}...HEAD`,
+  ]);
+
+  if (result.status !== 0) {
+    console.warn(
+      '[affected] Impossible de détecter finement les changements, fallback sur une validation minimale.',
+    );
+    return [];
+  }
+
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isRootSensitiveFile(filePath) {
+  return rootSensitivePaths.some((pattern) => {
+    if (pattern.endsWith('/')) {
+      return filePath.startsWith(pattern);
+    }
+
+    return filePath === pattern;
+  });
+}
+
+function collectAffectedWorkspaceNames(changedFiles) {
+  if (changedFiles.some(isRootSensitiveFile)) {
+    return workspaceDefinitions.map((definition) => definition.name);
+  }
+
+  const affectedWorkspaceNames = new Set();
+
+  for (const filePath of changedFiles) {
+    const isClientRootFile =
+      filePath.startsWith('apps/client/') &&
+      !filePath.startsWith('apps/client/projects/web/') &&
+      !filePath.startsWith('apps/client/projects/mobile/');
+
+    if (isClientRootFile) {
+      affectedWorkspaceNames.add('client-web');
+      affectedWorkspaceNames.add('client-mobile');
+    }
+
+    for (const definition of workspaceDefinitions) {
+      if (definition.prefixes.some((prefix) => filePath.startsWith(prefix))) {
+        affectedWorkspaceNames.add(definition.name);
+      }
+    }
+  }
+
+  return [...affectedWorkspaceNames];
+}
+
+function getCommandPlan(mode, affectedWorkspaceNames) {
+  const commandPlan = [];
+  const seenCommands = new Set();
+
+  for (const workspaceName of affectedWorkspaceNames) {
+    const definition = workspaceNameByDefinition.get(workspaceName);
+    const command = definition?.commands[mode];
+
+    if (!command) {
+      continue;
+    }
+
+    const commandKey = command.join('\u0000');
+
+    if (seenCommands.has(commandKey)) {
+      continue;
+    }
+
+    seenCommands.add(commandKey);
+    commandPlan.push({ workspaceName, command });
+  }
+
+  return commandPlan;
+}
+
+function runCommand(commandParts, label) {
+  console.info(`[affected] ${label}`);
+
+  const commandExecutable =
+    process.platform === 'win32' && commandParts[0] === 'pnpm'
+      ? 'pnpm.cmd'
+      : commandParts[0];
+  const result = spawnSync(commandExecutable, commandParts.slice(1), {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function main() {
+  const mode = process.argv[2];
+
+  if (!mode) {
+    console.error(
+      '[affected] Utilisation: node ./scripts/affected-workspaces.mjs <lint|test|build>',
+    );
+    process.exit(1);
+  }
+
+  const supportedModes = new Set(['lint', 'test', 'build']);
+
+  if (!supportedModes.has(mode)) {
+    console.error(`[affected] Mode inconnu: ${mode}`);
+    process.exit(1);
+  }
+
+  const changedFiles = getChangedFiles(resolveBaseRef());
+  const affectedWorkspaceNames = collectAffectedWorkspaceNames(changedFiles);
+
+  if (affectedWorkspaceNames.length === 0) {
+    console.info('[affected] Aucun workspace affecté, rien à exécuter.');
+    return;
+  }
+
+  const commandPlan = getCommandPlan(mode, affectedWorkspaceNames);
+
+  if (commandPlan.length === 0) {
+    console.info(
+      `[affected] Aucun script ${mode} disponible pour les workspaces affectés.`,
+    );
+    return;
+  }
+
+  for (const step of commandPlan) {
+    runCommand(step.command, `${mode} -> ${step.workspaceName}`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error('[affected] Erreur inattendue durant les contrôles:', error);
+    process.exit(1);
+  }
+}
+
+export {
+  collectAffectedWorkspaceNames,
+  getCommandPlan,
+  isRootSensitiveFile,
+  rootSensitivePaths,
+  workspaceDefinitions,
+};

--- a/scripts/affected-workspaces.test.mjs
+++ b/scripts/affected-workspaces.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  collectAffectedWorkspaceNames,
+  getCommandPlan,
+} from './affected-workspaces.mjs';
+
+test('Given root-sensitive files, When collecting affected workspaces, Then all workspaces are selected', () => {
+  const affectedWorkspaceNames = collectAffectedWorkspaceNames([
+    'package.json',
+  ]);
+
+  assert.deepEqual(affectedWorkspaceNames, [
+    'api',
+    'client-web',
+    'client-mobile',
+    'contracts',
+    'domain',
+    'api-client',
+    'tokens',
+  ]);
+});
+
+test('Given web-only files, When collecting affected workspaces, Then only the web target is selected', () => {
+  const affectedWorkspaceNames = collectAffectedWorkspaceNames([
+    'apps/client/projects/web/src/app/home.component.ts',
+  ]);
+
+  assert.deepEqual(affectedWorkspaceNames, ['client-web']);
+});
+
+test('Given mobile-only files, When collecting affected workspaces, Then only the mobile target is selected', () => {
+  const affectedWorkspaceNames = collectAffectedWorkspaceNames([
+    'apps/client/projects/mobile/src/app/home.component.ts',
+  ]);
+
+  assert.deepEqual(affectedWorkspaceNames, ['client-mobile']);
+});
+
+test('Given a root client file, When collecting affected workspaces, Then both client targets are selected', () => {
+  const affectedWorkspaceNames = collectAffectedWorkspaceNames([
+    'apps/client/angular.json',
+  ]);
+
+  assert.deepEqual(affectedWorkspaceNames, ['client-web', 'client-mobile']);
+});
+
+test('Given affected workspaces, When building the command plan, Then duplicate commands are removed', () => {
+  const commandPlan = getCommandPlan('lint', ['client-web', 'client-mobile']);
+
+  assert.deepEqual(commandPlan, [
+    {
+      workspaceName: 'client-web',
+      command: ['pnpm', '--filter', '@kraak/client', 'lint'],
+    },
+  ]);
+});

--- a/scripts/husky-pre-push.mjs
+++ b/scripts/husky-pre-push.mjs
@@ -1,0 +1,191 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import process from 'node:process';
+
+function resolveGitExecutable() {
+  const candidates = [];
+
+  if (process.env.GIT_EXECUTABLE) {
+    candidates.push(process.env.GIT_EXECUTABLE);
+  }
+
+  if (process.platform === 'win32') {
+    candidates.push(
+      String.raw`C:\Program Files\Git\cmd\git.exe`,
+      String.raw`C:\Program Files\Git\bin\git.exe`,
+    );
+  } else {
+    candidates.push(
+      '/usr/bin/git',
+      '/usr/local/bin/git',
+      '/opt/homebrew/bin/git',
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    '[pre-push] Exécutable git introuvable. Définissez GIT_EXECUTABLE avec un chemin absolu fiable.',
+  );
+}
+
+const gitExecutable = resolveGitExecutable();
+
+function runCommand(command, args, label) {
+  console.info(`[pre-push] ${label}`);
+
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function runPnpm(args, label) {
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  runCommand(pnpmCommand, args, label);
+}
+
+function runGit(args) {
+  return spawnSync(gitExecutable, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function getGitOutput(args) {
+  const result = runGit(args);
+
+  if (result.status !== 0) {
+    return '';
+  }
+
+  return result.stdout.trim();
+}
+
+function refExists(ref) {
+  const result = runGit([
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `${ref}^{commit}`,
+  ]);
+  return result.status === 0;
+}
+
+function resolveBaseRef() {
+  const upstream = getGitOutput([
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{upstream}',
+  ]);
+
+  if (upstream && refExists(upstream)) {
+    return upstream;
+  }
+
+  const candidates = [
+    'origin/staging',
+    'origin/main',
+    'staging',
+    'main',
+    'HEAD~1',
+  ];
+
+  for (const candidate of candidates) {
+    if (refExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return 'HEAD~1';
+}
+
+function getChangedFiles(baseRef) {
+  const result = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMRTUXB',
+    `${baseRef}...HEAD`,
+  ]);
+
+  if (result.status !== 0) {
+    console.warn(
+      '[pre-push] Impossible de détecter finement les changements, fallback sur validation minimale.',
+    );
+    return [];
+  }
+
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isDocsOnly(files) {
+  if (files.length === 0) {
+    return false;
+  }
+
+  return files.every((file) => {
+    if (file.endsWith('.md')) {
+      return true;
+    }
+
+    return (
+      file.startsWith('docs/') ||
+      file.startsWith('.github/') ||
+      file === 'README.md' ||
+      file === 'CONTRIBUTING.md' ||
+      file === 'AGENTS.md' ||
+      file === 'ARCHITECTURE.md'
+    );
+  });
+}
+
+function main() {
+  runPnpm(['exec', 'validate-branch-name'], 'Validation du nom de branche');
+
+  const changedFiles = getChangedFiles(resolveBaseRef());
+
+  if (changedFiles.length === 0) {
+    console.info(
+      '[pre-push] Aucun changement détecté dans le diff de branche, contrôles minimaux appliqués.',
+    );
+    return;
+  }
+
+  if (isDocsOnly(changedFiles)) {
+    console.info(
+      '[pre-push] Changements documentation uniquement, contrôles de code ignorés.',
+    );
+    return;
+  }
+
+  runPnpm(['affected:lint'], 'Lint ciblé des workspaces affectés');
+  runPnpm(['affected:test'], 'Tests ciblés des workspaces affectés');
+  runPnpm(['test:integration'], "Tests d'intégration API");
+
+  const touchesScripts = changedFiles.some((file) =>
+    file.startsWith('scripts/'),
+  );
+
+  if (touchesScripts) {
+    runPnpm(['test:workspace'], 'Tests des scripts workspace');
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error('[pre-push] Erreur inattendue durant les contrôles:', error);
+  process.exit(1);
+}

--- a/scripts/husky-pre-push.mjs
+++ b/scripts/husky-pre-push.mjs
@@ -38,9 +38,11 @@ const gitExecutable = resolveGitExecutable();
 function runCommand(command, args, label) {
   console.info(`[pre-push] ${label}`);
 
+  const useShell = process.platform === 'win32';
+
   const result = spawnSync(command, args, {
     stdio: 'inherit',
-    shell: false,
+    shell: useShell,
   });
 
   if (result.status !== 0) {
@@ -49,7 +51,7 @@ function runCommand(command, args, label) {
 }
 
 function runPnpm(args, label) {
-  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const pnpmCommand = 'pnpm';
   runCommand(pnpmCommand, args, label);
 }
 

--- a/scripts/workspace-commands.mjs
+++ b/scripts/workspace-commands.mjs
@@ -6,7 +6,7 @@ export function createWorkflows() {
   return {
     test: {
       description:
-        'Run shared libraries, API, client unit tests, then Playwright end-to-end tests.',
+        'Run shared libraries, API and client unit tests, API integration tests, then Playwright end-to-end tests.',
       phases: [
         {
           name: 'shared-libraries',
@@ -24,11 +24,21 @@ export function createWorkflows() {
           commands: [
             {
               name: 'api',
-              args: ['test:api'],
+              args: ['test:api:unit'],
             },
             {
               name: 'client',
               args: ['test:unit'],
+            },
+          ],
+        },
+        {
+          name: 'integration',
+          parallel: false,
+          commands: [
+            {
+              name: 'api-integration',
+              args: ['test:integration'],
             },
           ],
         },

--- a/scripts/workspace-commands.test.mjs
+++ b/scripts/workspace-commands.test.mjs
@@ -3,9 +3,10 @@ import test from 'node:test';
 
 import { createWorkflows } from './workspace-commands.mjs';
 
-test('test workflow runs shared libraries before unit and e2e phases', () => {
+test('test workflow runs shared libraries before unit, integration and e2e phases', () => {
   const workflows = createWorkflows();
-  const [librariesPhase, unitPhase, e2ePhase] = workflows.test.phases;
+  const [librariesPhase, unitPhase, integrationPhase, e2ePhase] =
+    workflows.test.phases;
 
   assert.equal(librariesPhase.parallel, false);
   assert.deepEqual(
@@ -19,6 +20,12 @@ test('test workflow runs shared libraries before unit and e2e phases', () => {
     ['api', 'client'],
   );
 
+  assert.equal(integrationPhase.parallel, false);
+  assert.deepEqual(
+    integrationPhase.commands.map((command) => command.name),
+    ['api-integration'],
+  );
+
   assert.equal(e2ePhase.parallel, false);
   assert.deepEqual(
     e2ePhase.commands.map((command) => command.name),
@@ -28,10 +35,12 @@ test('test workflow runs shared libraries before unit and e2e phases', () => {
 
 test('test workflow preserves the current root test commands', () => {
   const workflows = createWorkflows();
-  const [librariesPhase, unitPhase, e2ePhase] = workflows.test.phases;
+  const [librariesPhase, unitPhase, integrationPhase, e2ePhase] =
+    workflows.test.phases;
 
   assert.deepEqual(librariesPhase.commands[0].args, ['test:libs']);
-  assert.deepEqual(unitPhase.commands[0].args, ['test:api']);
+  assert.deepEqual(unitPhase.commands[0].args, ['test:api:unit']);
   assert.deepEqual(unitPhase.commands[1].args, ['test:unit']);
+  assert.deepEqual(integrationPhase.commands[0].args, ['test:integration']);
   assert.deepEqual(e2ePhase.commands[0].args, ['test:e2e']);
 });


### PR DESCRIPTION
## Summary

Implements PRG-04 minimal progression marking for participant programs.

## Changes

- **Domain rules (`packages/domain`)**
  - Added minimal progression engine (`progress.ts`) with session eligibility checks, marker updates, and derived progress computation.
  - Added dedicated unit tests (`progress.spec.ts`).

- **Shared contracts (`packages/contracts`)**
  - Added progression DTOs and payloads:
    - `ProgramProgressDto`
    - `MarkProgramSessionProgressRequestDto`
    - `MarkProgramSessionProgressResponseDto`
  - Extended participant program list/detail DTOs with `progress`.
  - Added enum `ProgramProgressStatus`.

- **API (`apps/api`)**
  - Added payload validation in `programs.dto.ts` (+ tests).
  - Added endpoint `POST /programs/:programId/progress` with Swagger docs.
  - Implemented persistence and restitution of progression in `ProgramsService`.
  - Auto-completes enrollment status when all visible sessions are marked completed.

- **Mobile (`apps/client/projects/mobile`)**
  - Added service method `markSessionProgress(programId, sessionId, completed)`.
  - Added session-level action buttons to mark/unmark completion.
  - Added progression display in program list/detail pages.
  - Updated/extended related specs.

- **Data model / migration**
  - Added migration `20260429110000_add_enrollment_progress_markers.sql`:
    - `enrollment.progress_completed_session_ids`
    - `enrollment.progress_updated_at`
  - Updated product model doc to keep enrollment fields aligned.

## Related

Closes #97
Depends on: PRG-02, LIB-02

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] API + shared domain/contracts + mobile MVP functionality

## Testing

- `pnpm --filter @kraak/contracts test`
- `pnpm --filter @kraak/domain test`
- `pnpm --filter @kraak/api-client test`
- `pnpm --filter @kraak/api test -- programs`
- `pnpm --filter @kraak/client test:mobile`
