### PR TITLE
fix: corriger la commande locale Sonar

### DIFF
--- a/scripts/sonarcloud-scan.mjs
+++ b/scripts/sonarcloud-scan.mjs
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { spawn, spawnSync } from 'node:child_process';
 import path from 'node:path';
 import process from 'node:process';
@@ -10,9 +16,16 @@ const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptDirectory, '..');
 const localEnvPath = path.join(repositoryRoot, '.env.local');
 const scannerWorkDirectory = path.join(repositoryRoot, '.scannerwork');
-const scannerReportDirectory = path.join(scannerWorkDirectory, 'scanner-report');
+const scannerReportDirectory = path.join(
+  scannerWorkDirectory,
+  'scanner-report',
+);
 const scannerLockPath = path.join(scannerWorkDirectory, 'sonarcloud-scan.lock');
-const strictDiagnosticDefaultLogPath = path.join(scannerWorkDirectory, 'sonar-strict-diagnostic.log');
+const strictDiagnosticDefaultLogPath = path.join(
+  scannerWorkDirectory,
+  'sonar-strict-diagnostic.log',
+);
+const sonarScanPackageName = '@sonar/scan';
 const lcovReportPathToSourcePrefix = {
   'apps/api/coverage/lcov.info': 'apps/api',
   'apps/client/coverage/web/lcov.info': 'apps/client',
@@ -85,7 +98,10 @@ export function readLocalSonarEnvironment(filePath = localEnvPath) {
   return parseEnvironmentFile(readFileSync(filePath, 'utf8'));
 }
 
-export function resolveSonarEnvironment(baseEnvironment = process.env, filePath = localEnvPath) {
+export function resolveSonarEnvironment(
+  baseEnvironment = process.env,
+  filePath = localEnvPath,
+) {
   const localEnvironment = readLocalSonarEnvironment(filePath);
   const localToken = localEnvironment.SONAR_TOKEN?.trim() ?? '';
   const shellToken = baseEnvironment.SONAR_TOKEN?.trim() ?? '';
@@ -102,7 +118,7 @@ export function resolveSonarEnvironment(baseEnvironment = process.env, filePath 
 export function createSonarScanCommand(platform = process.platform) {
   return {
     command: getPnpmCommand(platform),
-    args: ['--package=@sonar/scan', 'dlx', 'sonar-scanner'],
+    args: ['dlx', sonarScanPackageName],
   };
 }
 
@@ -154,7 +170,9 @@ function normalizeSourcePathForReport(sourcePath, sourcePrefix) {
   const normalizedSourcePath = trimLeadingDotSlash(toPosixPath(sourcePath));
 
   if (path.isAbsolute(normalizedSourcePath)) {
-    const relativeSourcePath = toPosixPath(path.relative(repositoryRoot, normalizedSourcePath));
+    const relativeSourcePath = toPosixPath(
+      path.relative(repositoryRoot, normalizedSourcePath),
+    );
 
     if (!relativeSourcePath.startsWith('..')) {
       return relativeSourcePath;
@@ -165,7 +183,9 @@ function normalizeSourcePathForReport(sourcePath, sourcePrefix) {
     return normalizedSourcePath;
   }
 
-  return collapseConsecutiveSlashes(`${normalizedPrefix}/${normalizedSourcePath}`);
+  return collapseConsecutiveSlashes(
+    `${normalizedPrefix}/${normalizedSourcePath}`,
+  );
 }
 
 export function normalizeLcovContent(content, sourcePrefix) {
@@ -175,7 +195,10 @@ export function normalizeLcovContent(content, sourcePrefix) {
     }
 
     const sourcePath = line.slice(3);
-    const normalizedSourcePath = normalizeSourcePathForReport(sourcePath, sourcePrefix);
+    const normalizedSourcePath = normalizeSourcePathForReport(
+      sourcePath,
+      sourcePrefix,
+    );
     return `SF:${normalizedSourcePath}`;
   });
 
@@ -275,9 +298,12 @@ function isTruthyFlag(value) {
 }
 
 export function resolveStrictDiagnosticOptions(baseEnvironment = process.env) {
-  const strictDiagnosticEnabled = isTruthyFlag(baseEnvironment.SONAR_STRICT_DIAGNOSTIC);
+  const strictDiagnosticEnabled = isTruthyFlag(
+    baseEnvironment.SONAR_STRICT_DIAGNOSTIC,
+  );
   const strictDiagnosticLogPath =
-    baseEnvironment.SONAR_STRICT_DIAGNOSTIC_LOG?.trim() || strictDiagnosticDefaultLogPath;
+    baseEnvironment.SONAR_STRICT_DIAGNOSTIC_LOG?.trim() ||
+    strictDiagnosticDefaultLogPath;
 
   return {
     enabled: strictDiagnosticEnabled,
@@ -326,7 +352,10 @@ function readLockPid(lockPath) {
   return Number.isInteger(lockPid) ? lockPid : null;
 }
 
-export function acquireScanLock(lockPath = scannerLockPath, currentPid = process.pid) {
+export function acquireScanLock(
+  lockPath = scannerLockPath,
+  currentPid = process.pid,
+) {
   mkdirSync(path.dirname(lockPath), { recursive: true });
 
   const existingPid = readLockPid(lockPath);
@@ -343,7 +372,12 @@ export function acquireScanLock(lockPath = scannerLockPath, currentPid = process
     writeFileSync(lockPath, `${currentPid}\n`, { flag: 'wx' });
     return { acquired: true, lockPid: null };
   } catch (error) {
-    if (error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST') {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'EEXIST'
+    ) {
       return { acquired: false, lockPid: readLockPid(lockPath) };
     }
 
@@ -433,9 +467,13 @@ function abortScannerProcess(childProcess, diagnosticLogger) {
   if (process.platform === 'win32') {
     try {
       const taskkillExecutablePath = resolveTaskkillExecutablePath();
-      const taskkillResult = spawnSync(taskkillExecutablePath, ['/PID', `${childPid}`, '/T', '/F'], {
-        stdio: 'ignore',
-      });
+      const taskkillResult = spawnSync(
+        taskkillExecutablePath,
+        ['/PID', `${childPid}`, '/T', '/F'],
+        {
+          stdio: 'ignore',
+        },
+      );
       diagnosticLogger.log(
         'ABORT_TASKKILL',
         `pid=${childPid} status=${taskkillResult.status ?? 'null'}`,
@@ -444,7 +482,10 @@ function abortScannerProcess(childProcess, diagnosticLogger) {
       const message = error instanceof Error ? error.message : String(error);
       diagnosticLogger.log('ABORT_TASKKILL_ERROR', message);
       const wasKilled = childProcess.kill('SIGKILL');
-      diagnosticLogger.log('ABORT_FALLBACK_SIGKILL', `pid=${childPid} killed=${wasKilled}`);
+      diagnosticLogger.log(
+        'ABORT_FALLBACK_SIGKILL',
+        `pid=${childPid} killed=${wasKilled}`,
+      );
     }
     return;
   }
@@ -454,16 +495,25 @@ function abortScannerProcess(childProcess, diagnosticLogger) {
 }
 
 export function resolveTaskkillExecutablePath(baseEnvironment = process.env) {
-  const systemRoot = baseEnvironment.SystemRoot?.trim() || baseEnvironment.WINDIR?.trim();
+  const systemRoot =
+    baseEnvironment.SystemRoot?.trim() || baseEnvironment.WINDIR?.trim();
 
   if (!systemRoot) {
-    throw new Error('Impossible de determiner le chemin système Windows (SystemRoot/WINDIR manquant).');
+    throw new Error(
+      'Impossible de determiner le chemin système Windows (SystemRoot/WINDIR manquant).',
+    );
   }
 
-  const taskkillExecutablePath = path.join(systemRoot, 'System32', 'taskkill.exe');
+  const taskkillExecutablePath = path.join(
+    systemRoot,
+    'System32',
+    'taskkill.exe',
+  );
 
   if (!existsSync(taskkillExecutablePath)) {
-    throw new Error(`Executable taskkill introuvable: ${taskkillExecutablePath}`);
+    throw new Error(
+      `Executable taskkill introuvable: ${taskkillExecutablePath}`,
+    );
   }
 
   return taskkillExecutablePath;
@@ -497,7 +547,10 @@ function createScannerReportMonitor(
     if (scannerReportExists) {
       if (!hasSeenScannerReportDirectory) {
         hasSeenScannerReportDirectory = true;
-        diagnosticLogger.log('SCANNER_REPORT_PRESENT', `path=${scannerReportDirectory}`);
+        diagnosticLogger.log(
+          'SCANNER_REPORT_PRESENT',
+          `path=${scannerReportDirectory}`,
+        );
       }
 
       missingSinceTimestamp = null;
@@ -520,7 +573,10 @@ function createScannerReportMonitor(
     }
 
     hasAbortedForMissingReport = true;
-    diagnosticLogger.log('SCANNER_REPORT_MISSING', `path=${scannerReportDirectory}`);
+    diagnosticLogger.log(
+      'SCANNER_REPORT_MISSING',
+      `path=${scannerReportDirectory}`,
+    );
     abortScannerProcess(childProcess, diagnosticLogger);
   }, monitorIntervalMs);
 
@@ -542,7 +598,10 @@ function runSonarScan(command, environment, strictDiagnosticOptions) {
       'STRICT_MODE',
       `enabled=${strictDiagnosticOptions.enabled} logPath=${strictDiagnosticOptions.logPath}`,
     );
-    diagnosticLogger.log('SCAN_STARTED', `pid=${childProcess.pid ?? 'unknown'}`);
+    diagnosticLogger.log(
+      'SCAN_STARTED',
+      `pid=${childProcess.pid ?? 'unknown'}`,
+    );
 
     const monitor = createScannerReportMonitor(
       strictDiagnosticOptions,
@@ -560,7 +619,10 @@ function runSonarScan(command, environment, strictDiagnosticOptions) {
       monitor.stop();
 
       if (monitor.shouldAbort()) {
-        diagnosticLogger.log('SCAN_ABORTED', 'scanner-report a disparu pendant le run');
+        diagnosticLogger.log(
+          'SCAN_ABORTED',
+          'scanner-report a disparu pendant le run',
+        );
       }
 
       if (signal) {
@@ -573,7 +635,9 @@ function runSonarScan(command, environment, strictDiagnosticOptions) {
     };
 
     childProcess.once('error', (error) => {
-      console.error(`ERROR: Impossible de lancer SonarScanner: ${error.message}`);
+      console.error(
+        `ERROR: Impossible de lancer SonarScanner: ${error.message}`,
+      );
       diagnosticLogger.log('SCAN_ERROR', error.message);
       finalize(1);
     });
@@ -588,7 +652,9 @@ export async function main() {
   const environment = resolveSonarEnvironment();
 
   if (!environment.SONAR_TOKEN) {
-    console.error('ERROR: SONAR_TOKEN manquant. Renseignez .env.local puis relancez.');
+    console.error(
+      'ERROR: SONAR_TOKEN manquant. Renseignez .env.local puis relancez.',
+    );
     return 1;
   }
 
@@ -598,7 +664,9 @@ export async function main() {
 
   if (!lock.acquired) {
     const pidLabel = lock.lockPid ?? 'inconnu';
-    console.error(`ERROR: Un scan Sonar est deja en cours (PID ${pidLabel}). Attendez sa fin puis relancez.`);
+    console.error(
+      `ERROR: Un scan Sonar est deja en cours (PID ${pidLabel}). Attendez sa fin puis relancez.`,
+    );
     return 1;
   }
 

--- a/scripts/sonarcloud-scan.test.mjs
+++ b/scripts/sonarcloud-scan.test.mjs
@@ -1,5 +1,11 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -16,11 +22,11 @@ import {
   resolveSonarEnvironment,
 } from './sonarcloud-scan.mjs';
 
-test('Given Windows, When the scan command is built, Then pnpm.cmd runs sonar-scanner explicitly', () => {
+test('Given Windows, When the scan command is built, Then pnpm.cmd runs the @sonar/scan package directly', () => {
   const command = createSonarScanCommand('win32');
 
   assert.equal(command.command, 'pnpm.cmd');
-  assert.deepEqual(command.args, ['--package=@sonar/scan', 'dlx', 'sonar-scanner']);
+  assert.deepEqual(command.args, ['dlx', '@sonar/scan']);
 });
 
 test('Given a local env file, When Sonar variables are read, Then token and host url are loaded', () => {
@@ -29,7 +35,11 @@ test('Given a local env file, When Sonar variables are read, Then token and host
 
   writeFileSync(
     tempEnvPath,
-    ['# comment', 'SONAR_TOKEN="abc123"', 'SONAR_HOST_URL=https://sonarcloud.io'].join('\n'),
+    [
+      '# comment',
+      'SONAR_TOKEN="abc123"',
+      'SONAR_HOST_URL=https://sonarcloud.io',
+    ].join('\n'),
   );
 
   const environment = readLocalSonarEnvironment(tempEnvPath);
@@ -68,11 +78,16 @@ test('Given no strict diagnostic env flag, When options are resolved, Then stric
   const options = resolveStrictDiagnosticOptions({});
 
   assert.equal(options.enabled, false);
-  assert.match(options.logPath, /\.scannerwork[\\/]sonar-strict-diagnostic\.log$/);
+  assert.match(
+    options.logPath,
+    /\.scannerwork[\\/]sonar-strict-diagnostic\.log$/,
+  );
 });
 
 test('Given a trusted SystemRoot, When resolving taskkill path, Then an explicit System32 executable path is returned', () => {
-  const tempDirectory = mkdtempSync(path.join(os.tmpdir(), 'kraak-systemroot-'));
+  const tempDirectory = mkdtempSync(
+    path.join(os.tmpdir(), 'kraak-systemroot-'),
+  );
   const fakeSystemRoot = path.join(tempDirectory, 'Windows');
   const fakeSystem32 = path.join(fakeSystemRoot, 'System32');
   const fakeTaskkill = path.join(fakeSystem32, 'taskkill.exe');
@@ -85,7 +100,10 @@ test('Given a trusted SystemRoot, When resolving taskkill path, Then an explicit
       SystemRoot: fakeSystemRoot,
     });
 
-    assert.equal(taskkillPath, path.join(fakeSystemRoot, 'System32', 'taskkill.exe'));
+    assert.equal(
+      taskkillPath,
+      path.join(fakeSystemRoot, 'System32', 'taskkill.exe'),
+    );
   } finally {
     rmSync(tempDirectory, { force: true, recursive: true });
   }
@@ -112,11 +130,19 @@ test('Given a Windows-style LCOV report, When content is normalized, Then SF pat
 });
 
 test('Given an already prefixed SF path, When content is normalized, Then source path is not duplicated', () => {
-  const rawContent = ['TN:', 'SF:apps/client/projects/web/src/ssr-path.ts', 'DA:1,1', 'end_of_record'].join('\n');
+  const rawContent = [
+    'TN:',
+    'SF:apps/client/projects/web/src/ssr-path.ts',
+    'DA:1,1',
+    'end_of_record',
+  ].join('\n');
 
   const normalizedContent = normalizeLcovContent(rawContent, 'apps/client');
 
-  assert.match(normalizedContent, /SF:apps\/client\/projects\/web\/src\/ssr-path\.ts/);
+  assert.match(
+    normalizedContent,
+    /SF:apps\/client\/projects\/web\/src\/ssr-path\.ts/,
+  );
   assert.doesNotMatch(
     normalizedContent,
     /SF:apps\/client\/apps\/client\/projects\/web\/src\/ssr-path\.ts/,
@@ -124,7 +150,11 @@ test('Given an already prefixed SF path, When content is normalized, Then source
 });
 
 test('Given stale scanner-report artifacts, When report directory is reset, Then scanner-report is recreated cleanly', () => {
-  const scannerReportPath = path.join(process.cwd(), '.scannerwork', 'scanner-report');
+  const scannerReportPath = path.join(
+    process.cwd(),
+    '.scannerwork',
+    'scanner-report',
+  );
   const staleFilePath = path.join(scannerReportPath, 'stale.pb');
 
   mkdirSync(scannerReportPath, { recursive: true });
@@ -136,8 +166,14 @@ test('Given stale scanner-report artifacts, When report directory is reset, Then
 });
 
 test('Given an active lock, When another scan starts, Then the second lock acquisition is rejected', () => {
-  const tempDirectory = mkdtempSync(path.join(os.tmpdir(), 'kraak-sonar-lock-'));
-  const lockPath = path.join(tempDirectory, '.scannerwork', 'sonarcloud-scan.lock');
+  const tempDirectory = mkdtempSync(
+    path.join(os.tmpdir(), 'kraak-sonar-lock-'),
+  );
+  const lockPath = path.join(
+    tempDirectory,
+    '.scannerwork',
+    'sonarcloud-scan.lock',
+  );
 
   try {
     const firstLock = acquireScanLock(lockPath, process.pid);
@@ -153,8 +189,14 @@ test('Given an active lock, When another scan starts, Then the second lock acqui
 });
 
 test('Given a stale lock file, When a new scan starts, Then lock is reclaimed', () => {
-  const tempDirectory = mkdtempSync(path.join(os.tmpdir(), 'kraak-sonar-stale-lock-'));
-  const lockPath = path.join(tempDirectory, '.scannerwork', 'sonarcloud-scan.lock');
+  const tempDirectory = mkdtempSync(
+    path.join(os.tmpdir(), 'kraak-sonar-stale-lock-'),
+  );
+  const lockPath = path.join(
+    tempDirectory,
+    '.scannerwork',
+    'sonarcloud-scan.lock',
+  );
 
   try {
     mkdirSync(path.dirname(lockPath), { recursive: true });


### PR DESCRIPTION
## Résumé

- corrige le wrapper \pnpm sonar\ pour lancer directement \@sonar/scan\
- met à jour le test Windows du wrapper pour verrouiller \pnpm.cmd dlx @sonar/scan\
- garde le chargement \.env.local\, le lock Sonar et la normalisation LCOV existants

## Validation

- RED: \
ode --test .\\scripts\\sonarcloud-scan.test.mjs\ échouait sur les anciens arguments \--package=@sonar/scan dlx sonar-scanner\
- GREEN/REFACTOR: \
ode --test .\\scripts\\sonarcloud-scan.test.mjs\
- \pnpm.cmd sonar\ : analyse uploadée, CE task \SUCCESS\, Quality Gate \OK\
- \pnpm.cmd test:workspace\ : 62/62 tests OK
- hook pre-push : validations affectées OK

Closes #632