### PR TITLE
feat(web): localiser l’accueil et la navigation publique

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 status: active
 owner: platform
-last_reviewed: 2026-07-23
+last_reviewed: 2026-08-16
 source_of_truth: true
 ---
 
@@ -57,9 +57,14 @@ Les locales applicatives retenues sont :
 - source et repli : `fr-CI` ;
 - anglais initial : `en-GB`.
 
-Cette décision ne signifie pas que les traductions, les catalogues ou les routes
-localisées sont déjà implémentés. Les PRs d'implémentation devront avancer par
-incréments courts, documentés et validés.
+Les routes publiques localisées et l'adaptateur runtime partagé sont actifs. La
+page d'accueil et la barre de navigation constituent le premier incrément public
+entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. Les autres
+pages publiques anglaises et leurs métadonnées SEO restent dans l'état de
+scaffold non indexable jusqu'à leur traduction et leur revue dédiées.
+
+Les incréments suivants doivent rester courts, documentés et validés sans
+localiser implicitement les routes privées, admin ou mobiles.
 
 ## Garde-fous
 

--- a/apps/client/projects/shared/i18n/catalogs/en-GB.json
+++ b/apps/client/projects/shared/i18n/catalogs/en-GB.json
@@ -8,6 +8,165 @@
       "icuSelectPath": "{audience, select, learner {Learner journey} leader {Leadership journey} other {KRAAK journey}}"
     }
   },
+  "web": {
+    "nav": {
+      "primaryLabel": "Main navigation",
+      "brandSymbolAlt": "KRAAK symbol",
+      "links": {
+        "home": "HOME",
+        "services": "SERVICES",
+        "programs": "PROGRAMMES",
+        "about": "ABOUT",
+        "contact": "CONTACT"
+      },
+      "mobileMenu": {
+        "openLabel": "Open navigation menu",
+        "closeLabel": "Close navigation menu"
+      },
+      "languageSwitcher": {
+        "label": "Choose language",
+        "frenchShort": "FR",
+        "englishShort": "EN",
+        "frenchCurrentLabel": "French, current language",
+        "englishCurrentLabel": "English, current language",
+        "switchToFrenchLabel": "View the site in French",
+        "switchToEnglishLabel": "View the site in English"
+      },
+      "participantArea": "Participant area"
+    },
+    "home": {
+      "hero": {
+        "titleSkills": "Build your skills.",
+        "titleProjects": "Launch your projects.",
+        "titleOpportunities": "Access international opportunities.",
+        "description": "KRAAK Consulting supports students, professionals, businesses and members of the diaspora with practical solutions in training, project management and immigration.",
+        "primaryCta": "Book a consultation",
+        "secondaryCta": "Explore our programmes",
+        "logoAlt": "Large KRAAK logo"
+      },
+      "need": {
+        "eyebrow": "A practical need",
+        "title": "An offer structured around employability, projects and mobility.",
+        "description": "We step in where progress stalls: clarifying goals, strengthening application tools, structuring projects, recruiting, planning international mobility and defining the next useful step."
+      },
+      "highlights": {
+        "training": {
+          "imageAlt": "Participants attending a professional development session in a collaborative workshop",
+          "caption": "Employability, professional confidence and language development."
+        },
+        "projects": {
+          "imageAlt": "A team meeting around a table to scope a project",
+          "caption": "Scoping, structuring and supporting projects that matter."
+        },
+        "mobility": {
+          "imageAlt": "An advisory meeting with documents to prepare an international mobility plan",
+          "caption": "Methodical preparation for study, work and international mobility."
+        }
+      },
+      "pillars": {
+        "title": "Our three areas of expertise",
+        "training": {
+          "title": "Training",
+          "description": "For young people and professionals who want to strengthen their employability, professional presence and application toolkit.",
+          "cta": "Explore our training"
+        },
+        "projects": {
+          "title": "Research & Project Management",
+          "description": "For start-ups, businesses and project leaders who need to scope, plan and move a worthwhile initiative forward.",
+          "cta": "Plan a project"
+        },
+        "mobility": {
+          "title": "Study & Immigration",
+          "description": "For people pursuing study, work or international mobility with clear, step-by-step preparation.",
+          "cta": "Discuss my plans"
+        }
+      },
+      "solutions": {
+        "eyebrow": "Key solutions",
+        "title": "Practical starting points for your goals.",
+        "description": "You do not need a perfectly defined brief: we start with a concrete goal, then clarify the right form of support.",
+        "items": {
+          "personalDevelopment": "Personal and professional development",
+          "professionalLanguages": "Professional English and French",
+          "leadership": "Leadership and public speaking",
+          "interviewPreparation": "Interview preparation",
+          "projectStructuring": "Project structuring",
+          "businessSupport": "Support for businesses and start-ups",
+          "internationalMobility": "International mobility advice",
+          "recruitment": "Recruitment and job placement"
+        }
+      },
+      "proof": {
+        "eyebrow": "Our approach in practice",
+        "title": "Support grounded in real needs.",
+        "description": "KRAAK works within a clear framework: a careful understanding of needs, practical formats and a focus on meaningful impact for individuals and organisations alike.",
+        "items": {
+          "socioeconomicIntegration": {
+            "title": "Employability and career integration",
+            "description": "Young people's employability remains at the heart of our offer: guidance, application tools, interviews, professional confidence and tangible progress towards employment."
+          },
+          "twoWayApproach": {
+            "title": "A two-way approach",
+            "description": "We support both talent and organisations to narrow the gap between market needs, available skills and expected performance."
+          },
+          "internationalExperience": {
+            "title": "International experience",
+            "description": "Our work and field experience draw on assignments in Canada, the United States, Spain, France, Colombia, Cuba, Ghana, Cameroon, Togo and Côte d'Ivoire."
+          },
+          "structuredSupport": {
+            "title": "Structured support",
+            "description": "Every engagement connects a clear understanding of the need with the next step, an action plan and follow-up. Our aim is not to multiply promises, but to make the path ahead clearer."
+          }
+        }
+      },
+      "whyChoose": {
+        "eyebrow": "How we stand apart",
+        "title": "Why choose KRAAK?",
+        "description": "Rigorous, practical support grounded in your real goals.",
+        "items": {
+          "internationalExpertise": {
+            "title": "Internationally recognised expertise",
+            "description": "Expertise applied across several settings to meet both local and international needs."
+          },
+          "personalisedSupport": {
+            "title": "Personalised support",
+            "description": "Every profile is unique, so we adapt the framework, pace and deliverables to the real context."
+          },
+          "measurableResults": {
+            "title": "Tangible, measurable results",
+            "description": "Our approach connects every action to an observable and useful next step."
+          }
+        }
+      },
+      "faq": {
+        "eyebrow": "Frequently asked questions",
+        "title": "Clarify your starting point before you begin.",
+        "description": "This initial selection of questions will help you identify the right service and the most useful next step for your needs.",
+        "backgroundAlt": "A KRAAK adviser guiding a participant through her options",
+        "panelTitle": "A first step towards clarity",
+        "panelDescription": "Review the answers to our most frequently asked questions before telling us about your needs.",
+        "items": {
+          "gettingStarted": {
+            "question": "I am not sure where to start. What is the first step?",
+            "answer": "Start by sharing your goal, context and timeframe through the contact form. We will then guide you to the right starting point."
+          },
+          "businessSupport": {
+            "question": "Do you offer support for businesses?",
+            "answer": "Yes. KRAAK also supports organisations with project management, staff training, recruitment and team performance."
+          },
+          "consultationFormat": {
+            "question": "Are consultations available in person or remotely?",
+            "answer": "Consultations can take place remotely or in person, depending on your needs, the service and the project's constraints."
+          }
+        }
+      },
+      "closing": {
+        "titleLine1": "You know where you want to go.",
+        "titleLine2": "We know how to help you get there.",
+        "cta": "Book an appointment now"
+      }
+    }
+  },
   "primeng": {
     "accept": "Accept",
     "reject": "Reject",

--- a/apps/client/projects/shared/i18n/catalogs/fr-CI.json
+++ b/apps/client/projects/shared/i18n/catalogs/fr-CI.json
@@ -8,6 +8,165 @@
       "icuSelectPath": "{audience, select, learner {Parcours apprenant} leader {Parcours leadership} other {Parcours KRAAK}}"
     }
   },
+  "web": {
+    "nav": {
+      "primaryLabel": "Navigation principale",
+      "brandSymbolAlt": "Symbole KRAAK",
+      "links": {
+        "home": "ACCUEIL",
+        "services": "SERVICES",
+        "programs": "PROGRAMMES",
+        "about": "À PROPOS",
+        "contact": "CONTACT"
+      },
+      "mobileMenu": {
+        "openLabel": "Ouvrir le menu de navigation",
+        "closeLabel": "Fermer le menu de navigation"
+      },
+      "languageSwitcher": {
+        "label": "Choisir la langue",
+        "frenchShort": "FR",
+        "englishShort": "EN",
+        "frenchCurrentLabel": "Français, langue actuelle",
+        "englishCurrentLabel": "Anglais, langue actuelle",
+        "switchToFrenchLabel": "Afficher le site en français",
+        "switchToEnglishLabel": "Afficher le site en anglais"
+      },
+      "participantArea": "Espace participant"
+    },
+    "home": {
+      "hero": {
+        "titleSkills": "Développez vos compétences.",
+        "titleProjects": "Lancez vos projets.",
+        "titleOpportunities": "Accédez aux opportunités internationales.",
+        "description": "KRAAK Consulting accompagne les étudiants, les professionnels, les entreprises et la diaspora avec des solutions concrètes en formation, en gestion de projets et en immigration.",
+        "primaryCta": "Réserver une consultation",
+        "secondaryCta": "Découvrir nos programmes",
+        "logoAlt": "Logo KRAAK grand format"
+      },
+      "need": {
+        "eyebrow": "Un besoin concret",
+        "title": "Une offre structurée autour de l'employabilité, des projets et de la mobilité.",
+        "description": "Nous intervenons là où les trajectoires se bloquent : clarification de projet, outils de candidature, structuration de projet, recrutement, orientation internationale et mise en mouvement de la prochaine étape utile."
+      },
+      "highlights": {
+        "training": {
+          "imageAlt": "Participants en formation professionnelle dans un atelier collaboratif",
+          "caption": "Employabilité, posture professionnelle et progression linguistique."
+        },
+        "projects": {
+          "imageAlt": "Équipe en réunion autour d'une table pour cadrer un projet",
+          "caption": "Cadrage, structuration et accompagnement de projets utiles."
+        },
+        "mobility": {
+          "imageAlt": "Entretien d'accompagnement avec des documents pour préparer un projet international",
+          "caption": "Études, travail et orientation internationale préparés avec méthode."
+        }
+      },
+      "pillars": {
+        "title": "Nos 3 pôles",
+        "training": {
+          "title": "Formation",
+          "description": "Pour les jeunes et les professionnels qui veulent renforcer leur employabilité, leur posture et leurs outils de candidature.",
+          "cta": "Voir les formations"
+        },
+        "projects": {
+          "title": "Recherche & Gestion de projets",
+          "description": "Pour les startups, les entreprises et les porteurs de projets qui doivent cadrer, planifier et faire avancer une initiative utile.",
+          "cta": "Structurer un projet"
+        },
+        "mobility": {
+          "title": "Études & Immigration",
+          "description": "Pour les profils qui visent les études, le travail ou une mobilité internationale avec une préparation claire et progressive.",
+          "cta": "Qualifier mon projet"
+        }
+      },
+      "solutions": {
+        "eyebrow": "Solutions clés",
+        "title": "Des points d'entrée concrets selon votre objectif.",
+        "description": "Vous n'avez pas besoin d'arriver avec un besoin parfaitement formulé : nous partons d'un objectif concret, puis nous clarifions le bon format d'appui.",
+        "items": {
+          "personalDevelopment": "Développement personnel et professionnel",
+          "professionalLanguages": "Anglais et français professionnels",
+          "leadership": "Leadership et prise de parole",
+          "interviewPreparation": "Préparation aux entretiens",
+          "projectStructuring": "Structuration de projets",
+          "businessSupport": "Accompagnement d'entreprises et startups",
+          "internationalMobility": "Conseils en mobilité internationale",
+          "recruitment": "Recrutement et placement en emploi"
+        }
+      },
+      "proof": {
+        "eyebrow": "Preuves d'approche",
+        "title": "Une proposition ancrée dans des besoins réels.",
+        "description": "KRAAK avance avec un cadre clair : une lecture fine des besoins, des formats concrets et une logique d'impact utile pour les personnes comme pour les organisations.",
+        "items": {
+          "socioeconomicIntegration": {
+            "title": "Insertion socioprofessionnelle",
+            "description": "L'employabilité des jeunes reste au cœur de l'offre : orientation, outils de candidature, entretiens, posture professionnelle et progression concrète vers l'emploi."
+          },
+          "twoWayApproach": {
+            "title": "Approche bidirectionnelle",
+            "description": "Nous accompagnons les talents comme les organisations afin de réduire le décalage entre les besoins du marché, les compétences disponibles et la performance attendue."
+          },
+          "internationalExperience": {
+            "title": "Expérience internationale",
+            "description": "Nos interventions et expériences de terrain s'appuient sur des missions menées au Canada, aux États-Unis, en Espagne, en France, en Colombie, à Cuba, au Ghana, au Cameroun, au Togo et en Côte d'Ivoire."
+          },
+          "structuredSupport": {
+            "title": "Accompagnement structuré",
+            "description": "Chaque accompagnement relie la clarification du besoin, la prochaine étape, le plan d'action et le suivi. Le but n'est pas de multiplier les promesses, mais de rendre la trajectoire plus lisible."
+          }
+        }
+      },
+      "whyChoose": {
+        "eyebrow": "Différenciation",
+        "title": "Pourquoi choisir KRAAK ?",
+        "description": "Un accompagnement exigeant, concret et ancré dans vos objectifs réels.",
+        "items": {
+          "internationalExpertise": {
+            "title": "Expertise reconnue à l'international",
+            "description": "Un savoir-faire activé sur plusieurs terrains pour des besoins locaux et internationaux."
+          },
+          "personalisedSupport": {
+            "title": "Accompagnement personnalisé",
+            "description": "Chaque profil est unique : nous ajustons le cadre, le rythme et les livrables au contexte réel."
+          },
+          "measurableResults": {
+            "title": "Résultats concrets et mesurables",
+            "description": "Notre approche relie chaque action à une prochaine étape observable et utile."
+          }
+        }
+      },
+      "faq": {
+        "eyebrow": "Questions fréquentes",
+        "title": "Clarifiez votre point de départ avant de vous lancer.",
+        "description": "Cette première sélection de questions aide à situer le bon service et la prochaine étape la plus utile selon votre besoin.",
+        "backgroundAlt": "Échange d'orientation entre une conseillère KRAAK et une participante",
+        "panelTitle": "Un premier repère pour avancer",
+        "panelDescription": "Consultez les réponses aux questions les plus fréquentes avant de nous présenter votre besoin.",
+        "items": {
+          "gettingStarted": {
+            "question": "Je ne sais pas par où commencer. Quelle est la première étape ?",
+            "answer": "Commencez par partager votre objectif, votre contexte et votre délai via le formulaire de contact. Nous vous orientons ensuite vers le bon point d'entrée."
+          },
+          "businessSupport": {
+            "question": "Proposez-vous un accompagnement pour les entreprises ?",
+            "answer": "Oui. KRAAK accompagne aussi les organisations sur la gestion de projets, la formation du personnel, le recrutement et la performance d'équipe."
+          },
+          "consultationFormat": {
+            "question": "Les consultations ont-elles lieu en présentiel ou à distance ?",
+            "answer": "Les échanges peuvent se faire à distance ou en présentiel selon le besoin, le service et les contraintes du projet."
+          }
+        }
+      },
+      "closing": {
+        "titleLine1": "Vous savez où vous voulez aller.",
+        "titleLine2": "Nous savons comment vous y amener.",
+        "cta": "Prendre rendez-vous maintenant"
+      }
+    }
+  },
   "primeng": {
     "accept": "Accepter",
     "reject": "Refuser",

--- a/apps/client/projects/web/src/app/app.component.spec.ts
+++ b/apps/client/projects/web/src/app/app.component.spec.ts
@@ -1,3 +1,4 @@
+import { ApplicationInitStatus } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   Event as RouterEvent,
@@ -8,23 +9,26 @@ import {
 import { MessageService } from 'primeng/api';
 import { Subject } from 'rxjs';
 import { vi } from 'vitest';
+import { provideKraakI18n } from '../../../shared/i18n';
 import { App } from './app.component';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
-      providers: [provideRouter([]), MessageService],
+      providers: [provideRouter([]), provideKraakI18n(), MessageService],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
   });
 
-  it('should create the app', () => {
+  it('Given the application shell When it is created Then the instance exists', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it('should render the app shell with navbar, main, and footer', async () => {
+  it('Given the application shell When it renders Then it includes the navbar, main content, and footer', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
@@ -33,7 +37,7 @@ describe('App', () => {
     expect(compiled.querySelector('kraak-footer')).toBeTruthy();
   });
 
-  it('should expose a skip link and main landmark target for keyboard users', async () => {
+  it('Given a keyboard user When the application shell renders Then it exposes a skip link and main landmark target', async () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     await fixture.whenStable();

--- a/apps/client/projects/web/src/app/features/home/home.page.html
+++ b/apps/client/projects/web/src/app/features/home/home.page.html
@@ -14,39 +14,34 @@
       <h1
         class="text-brand-white text-4xl leading-[1.08] font-black md:text-6xl lg:leading-[1.05]"
       >
-        Développez vos
-        <span class="text-brand-cyan">compétences</span>.
+        {{ 'web.home.hero.titleSkills' | kraakTranslate }}
         <br />
-        Lancez vos <span class="text-brand-cyan">projets</span>.
+        {{ 'web.home.hero.titleProjects' | kraakTranslate }}
         <br />
-        Accédez aux
-        <span class="text-brand-cyan">opportunités</span>
-        internationales.
+        {{ 'web.home.hero.titleOpportunities' | kraakTranslate }}
       </h1>
 
       <p
         class="mt-8 max-w-2xl text-lg leading-relaxed text-neutral-200 md:text-xl lg:mt-9"
       >
-        KRAAK Consulting accompagne étudiants, professionnels, entreprises et
-        diaspora avec des solutions concrètes en formation, gestion de projets
-        et immigration.
+        {{ 'web.home.hero.description' | kraakTranslate }}
       </p>
 
       <div class="mt-10 flex flex-wrap gap-4 lg:mt-10 lg:gap-5 xl:mt-10.5">
         <a
           pButton
           [routerLink]="'contact' | localizedPublicPath"
-          label="Réserver une consultation"
+          [label]="'web.home.hero.primaryCta' | kraakTranslate"
           icon="pi pi-calendar"
-          aria-label="Réserver une consultation"
+          [attr.aria-label]="'web.home.hero.primaryCta' | kraakTranslate"
           class="kr-button-primary rounded-2xl px-8 py-4 text-xs font-black tracking-widest uppercase"
         ></a>
         <a
           pButton
           [routerLink]="'programs' | localizedPublicPath"
-          label="Découvrir nos programmes"
+          [label]="'web.home.hero.secondaryCta' | kraakTranslate"
           icon="pi pi-bolt"
-          aria-label="Découvrir nos programmes"
+          [attr.aria-label]="'web.home.hero.secondaryCta' | kraakTranslate"
           class="kr-button-ghost border-brand-white/20 bg-brand-white/10 rounded-2xl px-8 py-4 text-xs font-black tracking-widest uppercase backdrop-blur-md"
         ></a>
       </div>
@@ -60,7 +55,7 @@
       >
         <img
           src="/kraak-logo.avif"
-          alt="Logo KRAAK grand format"
+          [alt]="'web.home.hero.logoAlt' | kraakTranslate"
           class="h-full w-full object-contain"
           loading="eager"
           decoding="async"
@@ -80,17 +75,13 @@
     <p
       class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
     >
-      Un besoin concret
+      {{ 'web.home.need.eyebrow' | kraakTranslate }}
     </p>
     <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-      Une offre structurée autour de l'employabilité, des projets et de la
-      mobilité.
+      {{ 'web.home.need.title' | kraakTranslate }}
     </h2>
     <p class="text-brand-navy mx-auto mt-6 max-w-3xl text-lg">
-      Nous intervenons là où les trajectoires se bloquent : clarification de
-      projet, outils de candidature, structuration de projet, recrutement,
-      orientation internationale et mise en mouvement de la prochaine étape
-      utile.
+      {{ 'web.home.need.description' | kraakTranslate }}
     </p>
   </div>
 </section>
@@ -110,14 +101,14 @@
       >
         <img
           src="/assets/site-visuals/photos/home-services-training.avif"
-          alt="Participants en formation professionnelle dans un atelier collaboratif"
+          [alt]="'web.home.highlights.training.imageAlt' | kraakTranslate"
           loading="lazy"
           decoding="async"
           fetchpriority="low"
           class="h-52 w-full object-cover"
         />
         <figcaption class="text-brand-navy p-4 text-sm">
-          Employabilité, posture professionnelle et progression linguistique.
+          {{ 'web.home.highlights.training.caption' | kraakTranslate }}
         </figcaption>
       </figure>
       <figure
@@ -128,14 +119,14 @@
       >
         <img
           src="/assets/site-visuals/photos/home-services-project-planning.avif"
-          alt="Équipe en réunion autour d'une table pour cadrer un projet"
+          [alt]="'web.home.highlights.projects.imageAlt' | kraakTranslate"
           loading="lazy"
           decoding="async"
           fetchpriority="low"
           class="h-52 w-full object-cover"
         />
         <figcaption class="text-brand-navy p-4 text-sm">
-          Cadrage, structuration et accompagnement de projets utiles.
+          {{ 'web.home.highlights.projects.caption' | kraakTranslate }}
         </figcaption>
       </figure>
       <figure
@@ -146,14 +137,14 @@
       >
         <img
           src="/assets/site-visuals/photos/services-immigration.avif"
-          alt="Entretien d'accompagnement avec documents pour préparer un projet international"
+          [alt]="'web.home.highlights.mobility.imageAlt' | kraakTranslate"
           loading="lazy"
           decoding="async"
           fetchpriority="low"
           class="h-52 w-full object-cover"
         />
         <figcaption class="text-brand-navy p-4 text-sm">
-          Études, travail et orientation internationale préparés avec méthode.
+          {{ 'web.home.highlights.mobility.caption' | kraakTranslate }}
         </figcaption>
       </figure>
     </div>
@@ -166,7 +157,9 @@
   [revealDelayMs]="80"
 >
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <h2 class="text-center text-3xl font-bold lg:text-4xl">Nos 3 pôles</h2>
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      {{ 'web.home.pillars.title' | kraakTranslate }}
+    </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-3">
       <article class="rounded-card bg-brand-white shadow-card p-6">
         <div
@@ -174,16 +167,17 @@
         >
           <i class="pi pi-graduation-cap text-2xl" aria-hidden="true"></i>
         </div>
-        <h3 class="text-xl font-bold">Formation</h3>
+        <h3 class="text-xl font-bold">
+          {{ 'web.home.pillars.training.title' | kraakTranslate }}
+        </h3>
         <p class="text-brand-navy mt-3">
-          Pour les jeunes et les professionnels qui veulent renforcer leur
-          employabilité, leur posture et leurs outils de candidature.
+          {{ 'web.home.pillars.training.description' | kraakTranslate }}
         </p>
         <a
           [routerLink]="'services' | localizedPublicPath"
           class="kr-link mt-5 inline-flex font-semibold"
         >
-          Voir les formations
+          {{ 'web.home.pillars.training.cta' | kraakTranslate }}
         </a>
       </article>
 
@@ -193,16 +187,17 @@
         >
           <i class="pi pi-chart-bar text-2xl" aria-hidden="true"></i>
         </div>
-        <h3 class="text-xl font-bold">Recherche &amp; Gestion de projets</h3>
+        <h3 class="text-xl font-bold">
+          {{ 'web.home.pillars.projects.title' | kraakTranslate }}
+        </h3>
         <p class="text-brand-navy mt-3">
-          Pour les startups, les entreprises et les porteurs de projets qui
-          doivent cadrer, planifier et faire avancer une initiative utile.
+          {{ 'web.home.pillars.projects.description' | kraakTranslate }}
         </p>
         <a
           [routerLink]="'services' | localizedPublicPath"
           class="kr-link mt-5 inline-flex font-semibold"
         >
-          Structurer un projet
+          {{ 'web.home.pillars.projects.cta' | kraakTranslate }}
         </a>
       </article>
 
@@ -212,16 +207,17 @@
         >
           <i class="pi pi-globe text-2xl" aria-hidden="true"></i>
         </div>
-        <h3 class="text-xl font-bold">Études &amp; Immigration</h3>
+        <h3 class="text-xl font-bold">
+          {{ 'web.home.pillars.mobility.title' | kraakTranslate }}
+        </h3>
         <p class="text-brand-navy mt-3">
-          Pour les profils qui visent les études, le travail ou une mobilité
-          internationale avec une préparation claire et progressive.
+          {{ 'web.home.pillars.mobility.description' | kraakTranslate }}
         </p>
         <a
           [routerLink]="'contact' | localizedPublicPath"
           class="kr-link mt-5 inline-flex font-semibold"
         >
-          Qualifier mon projet
+          {{ 'web.home.pillars.mobility.cta' | kraakTranslate }}
         </a>
       </article>
     </div>
@@ -239,19 +235,17 @@
         <p
           class="text-brand-blue text-sm font-semibold tracking-[0.18em] uppercase"
         >
-          Solutions clés
+          {{ 'web.home.solutions.eyebrow' | kraakTranslate }}
         </p>
         <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-          Des points d'entrée concrets selon votre objectif.
+          {{ 'web.home.solutions.title' | kraakTranslate }}
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
-          Vous n'avez pas besoin d'arriver avec un besoin parfaitement formulé :
-          nous partons d'un objectif concret, puis nous clarifions le bon format
-          d'appui.
+          {{ 'web.home.solutions.description' | kraakTranslate }}
         </p>
       </div>
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-        @for (solution of keySolutions; track solution) {
+        @for (solution of keySolutions; track solution.textKey) {
           <article class="rounded-card w-full bg-neutral-50 p-5 text-center">
             <span
               class="bg-brand-white text-brand-blue mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-sm"
@@ -259,7 +253,7 @@
               {{ $index + 1 }}
             </span>
             <p class="text-brand-navy text-lg leading-snug font-medium">
-              {{ solution }}
+              {{ solution.textKey | kraakTranslate }}
             </p>
           </article>
         }
@@ -278,62 +272,27 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.18em] uppercase"
       >
-        Preuves d'approche
+        {{ 'web.home.proof.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Une proposition ancrée dans des besoins réels.
+        {{ 'web.home.proof.title' | kraakTranslate }}
       </h2>
       <p class="text-brand-navy mx-auto mt-4 max-w-3xl text-lg">
-        KRAAK avance avec un cadre clair : une lecture fine des besoins, des
-        formats concrets et une logique d'impact utile pour les personnes comme
-        pour les organisations.
+        {{ 'web.home.proof.description' | kraakTranslate }}
       </p>
     </div>
 
     <div class="mt-10 grid gap-6 md:grid-cols-2">
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">
-          Insertion socioprofessionnelle
-        </p>
-        <p class="text-brand-navy mt-3">
-          L'employabilité des jeunes reste au cœur de l'offre : orientation,
-          outils de candidature, entretiens, posture professionnelle et
-          progression concrète vers l'emploi.
-        </p>
-      </article>
-
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">
-          Approche bidirectionnelle
-        </p>
-        <p class="text-brand-navy mt-3">
-          Nous accompagnons les talents comme les organisations afin de réduire
-          le décalage entre besoins du marché, compétences disponibles et
-          performance attendue.
-        </p>
-      </article>
-
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">
-          Expérience internationale
-        </p>
-        <p class="text-brand-navy mt-3">
-          Nos interventions et expériences de terrain s'appuient sur des
-          missions menées au Canada, aux États-Unis, en Espagne, en France, en
-          Colombie, à Cuba, au Ghana, au Cameroun, au Togo et en Côte d'Ivoire.
-        </p>
-      </article>
-
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">
-          Accompagnement structuré
-        </p>
-        <p class="text-brand-navy mt-3">
-          Chaque accompagnement relie clarification du besoin, prochaine étape,
-          plan d'action et suivi. Le but n'est pas de multiplier les promesses,
-          mais de rendre la trajectoire plus lisible.
-        </p>
-      </article>
+      @for (item of proofItems; track item.titleKey) {
+        <article class="rounded-card bg-brand-white p-6 shadow-sm">
+          <p class="text-primary text-sm font-semibold uppercase">
+            {{ item.titleKey | kraakTranslate }}
+          </p>
+          <p class="text-brand-navy mt-3">
+            {{ item.descriptionKey | kraakTranslate }}
+          </p>
+        </article>
+      }
     </div>
   </div>
 </section>
@@ -344,18 +303,18 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.18em] uppercase"
       >
-        Différenciation
+        {{ 'web.home.whyChoose.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Pourquoi choisir KRAAK ?
+        {{ 'web.home.whyChoose.title' | kraakTranslate }}
       </h2>
       <p class="text-brand-navy mx-auto mt-4 max-w-3xl text-lg">
-        Un accompagnement exigeant, concret et ancré dans vos objectifs réels.
+        {{ 'web.home.whyChoose.description' | kraakTranslate }}
       </p>
     </div>
 
     <div class="mt-10 grid gap-4 md:grid-cols-2">
-      @for (item of whyChooseItems; track item.title) {
+      @for (item of whyChooseItems; track item.titleKey) {
         <article class="rounded-card bg-neutral-50 p-6">
           <div class="flex items-start gap-4">
             <span
@@ -365,10 +324,10 @@
             </span>
             <div>
               <h3 class="text-brand-navy text-lg font-bold">
-                {{ item.title }}
+                {{ item.titleKey | kraakTranslate }}
               </h3>
               <p class="text-brand-navy mt-2 text-sm leading-6">
-                {{ item.description }}
+                {{ item.descriptionKey | kraakTranslate }}
               </p>
             </div>
           </div>
@@ -384,19 +343,23 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.18em] uppercase"
       >
-        Questions fréquentes
+        {{ 'web.home.faq.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Clarifiez votre point de départ avant de vous lancer.
+        {{ 'web.home.faq.title' | kraakTranslate }}
       </h2>
       <p class="text-brand-navy mx-auto mt-4 max-w-3xl text-lg">
-        Cette première sélection de questions aide à situer le bon service et la
-        prochaine étape la plus utile selon votre besoin.
+        {{ 'web.home.faq.description' | kraakTranslate }}
       </p>
     </div>
 
     <div class="mt-10">
-      <kraak-faq-accordion [items]="faqItems" />
+      <kraak-faq-accordion
+        [items]="faqItems()"
+        [heading]="'web.home.faq.panelTitle' | kraakTranslate"
+        [description]="'web.home.faq.panelDescription' | kraakTranslate"
+        [backgroundAlt]="'web.home.faq.backgroundAlt' | kraakTranslate"
+      />
     </div>
   </div>
 </section>
@@ -407,8 +370,8 @@
       class="from-brand-navy via-brand-blue to-brand-cyan text-brand-white shadow-brand-navy/20 overflow-hidden rounded-[3rem] bg-linear-to-r px-8 py-14 text-center shadow-2xl md:px-12 md:py-18 lg:px-20 lg:py-20"
     >
       <h2 class="text-3xl leading-tight font-black text-white md:text-5xl">
-        Vous savez où vous voulez aller.<br />
-        Nous savons comment vous y amener.
+        {{ 'web.home.closing.titleLine1' | kraakTranslate }}<br />
+        {{ 'web.home.closing.titleLine2' | kraakTranslate }}
       </h2>
 
       <a
@@ -416,13 +379,13 @@
         kraakPublicConversion="conversion_cta_click"
         [kraakPublicConversionPayload]="{
           cta_context: 'home_main_cta',
-          cta_label: 'Prendre rendez-vous maintenant',
+          cta_label: 'web.home.closing.cta' | kraakTranslate,
           cta_link: 'contact' | localizedPublicPath,
         }"
         class="bg-brand-white text-brand-navy hover:bg-brand-cyan hover:text-brand-white mt-8 inline-flex items-center justify-center rounded-2xl px-12 py-5 text-sm font-black tracking-widest uppercase shadow-xl transition-all duration-300"
-        aria-label="Prendre rendez-vous maintenant"
+        [attr.aria-label]="'web.home.closing.cta' | kraakTranslate"
       >
-        Prendre rendez-vous maintenant
+        {{ 'web.home.closing.cta' | kraakTranslate }}
       </a>
     </div>
   </div>

--- a/apps/client/projects/web/src/app/features/home/home.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.spec.ts
@@ -1,8 +1,23 @@
+import { ApplicationInitStatus, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
 import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
 import HomePage from './home.page';
+
+@Component({
+  standalone: true,
+  template: '',
+})
+class BlankRouteComponent {}
+
+function normalizedText(element: Element | null): string {
+  return (element?.textContent ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([.!?])/g, '$1')
+    .trim();
+}
 
 const gsapAnimationsServiceMock: Pick<
   GsapAnimationsService,
@@ -28,13 +43,16 @@ describe('HomePage', () => {
     await TestBed.configureTestingModule({
       imports: [HomePage],
       providers: [
-        provideRouter([]),
+        provideRouter([{ path: '**', component: BlankRouteComponent }]),
+        provideKraakI18n(),
         {
           provide: GsapAnimationsService,
           useValue: gsapAnimationsServiceMock,
         },
       ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
   });
 
   it('Given the home page component When it is created Then the instance exists', () => {
@@ -59,6 +77,90 @@ describe('HomePage', () => {
     expect(element.textContent).toContain('Recherche & Gestion de projets');
   });
 
+  it('Given the French public homepage When it renders Then the hero and primary action come from the French catalog', async () => {
+    await TestBed.inject(Router).navigateByUrl('/fr/');
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const hero = normalizedText(host.querySelector('h1'));
+
+    expect(hero).toContain('Développez vos compétences.');
+    expect(hero).toContain('Lancez vos projets.');
+    expect(hero).toContain('Accédez aux opportunités internationales.');
+    expect(normalizedText(host)).toContain('Réserver une consultation');
+  });
+
+  it('Given the English public homepage When it renders Then the hero and primary action come from the English catalog', async () => {
+    await TestBed.inject(Router).navigateByUrl('/en/');
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const hero = normalizedText(host.querySelector('h1'));
+
+    expect(hero).toContain('Build your skills.');
+    expect(hero).toContain('Launch your projects.');
+    expect(hero).toContain('Access international opportunities.');
+    expect(normalizedText(host)).toContain('Book a consultation');
+  });
+
+  it('Given the English public homepage When every section renders Then representative content and FAQ copy come from the English catalog', async () => {
+    await TestBed.inject(Router).navigateByUrl('/en/');
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+
+    const content = normalizedText(fixture.nativeElement as HTMLElement);
+
+    expect(content).toContain('Our three areas of expertise');
+    expect(content).toContain('Research & Project Management');
+    expect(content).toContain('Personal and professional development');
+    expect(content).toContain('Employability and career integration');
+    expect(content).toContain('Internationally recognised expertise');
+    expect(content).toContain(
+      'I am not sure where to start. What is the first step?',
+    );
+    expect(content).toContain('You know where you want to go.');
+    expect(content).not.toContain('[missing:web.home.');
+  });
+
+  it('Given an already rendered French homepage When the locale changes to English Then the FAQ content updates in the same fixture', async () => {
+    const i18n = TestBed.inject(KraakI18nService);
+    await i18n.setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(normalizedText(host)).toContain(
+      'Je ne sais pas par où commencer. Quelle est la première étape?',
+    );
+
+    await i18n.setLocale('en-GB');
+    fixture.detectChanges();
+
+    const content = normalizedText(host);
+    expect(content).toContain(
+      'I am not sure where to start. What is the first step?',
+    );
+    expect(content).toContain('A first step towards clarity');
+    expect(content).toContain(
+      'Review the answers to our most frequently asked questions',
+    );
+    expect(
+      host.querySelector('kraak-faq-accordion img')?.getAttribute('alt'),
+    ).toBe('A KRAAK adviser guiding a participant through her options');
+    expect(content).not.toContain(
+      'Je ne sais pas par où commencer. Quelle est la première étape?',
+    );
+  });
+
   it('Given the home page component When reading the hero background Then it exposes the expected style object', () => {
     const fixture = TestBed.createComponent(HomePage);
     const component = fixture.componentInstance;
@@ -78,7 +180,7 @@ describe('HomePage', () => {
     const content = fixture.nativeElement.textContent as string;
 
     expect(content).toContain('Développement personnel et professionnel');
-    expect(content).toContain('Anglais et français professionnel');
+    expect(content).toContain('Anglais et français professionnels');
     expect(content).toContain('Leadership et prise de parole');
     expect(content).toContain('Préparation aux entretiens');
     expect(content).toContain('Structuration de projets');
@@ -134,7 +236,7 @@ describe('HomePage', () => {
     expect(content).toContain('Prendre rendez-vous maintenant');
   });
 
-  it('should render home-specific FAQ section', () => {
+  it('Given the home page When its FAQ renders Then it shows the home-specific questions', () => {
     const fixture = TestBed.createComponent(HomePage);
     fixture.detectChanges();
 
@@ -142,7 +244,7 @@ describe('HomePage', () => {
 
     expect(content).toContain('Questions fréquentes');
     expect(content).toContain(
-      'Je ne sais pas par où commencer, quelle est la première étape ?',
+      'Je ne sais pas par où commencer. Quelle est la première étape ?',
     );
   });
 });

--- a/apps/client/projects/web/src/app/features/home/home.page.ts
+++ b/apps/client/projects/web/src/app/features/home/home.page.ts
@@ -1,4 +1,11 @@
-import { Component, Injector, OnDestroy, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  Injector,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+} from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ButtonDirective } from 'primeng/button';
@@ -16,10 +23,84 @@ import {
   type FaqItem,
 } from '../../shared/faq-accordion/faq-accordion.component';
 import { LocalizedPublicPathPipe } from '../../routing/localized-public-path.pipe';
+import {
+  KraakI18nService,
+  KraakTranslatePipe,
+} from '../../../../../shared/i18n';
 
 const HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/programs-workshop.avif',
 );
+
+interface HomeTextTranslation {
+  readonly textKey: string;
+}
+
+interface HomeCardTranslation {
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+}
+
+const HOME_SOLUTION_TRANSLATIONS: readonly HomeTextTranslation[] = [
+  { textKey: 'web.home.solutions.items.personalDevelopment' },
+  { textKey: 'web.home.solutions.items.professionalLanguages' },
+  { textKey: 'web.home.solutions.items.leadership' },
+  { textKey: 'web.home.solutions.items.interviewPreparation' },
+  { textKey: 'web.home.solutions.items.projectStructuring' },
+  { textKey: 'web.home.solutions.items.businessSupport' },
+  { textKey: 'web.home.solutions.items.internationalMobility' },
+  { textKey: 'web.home.solutions.items.recruitment' },
+];
+
+const HOME_PROOF_TRANSLATIONS: readonly HomeCardTranslation[] = [
+  {
+    titleKey: 'web.home.proof.items.socioeconomicIntegration.title',
+    descriptionKey: 'web.home.proof.items.socioeconomicIntegration.description',
+  },
+  {
+    titleKey: 'web.home.proof.items.twoWayApproach.title',
+    descriptionKey: 'web.home.proof.items.twoWayApproach.description',
+  },
+  {
+    titleKey: 'web.home.proof.items.internationalExperience.title',
+    descriptionKey: 'web.home.proof.items.internationalExperience.description',
+  },
+  {
+    titleKey: 'web.home.proof.items.structuredSupport.title',
+    descriptionKey: 'web.home.proof.items.structuredSupport.description',
+  },
+];
+
+const HOME_WHY_CHOOSE_TRANSLATIONS: readonly HomeCardTranslation[] = [
+  {
+    titleKey: 'web.home.whyChoose.items.internationalExpertise.title',
+    descriptionKey:
+      'web.home.whyChoose.items.internationalExpertise.description',
+  },
+  {
+    titleKey: 'web.home.whyChoose.items.personalisedSupport.title',
+    descriptionKey: 'web.home.whyChoose.items.personalisedSupport.description',
+  },
+  {
+    titleKey: 'web.home.whyChoose.items.measurableResults.title',
+    descriptionKey: 'web.home.whyChoose.items.measurableResults.description',
+  },
+];
+
+const HOME_FAQ_TRANSLATIONS = [
+  {
+    questionKey: 'web.home.faq.items.gettingStarted.question',
+    answerKey: 'web.home.faq.items.gettingStarted.answer',
+  },
+  {
+    questionKey: 'web.home.faq.items.businessSupport.question',
+    answerKey: 'web.home.faq.items.businessSupport.answer',
+  },
+  {
+    questionKey: 'web.home.faq.items.consultationFormat.question',
+    answerKey: 'web.home.faq.items.consultationFormat.answer',
+  },
+] as const;
 
 @Component({
   selector: 'kraak-home-page',
@@ -32,6 +113,7 @@ const HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
     PublicConversionTrackingDirective,
     RevealOnScrollDirective,
     LocalizedPublicPathPipe,
+    KraakTranslatePipe,
   ],
   templateUrl: './home.page.html',
   styles: [
@@ -86,60 +168,23 @@ const HOME_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
 export default class HomePage implements OnInit, OnDestroy {
   readonly heroBackgroundStyle = HOME_HERO_BACKGROUND_STYLE;
 
-  protected readonly whyChooseItems: readonly {
-    readonly title: string;
-    readonly description: string;
-  }[] = [
-    {
-      title: "Expertise reconnue à l'international",
-      description:
-        'Un savoir-faire activé sur plusieurs terrains pour des besoins locaux et internationaux.',
-    },
-    {
-      title: 'Accompagnement personnalisé',
-      description:
-        'Chaque profil est unique : nous ajustons le cadre, le rythme et les livrables au contexte réel.',
-    },
-    {
-      title: 'Résultats concrets et mesurables',
-      description:
-        'Notre approche relie chaque action à une prochaine étape observable et utile.',
-    },
-  ];
+  protected readonly keySolutions = HOME_SOLUTION_TRANSLATIONS;
+  protected readonly proofItems = HOME_PROOF_TRANSLATIONS;
+  protected readonly whyChooseItems = HOME_WHY_CHOOSE_TRANSLATIONS;
 
-  protected readonly keySolutions: readonly string[] = [
-    'Développement personnel et professionnel',
-    'Anglais et français professionnel',
-    'Leadership et prise de parole',
-    'Préparation aux entretiens',
-    'Structuration de projets',
-    "Accompagnement d'entreprises et startups",
-    'Conseils en mobilité internationale',
-    'Recrutement et placement en emploi',
-  ];
-
-  protected readonly faqItems: FaqItem[] = [
-    {
-      question:
-        'Je ne sais pas par où commencer, quelle est la première étape ?',
-      answer:
-        "Commencez par partager votre objectif, votre contexte et votre délai via le formulaire de contact. Nous vous orientons ensuite vers le bon point d'entrée.",
-    },
-    {
-      question: 'Proposez-vous un accompagnement pour les entreprises ?',
-      answer:
-        "Oui. KRAAK accompagne aussi les organisations sur la gestion de projets, la formation du personnel, le recrutement et la performance d'équipe.",
-    },
-    {
-      question: 'Les consultations sont-elles présentiel ou à distance ?',
-      answer:
-        'Les échanges peuvent se faire à distance ou en présentiel selon le besoin, le service et les contraintes du projet.',
-    },
-  ];
-
+  private readonly i18n = inject(KraakI18nService);
   private readonly injector = inject(Injector);
   private gsapService: GsapAnimationsService | null = null;
   private isDestroyed = false;
+
+  protected readonly faqItems = computed<readonly FaqItem[]>(() => {
+    this.i18n.locale();
+
+    return HOME_FAQ_TRANSLATIONS.map(({ questionKey, answerKey }) => ({
+      question: this.i18n.translate(questionKey),
+      answer: this.i18n.translate(answerKey),
+    }));
+  });
 
   ngOnInit(): void {
     void this.initializeAnimations();

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.html
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.html
@@ -4,7 +4,7 @@
   class="bg-brand-white/92 border-brand-blue/10 shadow-brand-navy/10 sticky top-0 z-50 border-b shadow-lg backdrop-blur-sm"
 >
   <nav
-    aria-label="Navigation principale"
+    [attr.aria-label]="'web.nav.primaryLabel' | kraakTranslate"
     class="relative mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-4 lg:px-6"
   >
     <a
@@ -14,7 +14,7 @@
     >
       <img
         src="/kraak_symbol.svg"
-        alt="Symbole KRAAK"
+        [attr.alt]="'web.nav.brandSymbolAlt' | kraakTranslate"
         width="44"
         height="44"
         fetchpriority="high"
@@ -30,7 +30,7 @@
     </a>
 
     <div
-      class="border-brand-blue/10 bg-brand-white absolute top-full left-0 z-50 w-full items-center justify-between border-t px-4 py-4 shadow-sm lg:static lg:flex lg:w-auto lg:grow lg:border-0 lg:bg-transparent lg:p-0 lg:shadow-none"
+      class="border-brand-blue/10 bg-brand-white absolute top-full left-0 z-50 w-full flex-col items-stretch justify-between gap-4 border-t px-4 py-4 shadow-sm lg:static lg:flex lg:w-auto lg:grow lg:flex-row lg:items-center lg:gap-0 lg:border-0 lg:bg-transparent lg:p-0 lg:shadow-none"
       [class.hidden]="!mobileMenuOpen()"
       [class.flex]="mobileMenuOpen()"
     >
@@ -39,26 +39,73 @@
       >
         @for (link of links; track link.pageId) {
           @let localizedPath = link.pageId | localizedPublicPath;
+          @let navLabel = link.labelKey | kraakTranslate;
           <li>
             <a
               [routerLink]="localizedPath"
               routerLinkActive="text-brand-navy after:scale-x-100"
               kraakPublicConversion="nav_cta_click"
               [kraakPublicConversionPayload]="{
-                nav_label: link.label,
+                nav_label: navLabel,
                 nav_path: localizedPath,
                 nav_surface: 'primary_nav',
               }"
               class="kr-nav-link kr-navbar-interactive uppercase"
               (click)="closeMobileMenu()"
             >
-              {{ link.label }}
+              {{ navLabel }}
             </a>
           </li>
         }
       </ul>
+      <div
+        role="group"
+        [attr.aria-label]="'web.nav.languageSwitcher.label' | kraakTranslate"
+        class="border-brand-blue/15 flex items-center self-start rounded-full border p-1 lg:mr-3 lg:self-auto"
+      >
+        @let frenchIsCurrent = locale() === 'fr-CI';
+        @let englishIsCurrent = locale() === 'en-GB';
+        <a
+          [attr.href]="buildLanguageHref('fr-CI')"
+          hreflang="fr-CI"
+          [attr.aria-current]="frenchIsCurrent ? 'page' : null"
+          [attr.aria-label]="
+            (frenchIsCurrent
+              ? 'web.nav.languageSwitcher.frenchCurrentLabel'
+              : 'web.nav.languageSwitcher.switchToFrenchLabel'
+            ) | kraakTranslate
+          "
+          class="kr-navbar-interactive rounded-full px-3 py-1.5 text-xs font-bold"
+          [class.bg-brand-navy]="frenchIsCurrent"
+          [class.text-brand-white]="frenchIsCurrent"
+          (click)="closeMobileMenu()"
+        >
+          <span lang="fr-CI">
+            {{ 'web.nav.languageSwitcher.frenchShort' | kraakTranslate }}
+          </span>
+        </a>
+        <a
+          [attr.href]="buildLanguageHref('en-GB')"
+          hreflang="en-GB"
+          [attr.aria-current]="englishIsCurrent ? 'page' : null"
+          [attr.aria-label]="
+            (englishIsCurrent
+              ? 'web.nav.languageSwitcher.englishCurrentLabel'
+              : 'web.nav.languageSwitcher.switchToEnglishLabel'
+            ) | kraakTranslate
+          "
+          class="kr-navbar-interactive rounded-full px-3 py-1.5 text-xs font-bold"
+          [class.bg-brand-navy]="englishIsCurrent"
+          [class.text-brand-white]="englishIsCurrent"
+          (click)="closeMobileMenu()"
+        >
+          <span lang="en-GB">
+            {{ 'web.nav.languageSwitcher.englishShort' | kraakTranslate }}
+          </span>
+        </a>
+      </div>
       <kraak-participant-nav-cta
-        class="mt-4 flex lg:mt-0"
+        class="flex self-start lg:self-auto"
         (activated)="closeMobileMenu()"
       />
     </div>
@@ -69,7 +116,12 @@
         class="kr-navbar-interactive border-brand-blue/25 bg-brand-white text-brand-navy hover:border-brand-blue/45 hover:bg-brand-cyan/8 shadow-brand-navy/20 inline-flex items-center justify-center rounded-(--kr-radius-btn) border px-3 py-3 shadow-xl"
         (click)="toggleMobileMenu()"
         [attr.aria-expanded]="mobileMenuOpen()"
-        aria-label="Menu de navigation"
+        [attr.aria-label]="
+          (mobileMenuOpen()
+            ? 'web.nav.mobileMenu.closeLabel'
+            : 'web.nav.mobileMenu.openLabel'
+          ) | kraakTranslate
+        "
       >
         <i
           [class]="mobileMenuOpen() ? 'pi pi-times' : 'pi pi-bars'"

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.spec.ts
@@ -1,26 +1,55 @@
 // apps\client\projects\web\src\app\layouts\navbar\navbar.component.spec.ts
 
-import { provideRouter } from '@angular/router';
+import { Location } from '@angular/common';
+import { ApplicationInitStatus, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { vi } from 'vitest';
 
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
 import { Navbar } from './navbar.component';
 
+@Component({
+  standalone: true,
+  template: '',
+})
+class BlankRouteComponent {}
+
 interface NavbarInternals {
-  links: { label: string; pageId: string }[];
+  links: { labelKey: string; pageId: string }[];
   mobileMenuOpen: () => boolean;
+}
+
+async function renderNavbarAt(
+  path: string,
+  locale: 'fr-CI' | 'en-GB',
+): Promise<HTMLElement> {
+  await TestBed.inject(Router).navigateByUrl(path);
+  await TestBed.inject(KraakI18nService).setLocale(locale);
+
+  const fixture = TestBed.createComponent(Navbar);
+  fixture.detectChanges();
+
+  return fixture.nativeElement as HTMLElement;
 }
 
 describe('Navbar', () => {
   const originalConfig = globalThis.__KRAAK_RUNTIME_CONFIG__;
 
   afterEach(() => {
+    vi.restoreAllMocks();
     globalThis.__KRAAK_RUNTIME_CONFIG__ = originalConfig;
   });
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Navbar],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([{ path: '**', component: BlankRouteComponent }]),
+        provideKraakI18n(),
+      ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
   });
 
   it('Given la navbar est créée, When Angular initialise le composant, Then la configuration de base existe', () => {
@@ -76,7 +105,7 @@ describe('Navbar', () => {
 
     const host = fixture.nativeElement as HTMLElement;
     const button = host.querySelector(
-      'button[aria-label="Menu de navigation"]',
+      'button[aria-label="Ouvrir le menu de navigation"]',
     );
     expect(button).not.toBeNull();
 
@@ -86,6 +115,9 @@ describe('Navbar', () => {
     fixture.detectChanges();
 
     expect(button?.getAttribute('aria-expanded')).toBe('true');
+    expect(button?.getAttribute('aria-label')).toBe(
+      'Fermer le menu de navigation',
+    );
 
     const firstNavLink = host.querySelector('a.kr-nav-link');
     expect(firstNavLink).not.toBeNull();
@@ -93,6 +125,110 @@ describe('Navbar', () => {
     fixture.detectChanges();
 
     expect(button?.getAttribute('aria-expanded')).toBe('false');
+    expect(button?.getAttribute('aria-label')).toBe(
+      'Ouvrir le menu de navigation',
+    );
+  });
+
+  it('Given a French public page with URL state When the navbar renders Then its labels, paths, and language selector are localized', async () => {
+    const host = await renderNavbarAt(
+      '/fr/programmes?utm_campaign=summer#offres',
+      'fr-CI',
+    );
+    const navLinks = Array.from(
+      host.querySelectorAll<HTMLAnchorElement>('a.kr-nav-link'),
+    );
+    const languageGroup = host.querySelector<HTMLElement>('[role="group"]');
+    const frenchLink = languageGroup?.querySelector<HTMLAnchorElement>(
+      'a[hreflang="fr-CI"]',
+    );
+    const englishLink = languageGroup?.querySelector<HTMLAnchorElement>(
+      'a[hreflang="en-GB"]',
+    );
+
+    expect(navLinks.map((link) => link.textContent?.trim())).toEqual([
+      'ACCUEIL',
+      'SERVICES',
+      'PROGRAMMES',
+      'À PROPOS',
+      'CONTACT',
+    ]);
+    expect(navLinks.map((link) => link.getAttribute('href'))).toEqual([
+      '/fr',
+      '/fr/services',
+      '/fr/programmes',
+      '/fr/a-propos',
+      '/fr/contact',
+    ]);
+    expect(languageGroup?.getAttribute('aria-label')).toBe('Choisir la langue');
+    expect(frenchLink?.hasAttribute('lang')).toBe(false);
+    expect(frenchLink?.querySelector('[lang="fr-CI"]')).not.toBeNull();
+    expect(frenchLink?.getAttribute('aria-current')).toBe('page');
+    expect(frenchLink?.getAttribute('href')).toBe(
+      '/fr/programmes?utm_campaign=summer#offres',
+    );
+    expect(englishLink?.hasAttribute('lang')).toBe(false);
+    expect(englishLink?.querySelector('[lang="en-GB"]')).not.toBeNull();
+    expect(englishLink?.hasAttribute('aria-current')).toBe(false);
+    expect(englishLink?.getAttribute('href')).toBe(
+      '/en/programs?utm_campaign=summer#offres',
+    );
+  });
+
+  it('Given an English public page with URL state When the navbar renders Then its labels, paths, and language selector are localized', async () => {
+    const host = await renderNavbarAt('/en/about?ref=nav#team', 'en-GB');
+    const navLinks = Array.from(
+      host.querySelectorAll<HTMLAnchorElement>('a.kr-nav-link'),
+    );
+    const languageGroup = host.querySelector<HTMLElement>('[role="group"]');
+    const frenchLink = languageGroup?.querySelector<HTMLAnchorElement>(
+      'a[hreflang="fr-CI"]',
+    );
+    const englishLink = languageGroup?.querySelector<HTMLAnchorElement>(
+      'a[hreflang="en-GB"]',
+    );
+
+    expect(navLinks.map((link) => link.textContent?.trim())).toEqual([
+      'HOME',
+      'SERVICES',
+      'PROGRAMMES',
+      'ABOUT',
+      'CONTACT',
+    ]);
+    expect(navLinks.map((link) => link.getAttribute('href'))).toEqual([
+      '/en',
+      '/en/services',
+      '/en/programs',
+      '/en/about',
+      '/en/contact',
+    ]);
+    expect(languageGroup?.getAttribute('aria-label')).toBe('Choose language');
+    expect(englishLink?.hasAttribute('lang')).toBe(false);
+    expect(englishLink?.querySelector('[lang="en-GB"]')).not.toBeNull();
+    expect(englishLink?.getAttribute('aria-current')).toBe('page');
+    expect(englishLink?.getAttribute('href')).toBe('/en/about?ref=nav#team');
+    expect(frenchLink?.hasAttribute('lang')).toBe(false);
+    expect(frenchLink?.querySelector('[lang="fr-CI"]')).not.toBeNull();
+    expect(frenchLink?.hasAttribute('aria-current')).toBe(false);
+    expect(frenchLink?.getAttribute('href')).toBe('/fr/a-propos?ref=nav#team');
+  });
+
+  it('Given the address bar has advanced while the router URL is transitional When the navbar renders Then the language href uses the address-bar URL', async () => {
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/fr/');
+    vi.spyOn(TestBed.inject(Location), 'path').mockReturnValue(
+      '/en/programs?campaign=summer#offres',
+    );
+
+    const fixture = TestBed.createComponent(Navbar);
+    fixture.detectChanges();
+
+    const frenchLink = fixture.nativeElement.querySelector(
+      'a[hreflang="fr-CI"]',
+    ) as HTMLAnchorElement;
+    expect(frenchLink.getAttribute('href')).toBe(
+      '/fr/programmes?campaign=summer#offres',
+    );
   });
 
   it('Given the participant area is enabled, When the navbar renders, Then the participant CTA is visible', () => {

--- a/apps/client/projects/web/src/app/layouts/navbar/navbar.component.ts
+++ b/apps/client/projects/web/src/app/layouts/navbar/navbar.component.ts
@@ -1,15 +1,26 @@
 // apps\client\projects\web\src\app\layouts\navbar\navbar.component.ts
 
-import { Component, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import type { SupportedLocale } from '@kraak/domain';
+
+import {
+  KraakI18nService,
+  KraakTranslatePipe,
+  type TranslationKey,
+} from '../../../../../shared/i18n';
 
 import { LocalizedPublicPathPipe } from '../../routing/localized-public-path.pipe';
-import type { LocalizedPublicPageId } from '../../routing/localized-public-routes';
+import {
+  buildLocalizedPublicLocalePath,
+  type LocalizedPublicPageId,
+} from '../../routing/localized-public-routes';
 import { PublicConversionTrackingDirective } from '../../shared/analytics/public-conversion-tracking.directive';
 import { ParticipantNavCta } from '../../shared/participant-nav-cta/participant-nav-cta.component';
 
 interface NavLink {
-  label: string;
+  labelKey: TranslationKey;
   pageId: LocalizedPublicPageId;
 }
 
@@ -21,19 +32,31 @@ interface NavLink {
     PublicConversionTrackingDirective,
     ParticipantNavCta,
     LocalizedPublicPathPipe,
+    KraakTranslatePipe,
   ],
   templateUrl: './navbar.component.html',
 })
 export class Navbar {
+  private readonly location = inject(Location);
+  private readonly i18n = inject(KraakI18nService);
+
   protected readonly links: NavLink[] = [
-    { label: 'ACCUEIL', pageId: 'home' },
-    { label: 'SERVICES', pageId: 'services' },
-    { label: 'PROGRAMMES', pageId: 'programs' },
-    { label: '\u00C0 PROPOS', pageId: 'about' },
-    { label: 'CONTACT', pageId: 'contact' },
+    { labelKey: 'web.nav.links.home', pageId: 'home' },
+    { labelKey: 'web.nav.links.services', pageId: 'services' },
+    { labelKey: 'web.nav.links.programs', pageId: 'programs' },
+    { labelKey: 'web.nav.links.about', pageId: 'about' },
+    { labelKey: 'web.nav.links.contact', pageId: 'contact' },
   ];
 
+  protected readonly locale = this.i18n.locale;
   protected readonly mobileMenuOpen = signal(false);
+
+  protected buildLanguageHref(targetLocale: SupportedLocale): string {
+    return buildLocalizedPublicLocalePath(
+      this.location.path(true),
+      targetLocale,
+    );
+  }
 
   protected toggleMobileMenu(): void {
     this.mobileMenuOpen.update((v) => !v);

--- a/apps/client/projects/web/src/app/routing/localized-public-routes.spec.ts
+++ b/apps/client/projects/web/src/app/routing/localized-public-routes.spec.ts
@@ -3,6 +3,7 @@ import { SOURCE_LOCALE, SUPPORTED_LOCALES } from '@kraak/domain';
 import {
   LOCALIZED_PUBLIC_LOCALES,
   LOCALIZED_PUBLIC_PAGES,
+  buildLocalizedPublicLocalePath,
   findLocalizedPublicRouteEntry,
   findLocalizedPublicRouteEntryByPath,
   findLocalizedPublicRouteEntryByLegacyPath,
@@ -126,6 +127,47 @@ describe('Given the localized public route model', () => {
     expect(
       findLocalizedPublicRouteEntryByLegacyPath('/contact', 'en-GB')?.path,
     ).toBe('/en/contact');
+  });
+
+  describe('Given a requested public locale switch', () => {
+    it('Given a localized page with query and fragment, When English is requested, Then the equivalent English page preserves both suffixes', () => {
+      expect(
+        buildLocalizedPublicLocalePath(
+          '/fr/programmes?campaign=summer#offres',
+          'en-GB',
+        ),
+      ).toBe('/en/programs?campaign=summer#offres');
+    });
+
+    it('Given an English page with a translated slug, When French is requested, Then the equivalent French slug is returned', () => {
+      expect(buildLocalizedPublicLocalePath('/en/about', 'fr-CI')).toBe(
+        '/fr/a-propos',
+      );
+    });
+
+    it.each([
+      ['/fr/inconnu?stale=1#old', 'en-GB', '/en/'],
+      ['/participant/dashboard?stale=1#old', 'fr-CI', '/fr/'],
+    ] as const)(
+      'Given an unmapped path %s, When %s is requested, Then the target homepage is returned without stale suffixes',
+      (currentUrl, targetLocale, expectedPath) => {
+        expect(buildLocalizedPublicLocalePath(currentUrl, targetLocale)).toBe(
+          expectedPath,
+        );
+      },
+    );
+
+    it.each([
+      ['/fr/', 'en-GB', '/en/'],
+      ['/en/', 'fr-CI', '/fr/'],
+    ] as const)(
+      'Given a localized homepage %s, When %s is requested, Then the target homepage keeps its trailing slash',
+      (currentUrl, targetLocale, expectedPath) => {
+        expect(buildLocalizedPublicLocalePath(currentUrl, targetLocale)).toBe(
+          expectedPath,
+        );
+      },
+    );
   });
 
   it('Given prerender paths, when the route set is generated, then every localized public path is present once', () => {

--- a/apps/client/projects/web/src/app/routing/localized-public-routes.ts
+++ b/apps/client/projects/web/src/app/routing/localized-public-routes.ts
@@ -167,6 +167,20 @@ export function findLocalizedPublicRouteEntryByPath(
   );
 }
 
+export function buildLocalizedPublicLocalePath(
+  currentUrl: string,
+  targetLocaleCandidate: string | null | undefined,
+): string {
+  const { path, suffix } = splitPublicUrl(currentUrl);
+  const currentEntry = findLocalizedPublicRouteEntryByPath(path);
+  const targetEntry = findLocalizedPublicRouteEntry(
+    currentEntry?.pageId ?? 'home',
+    targetLocaleCandidate,
+  );
+
+  return currentEntry ? `${targetEntry.path}${suffix}` : targetEntry.path;
+}
+
 export function findLegacyPublicRedirectBySourcePath(
   path: string,
 ): PublicRedirectRule | undefined {
@@ -278,4 +292,22 @@ function trimSlashes(value: string): string {
   }
 
   return value.slice(start, end);
+}
+
+function splitPublicUrl(url: string): {
+  readonly path: string;
+  readonly suffix: string;
+} {
+  const fragmentIndex = url.indexOf('#');
+  const fragment = fragmentIndex >= 0 ? url.slice(fragmentIndex) : '';
+  const pathAndQuery = fragmentIndex >= 0 ? url.slice(0, fragmentIndex) : url;
+  const queryIndex = pathAndQuery.indexOf('?');
+  const query = queryIndex >= 0 ? pathAndQuery.slice(queryIndex) : '';
+  const path =
+    queryIndex >= 0 ? pathAndQuery.slice(0, queryIndex) : pathAndQuery;
+
+  return {
+    path: path || '/',
+    suffix: `${query}${fragment}`,
+  };
 }

--- a/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.html
+++ b/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.html
@@ -5,7 +5,7 @@
     <img
       class="relative z-0 h-full w-full object-cover"
       [src]="backgroundImageUrl"
-      alt="Arrière-plan de la section questions fréquentes"
+      [alt]="backgroundAlt"
       loading="lazy"
       decoding="async"
       fetchpriority="low"
@@ -18,11 +18,10 @@
       <h2
         class="text-brand-white text-3xl leading-tight font-semibold lg:text-4xl"
       >
-        Questions fréquentes
+        {{ heading }}
       </h2>
       <p class="text-brand-white/80 text-base leading-relaxed">
-        Retrouvez ici les réponses rapides aux questions les plus posées sur nos
-        parcours, nos modalités d'accompagnement et nos délais de réponse.
+        {{ description }}
       </p>
     </div>
 

--- a/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.spec.ts
@@ -50,6 +50,28 @@ describe('FaqAccordion', () => {
     expect(answers).toHaveLength(SAMPLE_ITEMS.length);
   });
 
+  it('Given des libellés localisés, When le composant est rendu, Then le titre, la description et le texte alternatif utilisent les entrées fournies', () => {
+    const fixture = TestBed.createComponent(FaqAccordion);
+    fixture.componentRef.setInput('items', SAMPLE_ITEMS);
+    fixture.componentRef.setInput('heading', 'Frequently asked questions');
+    fixture.componentRef.setInput(
+      'description',
+      'Answers to common questions.',
+    );
+    fixture.componentRef.setInput('backgroundAlt', 'Advisory conversation');
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+
+    expect(host.querySelector('h2')?.textContent).toContain(
+      'Frequently asked questions',
+    );
+    expect(host.textContent).toContain('Answers to common questions.');
+    expect(host.querySelector('img')?.getAttribute('alt')).toBe(
+      'Advisory conversation',
+    );
+  });
+
   it('Given une liste d items, When une question est ouverte, Then la réponse devient visible', async () => {
     const fixture = TestBed.createComponent(FaqAccordion);
     fixture.componentRef.setInput('items', SAMPLE_ITEMS);

--- a/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.ts
+++ b/apps/client/projects/web/src/app/shared/faq-accordion/faq-accordion.component.ts
@@ -8,8 +8,8 @@ import {
 import { FAQ_BACKGROUND_IMAGE_URL } from '../brand/brand-constants';
 
 export interface FaqItem {
-  question: string;
-  answer: string;
+  readonly question: string;
+  readonly answer: string;
 }
 
 @Component({
@@ -38,7 +38,11 @@ export interface FaqItem {
   encapsulation: ViewEncapsulation.None,
 })
 export class FaqAccordion {
-  @Input({ required: true }) items: FaqItem[] = [];
+  @Input({ required: true }) items: readonly FaqItem[] = [];
+  @Input() heading = 'Questions fréquentes';
+  @Input() description =
+    "Retrouvez ici les réponses rapides aux questions les plus posées sur nos parcours, nos modalités d'accompagnement et nos délais de réponse.";
+  @Input() backgroundAlt = 'Arrière-plan de la section questions fréquentes';
 
   protected readonly backgroundImageUrl = FAQ_BACKGROUND_IMAGE_URL;
 }

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.html
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.html
@@ -3,10 +3,10 @@
 @if (participantAreaEnabled) {
   <a
     routerLink="/participant/dashboard"
-    aria-label="Espace participant"
+    [attr.aria-label]="'web.nav.participantArea' | kraakTranslate"
     class="bg-brand-blue text-brand-white hover:bg-brand-navy-soft inline-flex items-center justify-center rounded-(--kr-radius-btn) border border-transparent px-5 py-2.5 text-sm font-semibold shadow-[0_18px_35px_rgb(18_43_74/16%)] transition-all hover:-translate-y-px"
     (click)="notifyActivated()"
   >
-    Espace participant
+    {{ 'web.nav.participantArea' | kraakTranslate }}
   </a>
 }

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.spec.ts
@@ -1,11 +1,12 @@
 // apps\client\projects\web\src\app\shared\participant-nav-cta\participant-nav-cta-link.component.spec.ts
 
-import { Component } from '@angular/core';
+import { ApplicationInitStatus, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { environment } from '../../../environments/environment';
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
 import { ParticipantNavCtaLink } from './participant-nav-cta-link.component';
 
 @Component({
@@ -18,6 +19,7 @@ async function compile(): Promise<void> {
   await TestBed.configureTestingModule({
     imports: [ParticipantNavCtaLink],
     providers: [
+      provideKraakI18n(),
       provideRouter([
         {
           path: 'participant',
@@ -31,6 +33,8 @@ async function compile(): Promise<void> {
       ]),
     ],
   }).compileComponents();
+
+  await TestBed.inject(ApplicationInitStatus).donePromise;
 }
 
 describe('ParticipantNavCtaLink', () => {
@@ -46,7 +50,9 @@ describe('ParticipantNavCtaLink', () => {
       await compile();
     });
 
-    it('When the CTA renders Then it exposes the participant dashboard link', () => {
+    it('When the CTA renders in French Then it exposes the localized participant dashboard link', async () => {
+      await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
       const fixture = TestBed.createComponent(ParticipantNavCtaLink);
       fixture.detectChanges();
 
@@ -56,6 +62,23 @@ describe('ParticipantNavCtaLink', () => {
 
       expect(participantCta).toBeTruthy();
       expect(participantCta?.textContent).toContain('Espace participant');
+      expect(participantCta?.getAttribute('href')).toBe(
+        '/participant/dashboard',
+      );
+    });
+
+    it('When the CTA renders in English Then it exposes the localized participant dashboard link', async () => {
+      await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+      const fixture = TestBed.createComponent(ParticipantNavCtaLink);
+      fixture.detectChanges();
+
+      const participantCta = (
+        fixture.nativeElement as HTMLElement
+      ).querySelector<HTMLAnchorElement>('a[aria-label="Participant area"]');
+
+      expect(participantCta).toBeTruthy();
+      expect(participantCta?.textContent?.trim()).toBe('Participant area');
       expect(participantCta?.getAttribute('href')).toBe(
         '/participant/dashboard',
       );

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta-link.component.ts
@@ -3,12 +3,13 @@
 import { Component, output } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
+import { KraakTranslatePipe } from '../../../../../shared/i18n';
 import { isParticipantAreaEnabled } from '../../core/runtime/runtime-config';
 
 @Component({
   selector: 'kraak-participant-nav-cta-link',
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, KraakTranslatePipe],
   templateUrl: './participant-nav-cta-link.component.html',
 })
 export class ParticipantNavCtaLink {

--- a/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/participant-nav-cta/participant-nav-cta.component.spec.ts
@@ -1,9 +1,10 @@
 // apps\client\projects\web\src\app\shared\participant-nav-cta\participant-nav-cta.component.spec.ts
 
-import { Component } from '@angular/core';
+import { ApplicationInitStatus, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
+import { provideKraakI18n } from '../../../../../shared/i18n';
 import { ParticipantNavCta } from './participant-nav-cta.component';
 
 @Component({
@@ -16,6 +17,7 @@ async function compile(): Promise<void> {
   await TestBed.configureTestingModule({
     imports: [ParticipantNavCta],
     providers: [
+      provideKraakI18n(),
       provideRouter([
         {
           path: 'participant',
@@ -29,6 +31,8 @@ async function compile(): Promise<void> {
       ]),
     ],
   }).compileComponents();
+
+  await TestBed.inject(ApplicationInitStatus).donePromise;
 }
 
 describe('ParticipantNavCta', () => {

--- a/apps/client/tests/e2e/i18n-public.spec.ts
+++ b/apps/client/tests/e2e/i18n-public.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const FRENCH_NAVIGATION_LABELS = [
+  'ACCUEIL',
+  'SERVICES',
+  'PROGRAMMES',
+  'À PROPOS',
+  'CONTACT',
+];
+
+const ENGLISH_NAVIGATION_LABELS = [
+  'HOME',
+  'SERVICES',
+  'PROGRAMMES',
+  'ABOUT',
+  'CONTACT',
+];
+
+function getLanguageSelector(page: Page, accessibleName: RegExp) {
+  return page.getByRole('group', { name: accessibleName });
+}
+
+async function expectNavigationLabels(
+  page: Page,
+  expectedLabels: readonly string[],
+): Promise<void> {
+  await expect(page.getByRole('banner').locator('a.kr-nav-link')).toHaveText(
+    expectedLabels,
+  );
+}
+
+test.describe('Internationalisation publique de la page d’accueil', () => {
+  test('Given la route /fr/, When la page d’accueil se charge, Then le hero, la navbar et la langue du document sont en français', async ({
+    page,
+  }) => {
+    await page.goto('/fr/', { waitUntil: 'domcontentloaded' });
+
+    const heroHeading = page.getByRole('heading', { level: 1 }).first();
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
+    await expect(heroHeading).toContainText('Développez vos compétences.');
+    await expect(heroHeading).toContainText('Lancez vos projets.');
+    await expect(heroHeading).toContainText(
+      'Accédez aux opportunités internationales.',
+    );
+    await expectNavigationLabels(page, FRENCH_NAVIGATION_LABELS);
+    await expect(page.locator('body')).not.toContainText('[missing:web.');
+  });
+
+  test('Given la route /en/, When la page d’accueil se charge, Then le hero, la navbar et la langue du document sont en anglais', async ({
+    page,
+  }) => {
+    await page.goto('/en/', { waitUntil: 'domcontentloaded' });
+
+    const heroHeading = page.getByRole('heading', { level: 1 }).first();
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(heroHeading).toContainText('Build your skills.');
+    await expect(heroHeading).toContainText('Launch your projects.');
+    await expect(heroHeading).toContainText(
+      'Access international opportunities.',
+    );
+    await expectNavigationLabels(page, ENGLISH_NAVIGATION_LABELS);
+    await expect(page.locator('body')).not.toContainText('[missing:web.');
+  });
+
+  test('Given la page française, When le visiteur active au clavier le lien anglais du sélecteur de langue, Then la page anglaise devient active', async ({
+    page,
+  }) => {
+    await page.goto('/fr/', { waitUntil: 'domcontentloaded' });
+
+    const languageSelector = getLanguageSelector(page, /langue|language/i);
+    const englishLink = languageSelector.getByRole('link', {
+      name: /anglais|english/i,
+    });
+
+    await expect(languageSelector).toBeVisible();
+    await expect(englishLink).toHaveAttribute('hreflang', 'en-GB');
+    expect(await englishLink.getAttribute('lang')).toBeNull();
+    await expect(englishLink.locator('[lang="en-GB"]')).toHaveText('EN');
+
+    await englishLink.focus();
+    await expect(englishLink).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/en\/?$/);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(page.getByRole('heading', { level: 1 }).first()).toContainText(
+      'Build your skills.',
+    );
+  });
+
+  test('Given une largeur mobile, When le menu anglais est ouvert, Then les liens, le sélecteur et le CTA restent empilés dans la fenêtre', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/en/', { waitUntil: 'domcontentloaded' });
+
+    await page.getByRole('button', { name: 'Open navigation menu' }).click();
+
+    const header = page.getByRole('banner');
+    const navList = header.locator('ul').first();
+    const languageSelector = getLanguageSelector(page, /choose language/i);
+    const navListBox = await navList.boundingBox();
+    const languageBox = await languageSelector.boundingBox();
+
+    expect(navListBox).not.toBeNull();
+    expect(languageBox).not.toBeNull();
+    expect(languageBox!.y).toBeGreaterThanOrEqual(
+      navListBox!.y + navListBox!.height,
+    );
+    expect(languageBox!.x + languageBox!.width).toBeLessThanOrEqual(390);
+
+    const participantLink = header.getByRole('link', {
+      name: 'Participant area',
+    });
+    const participantBox = await participantLink.boundingBox();
+
+    await expect(participantLink).toBeVisible();
+    expect(participantBox).not.toBeNull();
+    expect(participantBox!.y).toBeGreaterThanOrEqual(
+      languageBox!.y + languageBox!.height,
+    );
+    expect(participantBox!.x + participantBox!.width).toBeLessThanOrEqual(390);
+  });
+
+  test('Given une page publique française avec query et fragment, When la langue change dans les deux sens, Then la page équivalente, la query et le fragment sont conservés', async ({
+    page,
+  }) => {
+    await page.goto('/fr/programmes?campaign=summer#offres', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const englishLink = getLanguageSelector(page, /langue|language/i).getByRole(
+      'link',
+      { name: /anglais|english/i },
+    );
+
+    await englishLink.click();
+    await expect(page).toHaveURL(/\/en\/programs\?campaign=summer#offres$/);
+
+    const frenchLink = getLanguageSelector(page, /langue|language/i).getByRole(
+      'link',
+      { name: /français|french/i },
+    );
+
+    await frenchLink.click();
+    await expect(page).toHaveURL(/\/fr\/programmes\?campaign=summer#offres$/);
+  });
+
+  test('Given une route française inconnue, When le visiteur choisit l’anglais, Then le sélecteur retombe sur la page d’accueil anglaise sans état obsolète', async ({
+    page,
+  }) => {
+    await page.goto('/fr/route-inconnue?campaign=summer#offres', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const englishLink = getLanguageSelector(page, /langue|language/i).getByRole(
+      'link',
+      { name: /anglais|english/i },
+    );
+
+    await englishLink.click();
+
+    await expect(page).toHaveURL(/\/en\/?$/);
+    await expect(page.getByRole('heading', { level: 1 }).first()).toContainText(
+      'Build your skills.',
+    );
+  });
+});

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -1,7 +1,7 @@
 ---
 status: active
 owner: platform
-last_reviewed: 2026-07-23
+last_reviewed: 2026-08-16
 source_of_truth: true
 ---
 
@@ -30,14 +30,18 @@ Le site web KRAAK est l'application Angular publique située dans
   `/fr/faq`, `/fr/programmes`, `/fr/ressources`, `/fr/contact`, pages légales
   et pages d'erreur sous `/fr/...`.
 - Internationalisation : `fr-CI` est la locale source et de repli, `en-GB` est
-  la première locale anglaise cible selon ARC-19. Les routes `/en/...` existent
-  comme scaffold technique non indexable tant que les contenus anglais relus ne
-  sont pas fournis.
+  la première locale anglaise selon ARC-19. La page d'accueil `/fr/` ou `/en/`
+  et la barre de navigation forment le premier incrément public bilingue. Les
+  autres pages `/en/...` restent un scaffold technique non indexable tant que
+  leurs contenus anglais ne sont pas traduits et relus.
 
 ## Implémentation active
 
 - Routes publiques : [`../../apps/client/projects/web/src/app/app.routes.ts`](../../apps/client/projects/web/src/app/app.routes.ts).
 - Prerender public : [`../../apps/client/projects/web/src/app/app.routes.server.ts`](../../apps/client/projects/web/src/app/app.routes.server.ts).
+- Catalogues runtime : [`../../apps/client/projects/shared/i18n/catalogs/`](../../apps/client/projects/shared/i18n/catalogs/),
+  avec les espaces de clés `web.home` et `web.nav` pour le premier incrément
+  public bilingue.
 - Tests de surface : [`../../apps/client/projects/web/src/app/app.routes.spec.ts`](../../apps/client/projects/web/src/app/app.routes.spec.ts)
   et [`../../apps/client/projects/web/src/app/app.routes.server.spec.ts`](../../apps/client/projects/web/src/app/app.routes.server.spec.ts).
 - Historique design : [`../archive/vitrine-design/`](../archive/vitrine-design/),
@@ -54,11 +58,18 @@ Le prerender, les métadonnées SEO, les canonicals, les liens `hreflang`, les
 entrées sitemap et l'attribut `<html lang>` sont générés par locale depuis le
 modèle de routes web localisées.
 
-Pour le scaffold PR3, les routes anglaises sont pré-rendues mais restent
-`noindex, nofollow`, exclues du sitemap de production et non annoncées en
-`hreflang="en-GB"` depuis les pages françaises indexables. `x-default` pointe
-vers la route française correspondante jusqu'à la revue des contenus anglais en
-PR4.
+La page d'accueil et la barre de navigation servent désormais leur contenu
+français ou anglais depuis les catalogues selon la locale de l'URL. Un sélecteur
+de langue relie les variantes d'une même page publique lorsque le mapping
+existe, puis revient à la page d'accueil de la langue cible lorsqu'aucune
+variante publique n'est disponible.
+
+Cette première tranche de contenu ne modifie pas encore la politique SEO du
+scaffold anglais : les routes anglaises restent `noindex, nofollow`, exclues du
+sitemap de production et non annoncées en `hreflang="en-GB"` depuis les pages
+françaises indexables. Leurs métadonnées anglaises restent temporaires jusqu'à
+une traduction et une revue SEO dédiées. `x-default` continue de pointer vers la
+route française correspondante.
 
 Les routes d'authentification technique, notamment les callbacks et liens de
 réinitialisation, restent compatibles avec Supabase Auth avant toute localisation


### PR DESCRIPTION
## Résumé

- sert la page d’accueil et la barre de navigation depuis les catalogues `fr-CI` et `en-GB` sur `/fr/` et `/en/` ;
- ajoute un sélecteur de langue accessible qui conserve la page publique, les paramètres de requête et le fragment lorsque le mapping existe, avec repli vers l’accueil cible ;
- localise le CTA participant et le panneau FAQ intégrés à cette tranche ;
- documente la première tranche publique bilingue tout en conservant les autres pages anglaises dans le scaffold non indexable.

## Validation

- `pnpm i18n:check`
- `pnpm --filter @kraak/client test:web` — 664 tests réussis
- `pnpm typecheck:web`
- lint ciblé sans avertissement
- `pnpm format:check`
- `pnpm build:web` — 26 routes pré-rendues
- Playwright ciblé Chromium, Firefox et WebKit — 18 scénarios réussis
- hook de pre-push : web 664/664, mobile 253/253, intégration API 31/31

Closes #638