### PR TITLE
fix(api): map Supabase invite rate-limit to HTTP 429 in UsersService

### DIFF
--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,6 +1,7 @@
 import {
   NotFoundException,
   InternalServerErrorException,
+  TooManyRequestsException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 
@@ -305,6 +306,29 @@ describe('UsersService', () => {
             preferredContactChannel: null,
           }),
         ).rejects.toThrow(InternalServerErrorException);
+      });
+
+      it('Given an invite rate limit error, When invite is called, Then throws TooManyRequestsException', async () => {
+        mockInviteUser.mockResolvedValueOnce({
+          data: null,
+          error: {
+            status: 429,
+            code: 'over_email_send_rate_limit',
+            message: 'email rate limit exceeded',
+          },
+        });
+
+        await expect(
+          service.invite({
+            email: 'alice@example.com',
+            firstName: 'Alice',
+            lastName: 'Martin',
+            role: 'participant',
+            isActive: true,
+            phone: null,
+            preferredContactChannel: null,
+          }),
+        ).rejects.toThrow(TooManyRequestsException);
       });
 
       it('Given invite response without user, When invite is called, Then throws InternalServerErrorException', async () => {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -3,6 +3,7 @@ import {
   InternalServerErrorException,
   Logger,
   NotFoundException,
+  TooManyRequestsException,
 } from '@nestjs/common';
 import type {
   AppUserDto,
@@ -195,6 +196,23 @@ export class UsersService {
         "Erreur lors de l'invitation de l'utilisateur",
         authError,
       );
+
+      const inviteErrorCode =
+        authError?.code ??
+        (authError as { error_code?: string } | null)?.error_code ??
+        null;
+      const inviteErrorMessage = (authError?.message ?? '').toLowerCase();
+      const isInviteRateLimited =
+        authError?.status === 429 ||
+        inviteErrorCode === 'over_email_send_rate_limit' ||
+        inviteErrorMessage.includes('rate limit');
+
+      if (isInviteRateLimited) {
+        throw new TooManyRequestsException(
+          "Trop d'invitations ont été envoyées récemment. Réessayez dans quelques minutes.",
+        );
+      }
+
       throw new InternalServerErrorException(
         "Impossible d'envoyer l'invitation",
       );


### PR DESCRIPTION
When inviteUserByEmail returns a rate-limit error (status 429 or code over_email_send_rate_limit), UsersService.invite now throws TooManyRequestsException instead of InternalServerErrorException.

- Add TooManyRequestsException import
- Detect rate-limit via status, code, or message heuristic
- Add unit test: Given invite rate-limit error, Then throws 429

# Pull Request

## Resume

## Pourquoi

## Type de changement

- [ ] bug
- [ ] amelioration
- [ ] contenu
- [ ] design
- [ ] maintenance

## Checklist

- [ ] Tache liée a une issue
- [ ] Portée MVP respectée
- [ ] Tests RED -> GREEN -> REFACTOR appliques (si code)
- [ ] Evidence de validation ajoutée (tests/captures)
- [ ] Documentation mise a jour si nécessaire
- [ ] Aucun secret/variable sensible commit

## Validation

- [ ] Tests unitaires
- [ ] Tests integration
- [ ] Tests E2E/smoke
- [ ] Verification manuelle

## Captures / preuves
