### PR TITLE
feat(web): localiser la coque publique partagée

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,9 +59,14 @@ Les locales applicatives retenues sont :
 
 Les routes publiques localisées et l'adaptateur runtime partagé sont actifs. La
 page d'accueil et la barre de navigation constituent le premier incrément public
-entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. Les autres
-pages publiques anglaises et leurs métadonnées SEO restent dans l'état de
-scaffold non indexable jusqu'à leur traduction et leur revue dédiées.
+entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. La coque
+publique partagée constitue le deuxième incrément. Les pages de conversion
+seront ensuite localisées dans des PR distinctes, dans l'ordre Contact, Services,
+Programmes, puis À propos. Les autres pages publiques anglaises et leurs
+métadonnées SEO restent dans l'état de scaffold non indexable jusqu'à leur
+traduction et leur revue humaine dédiées. L'indexation anglaise, les entrées
+sitemap et les liens `hreflang` réciproques ne sont activés qu'après cette revue
+pour chaque page.
 
 Les incréments suivants doivent rester courts, documentés et validés sans
 localiser implicitement les routes privées, admin ou mobiles.

--- a/apps/client/projects/shared/i18n/catalogs/en-GB.json
+++ b/apps/client/projects/shared/i18n/catalogs/en-GB.json
@@ -34,6 +34,46 @@
       },
       "participantArea": "Participant area"
     },
+    "shell": {
+      "skipToMainContent": "Skip to main content",
+      "scrollToTopLabel": "Back to top",
+      "footer": {
+        "cta": {
+          "title": "Ready to take action?",
+          "description": "Join the KRAAK ecosystem and take your ambitions further.",
+          "label": "Contact us"
+        },
+        "brand": {
+          "homeLabel": "Back to the KRAAK homepage",
+          "symbolAlt": "KRAAK symbol",
+          "description": "Operational excellence in service of human development. Strategic expertise in Africa and international support."
+        },
+        "socialNavigationLabel": "Social media",
+        "sections": {
+          "navigation": "Navigation",
+          "expertise": "Expertise",
+          "offices": "Offices"
+        },
+        "navigationLinks": {
+          "home": "Home",
+          "services": "Services",
+          "programs": "Programmes",
+          "about": "About",
+          "contact": "Contact"
+        },
+        "expertiseItems": {
+          "professionalTraining": "Professional training",
+          "projectManagement": "Project management",
+          "internationalMobility": "International mobility"
+        },
+        "policyLinks": {
+          "legalNotice": "Legal notice",
+          "faq": "FAQ",
+          "privacyPolicy": "Privacy policy"
+        },
+        "copyright": "© {{ year }} KRAAK. All rights reserved."
+      }
+    },
     "home": {
       "hero": {
         "titleSkills": "Build your skills.",

--- a/apps/client/projects/shared/i18n/catalogs/fr-CI.json
+++ b/apps/client/projects/shared/i18n/catalogs/fr-CI.json
@@ -34,6 +34,46 @@
       },
       "participantArea": "Espace participant"
     },
+    "shell": {
+      "skipToMainContent": "Aller au contenu principal",
+      "scrollToTopLabel": "Remonter vers le haut de la page",
+      "footer": {
+        "cta": {
+          "title": "Prêt à passer à l'action ?",
+          "description": "Rejoignez l'écosystème KRAAK et propulsez vos ambitions.",
+          "label": "Nous contacter"
+        },
+        "brand": {
+          "homeLabel": "Retour à l'accueil KRAAK",
+          "symbolAlt": "Symbole KRAAK",
+          "description": "L'excellence opérationnelle au service du développement humain. Expertise stratégique en Afrique et accompagnement international."
+        },
+        "socialNavigationLabel": "Réseaux sociaux",
+        "sections": {
+          "navigation": "Navigation",
+          "expertise": "Expertises",
+          "offices": "Bureaux"
+        },
+        "navigationLinks": {
+          "home": "Accueil",
+          "services": "Services",
+          "programs": "Programmes",
+          "about": "À propos",
+          "contact": "Contact"
+        },
+        "expertiseItems": {
+          "professionalTraining": "Formation professionnelle",
+          "projectManagement": "Pilotage de projets",
+          "internationalMobility": "Mobilité internationale"
+        },
+        "policyLinks": {
+          "legalNotice": "Mentions légales",
+          "faq": "FAQ",
+          "privacyPolicy": "Politique de confidentialité"
+        },
+        "copyright": "© {{ year }} KRAAK. Tous droits réservés."
+      }
+    },
     "home": {
       "hero": {
         "titleSkills": "Développez vos compétences.",

--- a/apps/client/projects/web/src/app/app.component.html
+++ b/apps/client/projects/web/src/app/app.component.html
@@ -1,4 +1,6 @@
-<a href="#main-content" class="kr-skip-link">Aller au contenu principal</a>
+<a href="#main-content" class="kr-skip-link" (click)="focusMainContent($event)">
+  {{ 'web.shell.skipToMainContent' | kraakTranslate }}
+</a>
 <kraak-navbar />
 <main id="main-content" tabindex="-1" class="min-h-dvh">
   <router-outlet />

--- a/apps/client/projects/web/src/app/app.component.spec.ts
+++ b/apps/client/projects/web/src/app/app.component.spec.ts
@@ -9,7 +9,7 @@ import {
 import { MessageService } from 'primeng/api';
 import { Subject } from 'rxjs';
 import { vi } from 'vitest';
-import { provideKraakI18n } from '../../../shared/i18n';
+import { KraakI18nService, provideKraakI18n } from '../../../shared/i18n';
 import { App } from './app.component';
 
 describe('App', () => {
@@ -44,13 +44,69 @@ describe('App', () => {
 
     const compiled = fixture.nativeElement as HTMLElement;
     const skipLink = compiled.querySelector(
-      'a[href="#main-content"]',
+      'a.kr-skip-link',
     ) as HTMLAnchorElement | null;
     const main = compiled.querySelector('main#main-content');
 
-    expect(skipLink?.textContent).toContain('contenu principal');
+    expect(skipLink).not.toBeNull();
+    expect(skipLink?.classList).toContain('kr-skip-link');
     expect(main).toBeTruthy();
     expect(main?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('Given the French public shell When it renders Then the skip link uses the French catalog copy', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const skipLink = fixture.nativeElement.querySelector(
+      'a.kr-skip-link',
+    ) as HTMLAnchorElement | null;
+
+    expect(skipLink?.textContent?.trim()).toBe('Aller au contenu principal');
+  });
+
+  it('Given the English public shell When it renders Then the skip link uses the English catalog copy', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const skipLink = fixture.nativeElement.querySelector(
+      'a.kr-skip-link',
+    ) as HTMLAnchorElement | null;
+
+    expect(skipLink?.textContent?.trim()).toBe('Skip to main content');
+  });
+
+  it('Given an English URL with a query and fragment When the skip link is activated Then it focuses main content without leaving the current page', () => {
+    const router = TestBed.inject(Router);
+    vi.spyOn(router, 'url', 'get').mockReturnValue(
+      '/en/?campaign=shell#previous',
+    );
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const skipLink = fixture.nativeElement.querySelector(
+      'a.kr-skip-link',
+    ) as HTMLAnchorElement | null;
+    const main = fixture.nativeElement.querySelector(
+      'main#main-content',
+    ) as HTMLElement | null;
+    const focusSpy = vi.spyOn(main as HTMLElement, 'focus');
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    skipLink?.dispatchEvent(clickEvent);
+
+    expect(skipLink?.getAttribute('href')).toBe('#main-content');
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(focusSpy).toHaveBeenCalledOnce();
+    expect(router.url).toBe('/en/?campaign=shell#previous');
   });
 
   it('Given un environnement SSR simulé, When ngOnInit est appelé, Then le composant retourne sans souscrire aux événements du routeur', () => {

--- a/apps/client/projects/web/src/app/app.component.ts
+++ b/apps/client/projects/web/src/app/app.component.ts
@@ -1,19 +1,34 @@
+import { DOCUMENT } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 import { Router, NavigationEnd, RouterOutlet } from '@angular/router';
 import { Toast } from 'primeng/toast';
 import { filter } from 'rxjs';
 
+import { KraakTranslatePipe } from '../../../shared/i18n';
 import { Footer } from './layouts/footer/footer.component';
 import { Navbar } from './layouts/navbar/navbar.component';
 import { ScrollToTop } from './shared/scroll-to-top/scroll-to-top.component';
 
 @Component({
   selector: 'kraak-root',
-  imports: [RouterOutlet, Navbar, Footer, Toast, ScrollToTop],
+  imports: [
+    RouterOutlet,
+    Navbar,
+    Footer,
+    Toast,
+    ScrollToTop,
+    KraakTranslatePipe,
+  ],
   templateUrl: './app.component.html',
 })
 export class App implements OnInit {
+  private readonly document = inject(DOCUMENT);
   private readonly router = inject(Router);
+
+  protected focusMainContent(event: Event): void {
+    event.preventDefault();
+    this.document.getElementById('main-content')?.focus();
+  }
 
   ngOnInit(): void {
     // Only set up scroll-to-top in browser environment (not during SSR)

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.html
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.html
@@ -6,24 +6,25 @@
       <h3
         class="text-brand-white text-3xl font-black tracking-tight md:text-4xl"
       >
-        Prêt à passer à l'action ?
+        {{ 'web.shell.footer.cta.title' | kraakTranslate }}
       </h3>
       <p class="mt-3 text-lg text-neutral-400">
-        Rejoignez l&apos;écosystème KRAAK et propulsez vos ambitions.
+        {{ 'web.shell.footer.cta.description' | kraakTranslate }}
       </p>
     </div>
 
+    @let footerCtaLabel = 'web.shell.footer.cta.label' | kraakTranslate;
     <a
       [routerLink]="'contact' | localizedPublicPath"
       kraakPublicConversion="footer_cta_click"
       [kraakPublicConversionPayload]="{
-        cta_label: 'Nous contacter',
+        cta_label: footerCtaLabel,
         cta_surface: 'footer_top_band',
         cta_path: 'contact' | localizedPublicPath,
       }"
       class="kr-footer-fade-left bg-brand-cyan shadow-brand-cyan/20 hover:bg-brand-white hover:shadow-brand-cyan/30 inline-flex items-center rounded-full px-10 py-4 text-sm font-black tracking-widest text-neutral-900 uppercase shadow-xl transition-all duration-300 hover:scale-[1.035] hover:shadow-2xl"
     >
-      Nous contacter
+      {{ footerCtaLabel }}
     </a>
   </div>
 
@@ -34,11 +35,11 @@
       <a
         [routerLink]="'home' | localizedPublicPath"
         class="group inline-flex items-center gap-3"
-        aria-label="Retour à l'accueil KRAAK"
+        [attr.aria-label]="'web.shell.footer.brand.homeLabel' | kraakTranslate"
       >
         <img
           src="/kraak-symbol.png"
-          alt="Symbole KRAAK"
+          [alt]="'web.shell.footer.brand.symbolAlt' | kraakTranslate"
           width="40"
           height="40"
           loading="lazy"
@@ -51,11 +52,15 @@
       </a>
 
       <p class="text-sm leading-relaxed text-neutral-500">
-        L'excellence opérationnelle au service du développement humain.
-        Expertise stratégique en Afrique et accompagnement international.
+        {{ 'web.shell.footer.brand.description' | kraakTranslate }}
       </p>
 
-      <nav class="flex gap-4" aria-label="R&eacute;seaux sociaux">
+      <nav
+        class="flex gap-4"
+        [attr.aria-label]="
+          'web.shell.footer.socialNavigationLabel' | kraakTranslate
+        "
+      >
         @for (social of socialLinks; track social.label) {
           <a
             [href]="social.href"
@@ -84,17 +89,17 @@
       <h4
         class="text-brand-white mb-8 text-xs font-black tracking-[0.3em] uppercase"
       >
-        Navigation
+        {{ 'web.shell.footer.sections.navigation' | kraakTranslate }}
       </h4>
       <ul class="space-y-4 text-sm font-medium">
-        @for (link of navigationLinks; track link.pageId + link.label) {
+        @for (link of navigationLinks; track link.pageId) {
           @let localizedPath = link.pageId | localizedPublicPath;
           <li>
             <a
               [routerLink]="localizedPath"
               class="hover:text-brand-cyan transition-all duration-200 hover:translate-x-px"
             >
-              {{ link.label }}
+              {{ link.labelKey | kraakTranslate }}
             </a>
           </li>
         }
@@ -105,11 +110,11 @@
       <h4
         class="text-brand-white mb-8 text-xs font-black tracking-[0.3em] uppercase"
       >
-        Expertises
+        {{ 'web.shell.footer.sections.expertise' | kraakTranslate }}
       </h4>
       <ul class="space-y-4 text-sm font-medium">
         @for (item of expertiseItems; track item) {
-          <li>{{ item }}</li>
+          <li>{{ item | kraakTranslate }}</li>
         }
       </ul>
     </div>
@@ -118,7 +123,7 @@
       <h4
         class="text-brand-white mb-8 text-xs font-black tracking-[0.3em] uppercase"
       >
-        Bureaux
+        {{ 'web.shell.footer.sections.offices' | kraakTranslate }}
       </h4>
       <ul class="space-y-5 text-sm font-medium">
         @for (item of officeItems; track item.label) {
@@ -153,18 +158,20 @@
       class="mx-auto grid max-w-7xl gap-4 px-6 py-8 text-[11px] font-bold tracking-[0.14em] text-neutral-600 uppercase md:grid-cols-[1fr_auto] md:items-center md:py-7 lg:py-8"
     >
       <p class="text-center md:text-left">
-        &copy; {{ currentYear }} KRAAK. Tous droits réservés.
+        {{
+          'web.shell.footer.copyright' | kraakTranslate: { year: currentYear }
+        }}
       </p>
       <div
         class="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 md:justify-end"
       >
-        @for (link of policyLinks; track link.pageId + link.label) {
+        @for (link of policyLinks; track link.pageId) {
           @let localizedPath = link.pageId | localizedPublicPath;
           <a
             [routerLink]="localizedPath"
             class="hover:text-brand-white transition-colors duration-200"
           >
-            {{ link.label }}
+            {{ link.labelKey | kraakTranslate }}
           </a>
         }
       </div>

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.spec.ts
@@ -1,7 +1,12 @@
+import { ApplicationInitStatus } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
+import { AnalyticsService } from '../../core/analytics/analytics.service';
+import { PublicConversionTrackingDirective } from '../../shared/analytics/public-conversion-tracking.directive';
 import { Footer } from './footer.component';
 
 interface FooterAnimationInternals {
@@ -9,12 +14,23 @@ interface FooterAnimationInternals {
   handleScroll: () => void;
 }
 
+const analyticsServiceMock = {
+  trackEvent: vi.fn(),
+} satisfies Pick<AnalyticsService, 'trackEvent'>;
+
 describe('Footer', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Footer],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        provideKraakI18n(),
+        { provide: AnalyticsService, useValue: analyticsServiceMock },
+      ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+    analyticsServiceMock.trackEvent.mockReset();
   });
 
   afterEach(() => {
@@ -117,5 +133,124 @@ describe('Footer', () => {
     expect(() => fixture.componentInstance.ngOnDestroy()).not.toThrow();
 
     windowGetterSpy.mockRestore();
+  });
+
+  it('Given the French public shell When the footer renders Then its content and accessible names use the French catalog copy', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue('/fr/');
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(Footer);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const content = (host.textContent ?? '').replace(/\s+/g, ' ').trim();
+    const brandLink = host.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Retour à l\'accueil KRAAK"]',
+    );
+    const socialNavigation = host.querySelector<HTMLElement>(
+      'nav[aria-label="Réseaux sociaux"]',
+    );
+
+    expect(content).toContain("Prêt à passer à l'action ?");
+    expect(content).toContain('Nous contacter');
+    expect(content).toContain('Formation professionnelle');
+    expect(content).toContain('Pilotage de projets');
+    expect(content).toContain('Mobilité internationale');
+    expect(content).toContain('Tous droits réservés.');
+    expect(content).toContain('Mentions légales');
+    expect(content).toContain('Politique de confidentialité');
+    expect(brandLink).not.toBeNull();
+    expect(host.querySelector('img[alt="Symbole KRAAK"]')).not.toBeNull();
+    expect(socialNavigation).not.toBeNull();
+  });
+
+  it('Given the English public shell When the footer renders Then all visitor-facing content and accessible names use the English catalog copy', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue('/en/');
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(Footer);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const content = (host.textContent ?? '').replace(/\s+/g, ' ').trim();
+    const footerLinks = Array.from(
+      host.querySelectorAll<HTMLAnchorElement>('footer a'),
+    );
+    const brandLink = host.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Back to the KRAAK homepage"]',
+    );
+    const socialNavigation = host.querySelector<HTMLElement>(
+      'nav[aria-label="Social media"]',
+    );
+
+    expect(content).toContain('Ready to take action?');
+    expect(content).toContain(
+      'Join the KRAAK ecosystem and take your ambitions further.',
+    );
+    expect(content).toContain('Contact us');
+    expect(content).toContain(
+      'Operational excellence in service of human development.',
+    );
+    expect(content).toContain('Professional training');
+    expect(content).toContain('Project management');
+    expect(content).toContain('International mobility');
+    expect(content).toContain('Offices');
+    expect(content).toContain('All rights reserved.');
+    expect(content).toContain('Legal notice');
+    expect(content).toContain('Privacy policy');
+    for (const label of [
+      'Home',
+      'Services',
+      'Programmes',
+      'About',
+      'Contact',
+    ]) {
+      expect(footerLinks.map((link) => link.textContent?.trim())).toContain(
+        label,
+      );
+    }
+    for (const label of ['Navigation', 'Expertise', 'Offices']) {
+      expect(content).toContain(label);
+    }
+    expect(footerLinks.map((link) => link.textContent?.trim())).toContain(
+      'FAQ',
+    );
+    expect(content).not.toContain("Prêt à passer à l'action ?");
+    expect(content).not.toContain('[missing:web.');
+    expect(brandLink).not.toBeNull();
+    expect(brandLink?.getAttribute('href')).toMatch(/^\/en\/?$/);
+    expect(host.querySelector('img[alt="KRAAK symbol"]')).not.toBeNull();
+    expect(socialNavigation).not.toBeNull();
+    expect(
+      footerLinks
+        .find((link) => link.textContent?.trim() === 'Contact us')
+        ?.getAttribute('href'),
+    ).toBe('/en/contact');
+  });
+
+  it('Given an English footer CTA When the visitor activates it Then analytics receives its localized label and path', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue('/en/');
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(Footer);
+    fixture.detectChanges();
+
+    const ctaTracking = fixture.debugElement
+      .queryAll(By.directive(PublicConversionTrackingDirective))
+      .map((debugElement) =>
+        debugElement.injector.get(PublicConversionTrackingDirective),
+      )
+      .find((tracking) => tracking.eventName === 'footer_cta_click');
+
+    ctaTracking?.trackClick();
+
+    expect(analyticsServiceMock.trackEvent).toHaveBeenCalledWith(
+      'footer_cta_click',
+      {
+        cta_label: 'Contact us',
+        cta_surface: 'footer_top_band',
+        cta_path: '/en/contact',
+      },
+    );
   });
 });

--- a/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
+++ b/apps/client/projects/web/src/app/layouts/footer/footer.component.ts
@@ -8,6 +8,10 @@ import {
 import { RouterLink } from '@angular/router';
 
 import {
+  KraakTranslatePipe,
+  type TranslationKey,
+} from '../../../../../shared/i18n';
+import {
   KRAAK_SOCIAL_LINKS,
   type SocialLink,
 } from '../../shared/brand/brand-constants';
@@ -16,7 +20,7 @@ import type { LocalizedPublicPageId } from '../../routing/localized-public-route
 import { PublicConversionTrackingDirective } from '../../shared/analytics/public-conversion-tracking.directive';
 
 interface FooterLink {
-  label: string;
+  labelKey: TranslationKey;
   pageId: LocalizedPublicPageId;
 }
 
@@ -33,6 +37,7 @@ interface FooterOfficeItem {
     RouterLink,
     PublicConversionTrackingDirective,
     LocalizedPublicPathPipe,
+    KraakTranslatePipe,
   ],
   templateUrl: './footer.component.html',
 })
@@ -44,18 +49,33 @@ export class Footer implements AfterViewInit, OnDestroy {
 
   protected readonly currentYear = new Date().getFullYear();
 
-  protected readonly navigationLinks: FooterLink[] = [
-    { label: 'Accueil', pageId: 'home' },
-    { label: 'Services', pageId: 'services' },
-    { label: 'Programmes', pageId: 'programs' },
-    { label: '\u00C0 propos', pageId: 'about' },
-    { label: 'Contact', pageId: 'contact' },
+  protected readonly navigationLinks: readonly FooterLink[] = [
+    {
+      labelKey: 'web.shell.footer.navigationLinks.home',
+      pageId: 'home',
+    },
+    {
+      labelKey: 'web.shell.footer.navigationLinks.services',
+      pageId: 'services',
+    },
+    {
+      labelKey: 'web.shell.footer.navigationLinks.programs',
+      pageId: 'programs',
+    },
+    {
+      labelKey: 'web.shell.footer.navigationLinks.about',
+      pageId: 'about',
+    },
+    {
+      labelKey: 'web.shell.footer.navigationLinks.contact',
+      pageId: 'contact',
+    },
   ];
 
-  protected readonly expertiseItems: readonly string[] = [
-    'Formation professionnelle',
-    'Pilotage de projets',
-    'Mobilité internationale',
+  protected readonly expertiseItems: readonly TranslationKey[] = [
+    'web.shell.footer.expertiseItems.professionalTraining',
+    'web.shell.footer.expertiseItems.projectManagement',
+    'web.shell.footer.expertiseItems.internationalMobility',
   ];
 
   protected readonly officeItems: readonly FooterOfficeItem[] = [
@@ -77,11 +97,14 @@ export class Footer implements AfterViewInit, OnDestroy {
 
   protected readonly socialLinks: readonly SocialLink[] = KRAAK_SOCIAL_LINKS;
 
-  protected readonly policyLinks: FooterLink[] = [
-    { label: 'Mentions l\u00E9gales', pageId: 'legalNotice' },
-    { label: 'FAQ', pageId: 'faq' },
+  protected readonly policyLinks: readonly FooterLink[] = [
     {
-      label: 'Politique de confidentialité',
+      labelKey: 'web.shell.footer.policyLinks.legalNotice',
+      pageId: 'legalNotice',
+    },
+    { labelKey: 'web.shell.footer.policyLinks.faq', pageId: 'faq' },
+    {
+      labelKey: 'web.shell.footer.policyLinks.privacyPolicy',
       pageId: 'privacyPolicy',
     },
   ];

--- a/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.component.html
+++ b/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.component.html
@@ -1,6 +1,8 @@
 <button
   (click)="scrollToTop()"
-  aria-label="Remonter vers le haut de la page"
+  [attr.aria-label]="'web.shell.scrollToTopLabel' | kraakTranslate"
+  [attr.aria-hidden]="isVisible ? null : true"
+  [attr.tabindex]="isVisible ? 0 : -1"
   class="fixed right-6 bottom-6 z-40 rounded-full bg-blue-600 text-white shadow-lg transition-all duration-300 hover:bg-blue-700"
   [class.opacity-0]="!isVisible"
   [class.pointer-events-none]="!isVisible"

--- a/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.component.spec.ts
+++ b/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.component.spec.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ApplicationInitStatus, DebugElement } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { DebugElement } from '@angular/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
 import { ScrollToTop } from './scroll-to-top.component';
 
 describe('ScrollToTop', () => {
@@ -11,7 +13,10 @@ describe('ScrollToTop', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ScrollToTop],
+      providers: [provideKraakI18n()],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
 
     fixture = TestBed.createComponent(ScrollToTop);
     component = fixture.componentInstance;
@@ -33,9 +38,24 @@ describe('ScrollToTop', () => {
       expect(button).toBeTruthy();
     });
 
-    it('Given the scroll button renders When accessibility attributes are inspected Then it should expose an aria label', () => {
+    it('Given the French public shell When the scroll control renders Then its accessible name uses the French catalog copy', async () => {
+      await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+      fixture.detectChanges();
+
       const button = debugElement.nativeElement.querySelector('button');
-      expect(button?.getAttribute('aria-label')).toBeTruthy();
+
+      expect(button?.getAttribute('aria-label')).toBe(
+        'Remonter vers le haut de la page',
+      );
+    });
+
+    it('Given the English public shell When the scroll control renders Then its accessible name uses the English catalog copy', async () => {
+      await TestBed.inject(KraakI18nService).setLocale('en-GB');
+      fixture.detectChanges();
+
+      const button = debugElement.nativeElement.querySelector('button');
+
+      expect(button?.getAttribute('aria-label')).toBe('Back to top');
     });
   });
 
@@ -44,6 +64,8 @@ describe('ScrollToTop', () => {
       const button = debugElement.nativeElement.querySelector('button');
       expect(button?.classList.contains('opacity-0')).toBe(true);
       expect(button?.classList.contains('pointer-events-none')).toBe(true);
+      expect(button?.getAttribute('tabindex')).toBe('-1');
+      expect(button?.getAttribute('aria-hidden')).toBe('true');
     });
   });
 
@@ -62,7 +84,7 @@ describe('ScrollToTop', () => {
       scrollToSpy.mockRestore();
     });
 
-    it('Given a non-browser environment, when scrollToTop is called, then it exits without scrolling', () => {
+    it('Given a non-browser environment When scrollToTop is called Then it exits without scrolling', () => {
       const scrollToSpy = vi.spyOn(globalThis, 'scrollTo');
       Object.defineProperty(component, 'isBrowser', {
         value: false,
@@ -94,8 +116,12 @@ describe('ScrollToTop', () => {
       });
 
       component.updateVisibility();
+      fixture.detectChanges();
 
       expect(component.isVisible).toBe(true);
+      const button = debugElement.nativeElement.querySelector('button');
+      expect(button?.getAttribute('tabindex')).toBe('0');
+      expect(button?.getAttribute('aria-hidden')).toBeNull();
     });
 
     it('Given the scroll position is before the threshold When visibility updates Then the button should be hidden', () => {
@@ -125,7 +151,7 @@ describe('ScrollToTop', () => {
       addEventListenerSpy.mockRestore();
     });
 
-    it('Given a non-browser environment, when ngOnInit runs, then no listener is attached', () => {
+    it('Given a non-browser environment When ngOnInit runs Then no listener is attached', () => {
       const addEventListenerSpy = vi.spyOn(globalThis, 'addEventListener');
       Object.defineProperty(component, 'isBrowser', {
         value: false,

--- a/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.component.ts
+++ b/apps/client/projects/web/src/app/shared/scroll-to-top/scroll-to-top.component.ts
@@ -7,10 +7,12 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { KraakTranslatePipe } from '../../../../../shared/i18n';
+
 @Component({
   selector: 'kraak-scroll-to-top',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, KraakTranslatePipe],
   templateUrl: './scroll-to-top.component.html',
 })
 export class ScrollToTop implements OnInit, OnDestroy {

--- a/apps/client/tests/e2e/i18n-public-shell.spec.ts
+++ b/apps/client/tests/e2e/i18n-public-shell.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Internationalisation de la coque publique', () => {
+  test('Given la route /fr/, When la coque publique se charge, Then le pied de page et les textes d’accessibilité globaux sont en français', async ({
+    page,
+  }) => {
+    await page.goto('/fr/', { waitUntil: 'domcontentloaded' });
+
+    const skipLink = page.locator('a.kr-skip-link');
+    const footer = page.getByRole('contentinfo');
+    const scrollControl = page.locator('kraak-scroll-to-top button');
+
+    await expect(skipLink).toHaveText('Aller au contenu principal');
+    await expect(scrollControl).toHaveAttribute(
+      'aria-label',
+      'Remonter vers le haut de la page',
+    );
+    await expect(
+      footer.getByRole('heading', {
+        name: "Prêt à passer à l'action ?",
+      }),
+    ).toBeVisible();
+    await expect(
+      footer.getByRole('link', { name: 'Nous contacter', exact: true }),
+    ).toHaveAttribute('href', '/fr/contact');
+    await expect(
+      footer.getByRole('link', { name: "Retour à l'accueil KRAAK" }),
+    ).toHaveAttribute('href', '/fr');
+    await expect(footer.getByAltText('Symbole KRAAK')).toBeAttached();
+    await expect(
+      footer.getByRole('navigation', { name: 'Réseaux sociaux' }),
+    ).toBeAttached();
+    await expect(footer).toContainText('Tous droits réservés.');
+    await expect(page.locator('body')).not.toContainText('[missing:web.');
+  });
+
+  test('Given la route /en/, When la coque publique se charge, Then le pied de page et les textes d’accessibilité globaux sont en anglais et utilisables au clavier', async ({
+    page,
+  }) => {
+    await page.goto('/en/', { waitUntil: 'domcontentloaded' });
+
+    const skipLink = page.locator('a.kr-skip-link');
+    const footer = page.getByRole('contentinfo');
+    const scrollControl = page.locator('kraak-scroll-to-top button');
+
+    await expect(skipLink).toHaveText('Skip to main content');
+    await expect(scrollControl).toHaveAttribute('tabindex', '-1');
+    await expect(scrollControl).toHaveAttribute('aria-hidden', 'true');
+    await skipLink.focus();
+    await expect(skipLink).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('main#main-content')).toBeFocused();
+    await expect(scrollControl).toHaveAttribute('aria-label', 'Back to top');
+    await expect(
+      footer.getByRole('heading', { name: 'Ready to take action?' }),
+    ).toBeVisible();
+    await expect(
+      footer.getByRole('link', { name: 'Contact us', exact: true }),
+    ).toHaveAttribute('href', '/en/contact');
+    await expect(
+      footer.getByRole('link', { name: 'Back to the KRAAK homepage' }),
+    ).toHaveAttribute('href', '/en');
+    await expect(footer.getByAltText('KRAAK symbol')).toBeAttached();
+    await expect(
+      footer.getByRole('navigation', { name: 'Social media' }),
+    ).toBeAttached();
+    await expect(footer).toContainText('Professional training');
+    await expect(footer).toContainText('Project management');
+    await expect(footer).toContainText('International mobility');
+    await expect(footer).toContainText('All rights reserved.');
+    await expect(footer).not.toContainText("Prêt à passer à l'action ?");
+    await expect(page.locator('body')).not.toContainText('[missing:web.');
+
+    await page.evaluate(() =>
+      globalThis.scrollTo(0, document.documentElement.scrollHeight),
+    );
+    await expect(scrollControl).toHaveAttribute('tabindex', '0');
+    await expect(scrollControl).not.toHaveAttribute('aria-hidden', 'true');
+    await scrollControl.focus();
+    await expect(scrollControl).toBeFocused();
+  });
+});

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -31,17 +31,19 @@ Le site web KRAAK est l'application Angular publique située dans
   et pages d'erreur sous `/fr/...`.
 - Internationalisation : `fr-CI` est la locale source et de repli, `en-GB` est
   la première locale anglaise selon ARC-19. La page d'accueil `/fr/` ou `/en/`
-  et la barre de navigation forment le premier incrément public bilingue. Les
-  autres pages `/en/...` restent un scaffold technique non indexable tant que
-  leurs contenus anglais ne sont pas traduits et relus.
+  et la barre de navigation forment le premier incrément public bilingue. La
+  coque publique partagée (pied de page, lien d'accès rapide et commande de
+  retour en haut) forme le deuxième incrément. Les autres pages `/en/...`
+  restent un scaffold technique non indexable tant que leurs contenus anglais
+  ne sont pas traduits et relus.
 
 ## Implémentation active
 
 - Routes publiques : [`../../apps/client/projects/web/src/app/app.routes.ts`](../../apps/client/projects/web/src/app/app.routes.ts).
 - Prerender public : [`../../apps/client/projects/web/src/app/app.routes.server.ts`](../../apps/client/projects/web/src/app/app.routes.server.ts).
 - Catalogues runtime : [`../../apps/client/projects/shared/i18n/catalogs/`](../../apps/client/projects/shared/i18n/catalogs/),
-  avec les espaces de clés `web.home` et `web.nav` pour le premier incrément
-  public bilingue.
+  avec les espaces de clés `web.home`, `web.nav` et `web.shell` pour les deux
+  premiers incréments publics bilingues.
 - Tests de surface : [`../../apps/client/projects/web/src/app/app.routes.spec.ts`](../../apps/client/projects/web/src/app/app.routes.spec.ts)
   et [`../../apps/client/projects/web/src/app/app.routes.server.spec.ts`](../../apps/client/projects/web/src/app/app.routes.server.spec.ts).
 - Historique design : [`../archive/vitrine-design/`](../archive/vitrine-design/),
@@ -58,18 +60,24 @@ Le prerender, les métadonnées SEO, les canonicals, les liens `hreflang`, les
 entrées sitemap et l'attribut `<html lang>` sont générés par locale depuis le
 modèle de routes web localisées.
 
-La page d'accueil et la barre de navigation servent désormais leur contenu
-français ou anglais depuis les catalogues selon la locale de l'URL. Un sélecteur
-de langue relie les variantes d'une même page publique lorsque le mapping
-existe, puis revient à la page d'accueil de la langue cible lorsqu'aucune
-variante publique n'est disponible.
+La page d'accueil, la barre de navigation et la coque publique partagée servent
+désormais leur contenu français ou anglais depuis les catalogues selon la locale
+de l'URL. Un sélecteur de langue relie les variantes d'une même page publique
+lorsque le mapping existe, puis revient à la page d'accueil de la langue cible
+lorsqu'aucune variante publique n'est disponible.
 
-Cette première tranche de contenu ne modifie pas encore la politique SEO du
-scaffold anglais : les routes anglaises restent `noindex, nofollow`, exclues du
-sitemap de production et non annoncées en `hreflang="en-GB"` depuis les pages
-françaises indexables. Leurs métadonnées anglaises restent temporaires jusqu'à
-une traduction et une revue SEO dédiées. `x-default` continue de pointer vers la
-route française correspondante.
+Les prochaines pages de conversion doivent être localisées séparément, avec une
+seule page par PR, dans cet ordre : Contact, Services, Programmes, puis À propos.
+L'activation de l'indexation anglaise, des entrées sitemap et des liens
+`hreflang` réciproques reste conditionnée à une revue humaine du contenu anglais
+de chaque page.
+
+Ces deux premières tranches de contenu ne modifient pas encore la politique SEO
+du scaffold anglais : les routes anglaises restent `noindex, nofollow`, exclues
+du sitemap de production et non annoncées en `hreflang="en-GB"` depuis les
+pages françaises indexables. Leurs métadonnées anglaises restent temporaires
+jusqu'à une traduction et une revue SEO dédiées. `x-default` continue de pointer
+vers la route française correspondante.
 
 Les routes d'authentification technique, notamment les callbacks et liens de
 réinitialisation, restent compatibles avec Supabase Auth avant toute localisation


### PR DESCRIPTION
## Résumé

- localise le pied de page, le lien d’accès rapide et le libellé de retour en haut via les catalogues `fr-CI` et `en-GB`
- préserve la page et la locale lors de l’activation du lien d’accès rapide
- retire la commande de retour en haut de l’arbre d’accessibilité tant qu’elle est masquée
- ajoute les tests composants Given/When/Then et les scénarios Playwright Chromium, Firefox et WebKit
- documente l’ordre Contact → Services → Programmes → À propos, une page par PR

## Validation

- `pnpm.cmd i18n:check` — 123 clés symétriques
- `pnpm.cmd typecheck:web`
- ESLint ciblé — 0 avertissement
- tests web — 81 fichiers, 671 tests
- tests mobile du pré-push — 29 fichiers, 253 tests
- intégration API du pré-push — 31 tests
- Playwright — 6 scénarios sur Chromium, Firefox et WebKit
- build web — 26 routes pré-rendues (avertissement de budget initial préexistant)

## Garde-fou SEO

Cette PR n’active ni indexation anglaise, ni entrée sitemap, ni `hreflang` anglais réciproque. Ces activations restent conditionnées à une revue humaine, page par page.

Closes #640