### PR TITLE
fix(client): restore Angular build configuration

### DIFF
--- a/apps/client/angular.json
+++ b/apps/client/angular.json
@@ -39,9 +39,6 @@
             "scripts": [],
             "server": "projects/web/src/main.server.ts",
             "outputMode": "server",
-            "security": {
-              "allowedHosts": []
-            },
             "ssr": {
               "entry": "projects/web/src/server.ts"
             }
@@ -121,6 +118,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "allowedHosts": []
+          },
           "configurations": {
             "production": {
               "buildTarget": "web:build:production"

--- a/package.json
+++ b/package.json
@@ -8,18 +8,6 @@
     "pnpm": ">=10.0.0"
   },
   "packageManager": "pnpm@10.23.0",
-  "pnpm": {
-    "overrides": {
-      "typescript": "~5.9.2"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lmdb",
-      "playwright",
-      "rollup",
-      "sharp"
-    ]
-  },
   "scripts": {
     "clean": "pnpm -r clean && node ./scripts/clean.mjs",
     "dev": "node ./scripts/dev-all.mjs",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
+
+overrides:
+  typescript: ~5.9.2
+
+onlyBuiltDependencies:
+  - esbuild
+  - lmdb
+  - playwright
+  - rollup
+  - sharp

--- a/scripts/angular-web-build-config.test.mjs
+++ b/scripts/angular-web-build-config.test.mjs
@@ -2,12 +2,64 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const angularWorkspace = JSON.parse(
-  readFileSync(new URL('../apps/client/angular.json', import.meta.url), 'utf8'),
+const angularWorkspaceUrl = new URL(
+  '../apps/client/angular.json',
+  import.meta.url,
+);
+const applicationSchemaUrl = new URL(
+  '../apps/client/node_modules/@angular/build/src/builders/application/schema.json',
+  import.meta.url,
+);
+const devServerSchemaUrl = new URL(
+  '../apps/client/node_modules/@angular/build/src/builders/dev-server/schema.json',
+  import.meta.url,
 );
 
-const webBuildConfigurations =
-  angularWorkspace.projects?.web?.architect?.build?.configurations ?? {};
+const angularWorkspaceContent = readFileSync(angularWorkspaceUrl, 'utf8');
+const angularWorkspace = JSON.parse(angularWorkspaceContent);
+const applicationSchema = JSON.parse(
+  readFileSync(applicationSchemaUrl, 'utf8'),
+);
+const devServerSchema = JSON.parse(readFileSync(devServerSchemaUrl, 'utf8'));
+
+const webBuildTarget = angularWorkspace.projects?.web?.architect?.build ?? {};
+const webServeTarget = angularWorkspace.projects?.web?.architect?.serve ?? {};
+const webBuildOptions = webBuildTarget.options ?? {};
+const webBuildConfigurations = webBuildTarget.configurations ?? {};
+const webServeOptions = webServeTarget.options ?? {};
+const webServeConfigurations = webServeTarget.configurations ?? {};
+
+const applicationOptionNames = new Set(
+  Object.keys(applicationSchema.properties),
+);
+const devServerOptionNames = new Set(Object.keys(devServerSchema.properties));
+
+function assertSupportedOptions(options, supportedOptions, targetName) {
+  const unsupportedOptions = Object.keys(options).filter(
+    (optionName) => !supportedOptions.has(optionName),
+  );
+
+  assert.deepEqual(
+    unsupportedOptions,
+    [],
+    `${targetName} contient des propriétés Angular non supportées: ${unsupportedOptions.join(
+      ', ',
+    )}`,
+  );
+}
+
+test('Given le fichier angular.json, When la configuration est lue, Then le JSON est valide', () => {
+  assert.doesNotThrow(() => JSON.parse(angularWorkspaceContent));
+});
+
+test('Given la cible build web Angular, When ses options sont vérifiées, Then aucune propriété non supportée n est déclarée', () => {
+  assertSupportedOptions(
+    webBuildOptions,
+    applicationOptionNames,
+    'web.architect.build.options',
+  );
+  assert.equal(webBuildOptions.security, undefined);
+});
 
 test('Given the deployed web builds, When CSP forbids inline event handlers, Then staging and production keep critical CSS inlining disabled', () => {
   assert.equal(
@@ -18,4 +70,36 @@ test('Given the deployed web builds, When CSP forbids inline event handlers, The
     webBuildConfigurations.staging?.optimization?.styles?.inlineCritical,
     false,
   );
+});
+
+test('Given la configuration production du build web, When ses options sont vérifiées, Then elle reste compatible avec le builder Angular', () => {
+  assertSupportedOptions(
+    webBuildConfigurations.production ?? {},
+    applicationOptionNames,
+    'web.architect.build.configurations.production',
+  );
+  assert.equal(
+    webBuildConfigurations.production?.optimization?.styles?.inlineCritical,
+    false,
+  );
+});
+
+test('Given les serveurs web local et staging, When leurs options sont vérifiées, Then allowedHosts reste une option du dev-server', () => {
+  assertSupportedOptions(
+    webServeOptions,
+    devServerOptionNames,
+    'web.architect.serve.options',
+  );
+  assert.deepEqual(webServeOptions.allowedHosts, []);
+
+  for (const configurationName of ['local', 'staging']) {
+    const configuration = webServeConfigurations[configurationName];
+
+    assertSupportedOptions(
+      configuration,
+      devServerOptionNames,
+      `web.architect.serve.configurations.${configurationName}`,
+    );
+    assert.equal(configuration.buildTarget, `web:build:${configurationName}`);
+  }
 });


### PR DESCRIPTION
## Summary
- Move PNPM workspace settings into pnpm-workspace.yaml so PNPM no longer ignores overrides or onlyBuiltDependencies.
- Move web allowedHosts to the Angular dev-server target and remove the build-level security block.
- Add schema-backed Angular config regression checks for build and serve targets.

## Validation
- pnpm list -r --depth 0
- pnpm why vitest
- pnpm why typescript
- pnpm test:libs
- pnpm test:workspace
- pnpm typecheck
- node --test scripts/angular-web-build-config.test.mjs
- pnpm typecheck:web
- pnpm typecheck:mobile
- pnpm --filter @kraak/client test
- pnpm build:web
- pnpm build:mobile
- pnpm format:check
- pnpm test:api
- pnpm test:unit
- pnpm build

Note: pnpm commands were run as pnpm.cmd because PowerShell blocks pnpm.ps1 in this environment. The mobile build still emits the existing initial bundle budget warning, but exits successfully.