### PR TITLE
feat(web): localiser la page Contact

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,9 +60,10 @@ Les locales applicatives retenues sont :
 Les routes publiques localisées et l'adaptateur runtime partagé sont actifs. La
 page d'accueil et la barre de navigation constituent le premier incrément public
 entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. La coque
-publique partagée constitue le deuxième incrément. Les pages de conversion
-seront ensuite localisées dans des PR distinctes, dans l'ordre Contact, Services,
-Programmes, puis À propos. Les autres pages publiques anglaises et leurs
+publique partagée constitue le deuxième incrément et la page Contact le
+troisième. Les autres pages de conversion seront localisées dans des PR
+distinctes, dans l'ordre Services, Programmes, puis À propos. Les autres pages
+publiques anglaises et leurs
 métadonnées SEO restent dans l'état de scaffold non indexable jusqu'à leur
 traduction et leur revue humaine dédiées. L'indexation anglaise, les entrées
 sitemap et les liens `hreflang` réciproques ne sont activés qu'après cette revue

--- a/apps/client/projects/shared/i18n/catalogs/en-GB.json
+++ b/apps/client/projects/shared/i18n/catalogs/en-GB.json
@@ -205,6 +205,124 @@
         "titleLine2": "We know how to help you get there.",
         "cta": "Book an appointment now"
       }
+    },
+    "contact": {
+      "hero": {
+        "eyebrow": "Contact KRAAK",
+        "titleLead": "Tell us about your",
+        "titleEmphasis": "goal",
+        "description": "Would you like to take a course, structure a project, prepare for international mobility or discuss a partnership? The KRAAK team is here to guide you towards the support that best fits your needs.",
+        "primaryCta": "Send an enquiry",
+        "primaryCtaAriaLabel": "Go to the contact form",
+        "secondaryCta": "Explore our services"
+      },
+      "details": {
+        "ariaLabel": "KRAAK contact details",
+        "imageAlt": "A guidance meeting to clarify support needs",
+        "heading": "Give us the right information to guide you.",
+        "description": "Training, projects, leadership and international mobility: tell us your priority and we will come back to you with a clear action plan.",
+        "serviceArea": "Africa & worldwide",
+        "whatsappPrefix": "WhatsApp:",
+        "openWhatsApp": "Open WhatsApp",
+        "responseTime": "Response within 48 business hours",
+        "socialNavigationLabel": "KRAAK social media"
+      },
+      "form": {
+        "heading": "Send your enquiry",
+        "description": "Briefly describe your goal—training, project, immigration, partnership or another request. We will respond as soon as possible.",
+        "success": "Your message has been sent. We will get back to you as soon as possible.",
+        "genericError": "Something went wrong. Please try again later.",
+        "fallback": {
+          "heading": "Alternative contact options: you can continue your enquiry without the form.",
+          "emailLead": "Email us directly at",
+          "whatsappConnector": "or open",
+          "instruction": "Include the selected enquiry type so we can route it correctly."
+        },
+        "fields": {
+          "name": {
+            "label": "Full name",
+            "placeholder": "Your name",
+            "required": "Name is required.",
+            "minLength": "Name must be at least 2 characters long."
+          },
+          "email": {
+            "label": "Email address",
+            "placeholder": "your.email@example.com",
+            "required": "Email address is required.",
+            "invalid": "Enter a valid email address."
+          },
+          "subject": {
+            "label": "Goal",
+            "placeholder": "E.g. launch a project, find training or assess a profile",
+            "required": "Goal is required."
+          },
+          "country": {
+            "label": "Country",
+            "placeholder": "Your country of residence",
+            "required": "Country is required."
+          },
+          "serviceType": {
+            "label": "Service type",
+            "internalQueueLabel": "Internal queue",
+            "workflowLabel": "Workflow",
+            "responseWorkflowLabel": "Response workflow",
+            "fallbackWorkflowLabel": "Operational fallback"
+          },
+          "message": {
+            "label": "Message",
+            "placeholder": "Describe your needs, timeframe or the next decision you need to make...",
+            "required": "Message is required.",
+            "minLength": "Message must be at least 10 characters long."
+          }
+        },
+        "actions": {
+          "submit": "Send my enquiry",
+          "whatsapp": "Chat on WhatsApp"
+        },
+        "serviceOptions": {
+          "training": {
+            "label": "Training",
+            "responseWorkflow": "training guidance within 48 business hours",
+            "fallbackWorkflow": "direct email or WhatsApp"
+          },
+          "project": {
+            "label": "Project management",
+            "responseWorkflow": "project scoping within 48 business hours",
+            "fallbackWorkflow": "direct email or WhatsApp"
+          },
+          "immigration": {
+            "label": "Immigration advice",
+            "responseWorkflow": "mobility guidance without submitting sensitive documents",
+            "fallbackWorkflow": "WhatsApp or direct email"
+          },
+          "business": {
+            "label": "Business solutions",
+            "responseWorkflow": "organisation enquiry assessed within 48 business hours",
+            "fallbackWorkflow": "direct email"
+          },
+          "partnership": {
+            "label": "Partnership",
+            "responseWorkflow": "partnership enquiry assessed within 48 business hours",
+            "fallbackWorkflow": "direct email or WhatsApp"
+          },
+          "other": {
+            "label": "Other enquiry",
+            "responseWorkflow": "general triage and referral within 48 business hours",
+            "fallbackWorkflow": "direct email or WhatsApp"
+          }
+        }
+      },
+      "coordinates": {
+        "heading": "Our contact details",
+        "emailLabel": "Email",
+        "whatsappLabel": "WhatsApp",
+        "areaHeading": "Where we work",
+        "areaDescription": "Africa and worldwide — remote and in-person support."
+      },
+      "closing": {
+        "heading": "Let’s discuss your next step.",
+        "body": "Send your enquiry through the form or start a conversation directly on WhatsApp."
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/shared/i18n/catalogs/fr-CI.json
+++ b/apps/client/projects/shared/i18n/catalogs/fr-CI.json
@@ -205,6 +205,124 @@
         "titleLine2": "Nous savons comment vous y amener.",
         "cta": "Prendre rendez-vous maintenant"
       }
+    },
+    "contact": {
+      "hero": {
+        "eyebrow": "Contact KRAAK",
+        "titleLead": "Parlez-nous de votre",
+        "titleEmphasis": "objectif",
+        "description": "Vous souhaitez suivre une formation, structurer un projet, préparer une mobilité internationale ou discuter d'un partenariat ? L'équipe KRAAK est disponible pour vous orienter vers l'accompagnement le plus adapté.",
+        "primaryCta": "Envoyer une demande",
+        "primaryCtaAriaLabel": "Aller au formulaire de contact",
+        "secondaryCta": "Voir les services"
+      },
+      "details": {
+        "ariaLabel": "Informations de contact KRAAK",
+        "imageAlt": "Entretien d'orientation pour clarifier un besoin d'accompagnement",
+        "heading": "Donnez-nous les bons repères pour vous orienter.",
+        "description": "Formation, projets, leadership, mobilité internationale : décrivez votre priorité et nous revenons vers vous avec un plan d'action clair.",
+        "serviceArea": "Afrique & international",
+        "whatsappPrefix": "WhatsApp :",
+        "openWhatsApp": "Ouvrir WhatsApp",
+        "responseTime": "Réponse sous 48h ouvrées",
+        "socialNavigationLabel": "Réseaux sociaux KRAAK"
+      },
+      "form": {
+        "heading": "Envoyez votre demande",
+        "description": "Décrivez brièvement votre objectif : formation, projet, immigration, partenariat, ou autre demande. Nous vous répondrons dans les meilleurs délais.",
+        "success": "Votre message a bien été envoyé. Nous vous répondrons dans les plus brefs délais.",
+        "genericError": "Une erreur est survenue. Veuillez réessayer plus tard.",
+        "fallback": {
+          "heading": "Fallback opérationnel : votre demande peut continuer sans le formulaire.",
+          "emailLead": "Écrivez directement à",
+          "whatsappConnector": "ou ouvrez",
+          "instruction": "Indiquez le type de demande sélectionné pour garder le triage interne."
+        },
+        "fields": {
+          "name": {
+            "label": "Nom complet",
+            "placeholder": "Votre nom",
+            "required": "Le nom est requis.",
+            "minLength": "Le nom doit contenir au moins 2 caractères."
+          },
+          "email": {
+            "label": "Adresse e-mail",
+            "placeholder": "votre.email@exemple.com",
+            "required": "L'adresse e-mail est requise.",
+            "invalid": "Veuillez saisir une adresse e-mail valide."
+          },
+          "subject": {
+            "label": "Objectif",
+            "placeholder": "Ex. lancer un projet, trouver une formation, évaluer un profil",
+            "required": "L'objectif est requis."
+          },
+          "country": {
+            "label": "Pays",
+            "placeholder": "Votre pays de résidence",
+            "required": "Le pays est requis."
+          },
+          "serviceType": {
+            "label": "Type de service",
+            "internalQueueLabel": "File interne",
+            "workflowLabel": "Workflow",
+            "responseWorkflowLabel": "Workflow de réponse",
+            "fallbackWorkflowLabel": "Fallback opérationnel"
+          },
+          "message": {
+            "label": "Message",
+            "placeholder": "Décrivez votre besoin, votre calendrier ou la prochaine décision à prendre...",
+            "required": "Le message est requis.",
+            "minLength": "Le message doit contenir au moins 10 caractères."
+          }
+        },
+        "actions": {
+          "submit": "Envoyer ma demande",
+          "whatsapp": "Discuter sur WhatsApp"
+        },
+        "serviceOptions": {
+          "training": {
+            "label": "Formation",
+            "responseWorkflow": "orientation formation sous 48h ouvrées",
+            "fallbackWorkflow": "e-mail direct ou WhatsApp"
+          },
+          "project": {
+            "label": "Gestion de projets",
+            "responseWorkflow": "cadrage projet sous 48h ouvrées",
+            "fallbackWorkflow": "e-mail direct ou WhatsApp"
+          },
+          "immigration": {
+            "label": "Conseil en immigration",
+            "responseWorkflow": "orientation mobilité sans dépôt de dossier sensible",
+            "fallbackWorkflow": "WhatsApp ou e-mail direct"
+          },
+          "business": {
+            "label": "Solutions entreprises",
+            "responseWorkflow": "qualification organisation sous 48h ouvrées",
+            "fallbackWorkflow": "e-mail direct"
+          },
+          "partnership": {
+            "label": "Partenariat",
+            "responseWorkflow": "qualification partenariat sous 48h ouvrées",
+            "fallbackWorkflow": "e-mail direct ou WhatsApp"
+          },
+          "other": {
+            "label": "Autre demande",
+            "responseWorkflow": "triage général puis réorientation sous 48h ouvrées",
+            "fallbackWorkflow": "e-mail direct ou WhatsApp"
+          }
+        }
+      },
+      "coordinates": {
+        "heading": "Nos coordonnées",
+        "emailLabel": "E-mail",
+        "whatsappLabel": "WhatsApp",
+        "areaHeading": "Zone d'intervention",
+        "areaDescription": "Afrique & international — accompagnement à distance et en présentiel."
+      },
+      "closing": {
+        "heading": "Parlons de votre prochaine étape.",
+        "body": "Envoyez votre demande via le formulaire ou lancez directement un échange sur WhatsApp."
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/web/src/app/features/contact/contact.page.html
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.html
@@ -16,37 +16,43 @@
       <p
         class="text-brand-cyan text-[11px] font-semibold tracking-[0.26em] uppercase sm:text-xs"
       >
-        Contact KRAAK
+        {{ 'web.contact.hero.eyebrow' | kraakTranslate }}
       </p>
       <h1
         class="text-brand-white mt-3 text-4xl leading-[1.08] font-black sm:mt-4 sm:text-5xl lg:text-6xl lg:leading-[1.04]"
       >
-        Parlez-nous de votre <span class="text-brand-cyan">objectif</span>.
+        {{ 'web.contact.hero.titleLead' | kraakTranslate }}
+        <span class="text-brand-cyan">{{
+          'web.contact.hero.titleEmphasis' | kraakTranslate
+        }}</span
+        >.
       </h1>
       <p
         class="mt-6 max-w-2xl text-base leading-relaxed text-neutral-200 sm:mt-7 sm:text-lg lg:text-xl"
       >
-        Vous souhaitez suivre une formation, structurer un projet, préparer une
-        mobilité internationale ou discuter d'un partenariat ? L'équipe KRAAK
-        est disponible pour vous orienter vers l'accompagnement le plus adapté.
+        {{ 'web.contact.hero.description' | kraakTranslate }}
       </p>
       <div
         class="mt-8 flex flex-col items-stretch gap-3 sm:mt-9 sm:flex-row sm:items-center sm:gap-4"
       >
         <a
           pButton
-          href="#contact-form"
-          label="Envoyer une demande"
+          [routerLink]="[]"
+          fragment="contact-form"
+          queryParamsHandling="preserve"
+          [label]="'web.contact.hero.primaryCta' | kraakTranslate"
           icon="pi pi-send"
-          aria-label="Aller au formulaire de contact"
+          [attr.aria-label]="
+            'web.contact.hero.primaryCtaAriaLabel' | kraakTranslate
+          "
           class="kr-button-primary w-full justify-center rounded-2xl px-8 py-4 text-xs font-black tracking-widest uppercase sm:w-auto"
         ></a>
         <a
           pButton
           [routerLink]="'services' | localizedPublicPath"
-          label="Voir les services"
+          [label]="'web.contact.hero.secondaryCta' | kraakTranslate"
           icon="pi pi-compass"
-          aria-label="Voir les services"
+          [attr.aria-label]="'web.contact.hero.secondaryCta' | kraakTranslate"
           class="kr-button-ghost border-brand-white/20 bg-brand-white/10 w-full justify-center rounded-2xl px-8 py-4 text-xs font-black tracking-widest uppercase backdrop-blur-md sm:w-auto"
         ></a>
       </div>
@@ -67,11 +73,11 @@
       <div class="flex flex-col lg:min-h-184 lg:flex-row">
         <aside
           class="bg-brand-navy relative order-2 min-h-96 flex-1 lg:order-1 lg:min-h-full"
-          aria-label="Informations de contact KRAAK"
+          [attr.aria-label]="'web.contact.details.ariaLabel' | kraakTranslate"
         >
           <img
             [src]="contactVisualUrl"
-            alt="Entretien d'orientation pour clarifier un besoin d'accompagnement"
+            [alt]="'web.contact.details.imageAlt' | kraakTranslate"
             class="absolute inset-0 h-full w-full object-cover"
             loading="lazy"
             decoding="async"
@@ -89,17 +95,15 @@
               <p
                 class="text-brand-cyan text-xs font-semibold tracking-[0.18em] uppercase"
               >
-                Contact KRAAK
+                {{ 'web.contact.hero.eyebrow' | kraakTranslate }}
               </p>
               <h2
                 class="text-brand-white mt-3 text-3xl leading-tight font-bold lg:text-4xl"
               >
-                Donnez-nous les bons repères pour vous orienter.
+                {{ 'web.contact.details.heading' | kraakTranslate }}
               </h2>
               <p class="text-brand-white mt-4 text-sm leading-6">
-                Formation, projets, leadership, mobilité internationale :
-                décrivez votre priorité et nous revenons vers vous avec un plan
-                d'action clair.
+                {{ 'web.contact.details.description' | kraakTranslate }}
               </p>
             </div>
 
@@ -128,14 +132,18 @@
                     class="pi pi-map-marker text-brand-cyan"
                     aria-hidden="true"
                   ></i>
-                  <span>Afrique &amp; international</span>
+                  <span>{{
+                    'web.contact.details.serviceArea' | kraakTranslate
+                  }}</span>
                 </li>
                 <li class="flex items-center gap-3">
                   <i
                     class="pi pi-whatsapp text-brand-cyan"
                     aria-hidden="true"
                   ></i>
-                  <span>WhatsApp :</span>
+                  <span>{{
+                    'web.contact.details.whatsappPrefix' | kraakTranslate
+                  }}</span>
                   <a
                     [href]="contactPhoneHref"
                     class="hover:text-brand-cyan transition-colors"
@@ -154,19 +162,23 @@
                     }"
                     class="hover:text-brand-cyan transition-colors"
                   >
-                    Ouvrir WhatsApp
+                    {{ 'web.contact.details.openWhatsApp' | kraakTranslate }}
                   </a>
                 </li>
                 <li class="flex items-center gap-3">
                   <i class="pi pi-clock text-brand-cyan" aria-hidden="true"></i>
-                  <span>Réponse sous 48h ouvrées</span>
+                  <span>{{
+                    'web.contact.details.responseTime' | kraakTranslate
+                  }}</span>
                 </li>
               </ul>
             </address>
 
             <nav
               class="flex items-center gap-3"
-              aria-label="Réseaux sociaux KRAAK"
+              [attr.aria-label]="
+                'web.contact.details.socialNavigationLabel' | kraakTranslate
+              "
             >
               @for (social of socialLinks; track social.label) {
                 <a
@@ -201,19 +213,17 @@
             <h2
               class="text-brand-navy text-3xl leading-tight font-bold lg:text-4xl"
             >
-              Envoyez votre demande
+              {{ 'web.contact.form.heading' | kraakTranslate }}
             </h2>
             <p class="text-brand-navy text-base leading-relaxed">
-              Décrivez brièvement votre objectif : formation, projet,
-              immigration, partenariat, ou autre demande. Nous vous répondrons
-              dans les meilleurs délais.
+              {{ 'web.contact.form.description' | kraakTranslate }}
             </p>
           </div>
 
           @if (success()) {
             <p-message
               severity="success"
-              text="Votre message a bien été envoyé. Nous vous répondrons dans les plus brefs délais."
+              [text]="'web.contact.form.success' | kraakTranslate"
               [closable]="false"
               styleClass="w-full mb-6"
             ></p-message>
@@ -234,11 +244,12 @@
                     role="alert"
                   >
                     <p class="font-semibold">
-                      Fallback opérationnel : votre demande peut continuer sans
-                      le formulaire.
+                      {{ 'web.contact.form.fallback.heading' | kraakTranslate }}
                     </p>
                     <p class="mt-2">
-                      Écrivez directement à
+                      {{
+                        'web.contact.form.fallback.emailLead' | kraakTranslate
+                      }}
                       <a
                         [href]="contactEmailHref"
                         kraakPublicConversion="direct_email_click"
@@ -250,7 +261,10 @@
                         class="kr-link font-semibold"
                         >{{ contactEmail }}</a
                       >
-                      ou ouvrez
+                      {{
+                        'web.contact.form.fallback.whatsappConnector'
+                          | kraakTranslate
+                      }}
                       <a
                         [href]="whatsappLink"
                         target="_blank"
@@ -263,8 +277,10 @@
                         }"
                         class="kr-link font-semibold"
                         >WhatsApp</a
-                      >. Indiquez le type de demande sélectionné pour garder le
-                      triage interne.
+                      >.
+                      {{
+                        'web.contact.form.fallback.instruction' | kraakTranslate
+                      }}
                     </p>
                   </div>
                 }
@@ -283,14 +299,17 @@
                     for="name"
                     class="text-brand-navy mb-2 block text-sm font-semibold"
                   >
-                    Nom complet
+                    {{ 'web.contact.form.fields.name.label' | kraakTranslate }}
                     <span class="text-red-500" aria-hidden="true">*</span>
                   </label>
                   <input
                     pInputText
                     id="name"
                     type="text"
-                    placeholder="Votre nom"
+                    [placeholder]="
+                      'web.contact.form.fields.name.placeholder'
+                        | kraakTranslate
+                    "
                     formControlName="name"
                     class="border-brand-blue/20 bg-brand-white/95 text-brand-navy focus:border-brand-blue focus:bg-brand-white focus:ring-brand-cyan/25 h-12 w-full rounded-2xl border px-4 text-sm shadow-[0_8px_24px_rgb(18_43_74/8%)] transition duration-200 outline-none placeholder:text-neutral-600 focus:-translate-y-px focus:shadow-[0_14px_32px_rgb(18_43_74/14%)] focus:ring-4"
                     [ngClass]="{
@@ -310,9 +329,15 @@
                       role="alert"
                     >
                       @if (name.errors?.['required']) {
-                        Le nom est requis.
+                        {{
+                          'web.contact.form.fields.name.required'
+                            | kraakTranslate
+                        }}
                       } @else if (name.errors?.['minlength']) {
-                        Le nom doit contenir au moins 2 caractères.
+                        {{
+                          'web.contact.form.fields.name.minLength'
+                            | kraakTranslate
+                        }}
                       }
                     </p>
                   }
@@ -323,14 +348,17 @@
                     for="email"
                     class="text-brand-navy mb-2 block text-sm font-semibold"
                   >
-                    Adresse e-mail
+                    {{ 'web.contact.form.fields.email.label' | kraakTranslate }}
                     <span class="text-red-500" aria-hidden="true">*</span>
                   </label>
                   <input
                     pInputText
                     id="email"
                     type="email"
-                    placeholder="votre.email@exemple.com"
+                    [placeholder]="
+                      'web.contact.form.fields.email.placeholder'
+                        | kraakTranslate
+                    "
                     formControlName="email"
                     class="border-brand-blue/20 bg-brand-white/95 text-brand-navy focus:border-brand-blue focus:bg-brand-white focus:ring-brand-cyan/25 h-12 w-full rounded-2xl border px-4 text-sm shadow-[0_8px_24px_rgb(18_43_74/8%)] transition duration-200 outline-none placeholder:text-neutral-600 focus:-translate-y-px focus:shadow-[0_14px_32px_rgb(18_43_74/14%)] focus:ring-4"
                     [ngClass]="{
@@ -350,9 +378,15 @@
                       role="alert"
                     >
                       @if (email.errors?.['required']) {
-                        L'adresse e-mail est requise.
+                        {{
+                          'web.contact.form.fields.email.required'
+                            | kraakTranslate
+                        }}
                       } @else if (email.errors?.['email']) {
-                        Veuillez saisir une adresse e-mail valide.
+                        {{
+                          'web.contact.form.fields.email.invalid'
+                            | kraakTranslate
+                        }}
                       }
                     </p>
                   }
@@ -364,14 +398,17 @@
                   for="subject"
                   class="text-brand-navy mb-2 block text-sm font-semibold"
                 >
-                  Objectif
+                  {{ 'web.contact.form.fields.subject.label' | kraakTranslate }}
                   <span class="text-red-500" aria-hidden="true">*</span>
                 </label>
                 <input
                   pInputText
                   id="subject"
                   type="text"
-                  placeholder="Ex. lancer un projet, trouver une formation, &eacute;valuer un profil"
+                  [placeholder]="
+                    'web.contact.form.fields.subject.placeholder'
+                      | kraakTranslate
+                  "
                   formControlName="subject"
                   class="border-brand-blue/20 bg-brand-white/95 text-brand-navy focus:border-brand-blue focus:bg-brand-white focus:ring-brand-cyan/25 h-12 w-full rounded-2xl border px-4 text-sm shadow-[0_8px_24px_rgb(18_43_74/8%)] transition duration-200 outline-none placeholder:text-neutral-600 focus:-translate-y-px focus:shadow-[0_14px_32px_rgb(18_43_74/14%)] focus:ring-4"
                   [ngClass]="{
@@ -390,7 +427,10 @@
                     class="mt-1 text-sm text-red-600"
                     role="alert"
                   >
-                    L'objectif est requis.
+                    {{
+                      'web.contact.form.fields.subject.required'
+                        | kraakTranslate
+                    }}
                   </p>
                 }
               </div>
@@ -401,13 +441,19 @@
                     for="country"
                     class="text-brand-navy mb-2 block text-sm font-semibold"
                   >
-                    Pays <span class="text-red-500" aria-hidden="true">*</span>
+                    {{
+                      'web.contact.form.fields.country.label' | kraakTranslate
+                    }}
+                    <span class="text-red-500" aria-hidden="true">*</span>
                   </label>
                   <input
                     pInputText
                     id="country"
                     type="text"
-                    placeholder="Votre pays de résidence"
+                    [placeholder]="
+                      'web.contact.form.fields.country.placeholder'
+                        | kraakTranslate
+                    "
                     formControlName="country"
                     class="border-brand-blue/20 bg-brand-white/95 text-brand-navy focus:border-brand-blue focus:bg-brand-white focus:ring-brand-cyan/25 h-12 w-full rounded-2xl border px-4 text-sm shadow-[0_8px_24px_rgb(18_43_74/8%)] transition duration-200 outline-none placeholder:text-neutral-600 focus:-translate-y-px focus:shadow-[0_14px_32px_rgb(18_43_74/14%)] focus:ring-4"
                     [ngClass]="{
@@ -426,7 +472,10 @@
                       class="mt-1 text-sm text-red-600"
                       role="alert"
                     >
-                      Le pays est requis.
+                      {{
+                        'web.contact.form.fields.country.required'
+                          | kraakTranslate
+                      }}
                     </p>
                   }
                 </div>
@@ -436,7 +485,10 @@
                     for="serviceType"
                     class="text-brand-navy mb-2 block text-sm font-semibold"
                   >
-                    Type de service
+                    {{
+                      'web.contact.form.fields.serviceType.label'
+                        | kraakTranslate
+                    }}
                     <span class="text-red-500" aria-hidden="true">*</span>
                   </label>
                   <select
@@ -459,8 +511,15 @@
                     id="serviceType-help"
                     class="text-brand-navy mt-2 text-xs leading-5"
                   >
-                    File interne :
-                    {{ getSelectedServiceOption().triagePath }}. Workflow :
+                    {{
+                      'web.contact.form.fields.serviceType.internalQueueLabel'
+                        | kraakTranslate
+                    }}{{ helpLabelSeparator }}
+                    {{ getSelectedServiceOption().triagePath }}.
+                    {{
+                      'web.contact.form.fields.serviceType.workflowLabel'
+                        | kraakTranslate
+                    }}{{ helpLabelSeparator }}
                     {{ getSelectedServiceOption().responseWorkflow }}.
                   </p>
                 </div>
@@ -471,13 +530,17 @@
                   for="message"
                   class="text-brand-navy mb-2 block text-sm font-semibold"
                 >
-                  Message <span class="text-red-500" aria-hidden="true">*</span>
+                  {{ 'web.contact.form.fields.message.label' | kraakTranslate }}
+                  <span class="text-red-500" aria-hidden="true">*</span>
                 </label>
                 <textarea
                   pTextarea
                   id="message"
                   rows="6"
-                  placeholder="Décrivez votre besoin, votre calendrier ou la prochaine décision à prendre..."
+                  [placeholder]="
+                    'web.contact.form.fields.message.placeholder'
+                      | kraakTranslate
+                  "
                   formControlName="message"
                   class="border-brand-blue/20 bg-brand-white/95 text-brand-navy focus:border-brand-blue focus:bg-brand-white focus:ring-brand-cyan/25 min-h-36 w-full rounded-2xl border px-4 py-3 text-sm leading-relaxed shadow-[0_8px_24px_rgb(18_43_74/8%)] transition duration-200 outline-none placeholder:text-neutral-600 focus:-translate-y-px focus:shadow-[0_14px_32px_rgb(18_43_74/14%)] focus:ring-4"
                   [ngClass]="{
@@ -497,9 +560,15 @@
                     role="alert"
                   >
                     @if (message.errors?.['required']) {
-                      Le message est requis.
+                      {{
+                        'web.contact.form.fields.message.required'
+                          | kraakTranslate
+                      }}
                     } @else if (message.errors?.['minlength']) {
-                      Le message doit contenir au moins 10 caractères.
+                      {{
+                        'web.contact.form.fields.message.minLength'
+                          | kraakTranslate
+                      }}
                     }
                   </p>
                 }
@@ -508,9 +577,11 @@
               <div class="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center">
                 <p-button
                   type="submit"
-                  label="Envoyer ma demande"
+                  [label]="'web.contact.form.actions.submit' | kraakTranslate"
                   size="large"
-                  [ariaLabel]="'Envoyer ma demande'"
+                  [ariaLabel]="
+                    'web.contact.form.actions.submit' | kraakTranslate
+                  "
                   [loading]="loading()"
                   [disabled]="loading()"
                   class="kr-button-primary w-full sm:w-auto"
@@ -526,12 +597,13 @@
                     contact_surface: 'contact_form_secondary_cta',
                     link_url: whatsappLink,
                   }"
-                  label="Discuter sur WhatsApp"
-                  aria-label="Discuter sur WhatsApp"
+                  [label]="'web.contact.form.actions.whatsapp' | kraakTranslate"
+                  [attr.aria-label]="
+                    'web.contact.form.actions.whatsapp' | kraakTranslate
+                  "
                   icon="pi pi-whatsapp"
                   class="kr-button-secondary w-full sm:w-auto"
-                  >Discuter sur WhatsApp</a
-                >
+                ></a>
               </div>
             </form>
           }
@@ -543,11 +615,15 @@
 
 <section class="kr-perf-section bg-neutral-50 py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <h2 class="text-center text-3xl font-bold lg:text-4xl">Nos coordonnées</h2>
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      {{ 'web.contact.coordinates.heading' | kraakTranslate }}
+    </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-2">
       <div class="text-center">
         <i class="pi pi-envelope text-3xl" aria-hidden="true"></i>
-        <h3 class="mt-2 text-lg font-bold">E-mail</h3>
+        <h3 class="mt-2 text-lg font-bold">
+          {{ 'web.contact.coordinates.emailLabel' | kraakTranslate }}
+        </h3>
         <a
           [href]="contactEmailHref"
           kraakPublicConversion="direct_email_click"
@@ -563,7 +639,9 @@
       </div>
       <div class="text-center">
         <i class="pi pi-whatsapp text-3xl" aria-hidden="true"></i>
-        <h3 class="mt-2 text-lg font-bold">WhatsApp</h3>
+        <h3 class="mt-2 text-lg font-bold">
+          {{ 'web.contact.coordinates.whatsappLabel' | kraakTranslate }}
+        </h3>
         <a [href]="contactPhoneHref" class="kr-link mt-1 block">
           {{ contactPhone }}
         </a>
@@ -579,15 +657,16 @@
           }"
           class="kr-link mt-2 inline-block"
         >
-          Ouvrir WhatsApp
+          {{ 'web.contact.details.openWhatsApp' | kraakTranslate }}
         </a>
       </div>
       <div class="text-center md:col-span-2">
         <i class="pi pi-map-marker text-3xl" aria-hidden="true"></i>
-        <h3 class="mt-2 text-lg font-bold">Zone d'intervention</h3>
+        <h3 class="mt-2 text-lg font-bold">
+          {{ 'web.contact.coordinates.areaHeading' | kraakTranslate }}
+        </h3>
         <p class="mt-1 text-neutral-700">
-          Afrique &amp; international &mdash; accompagnement à distance et en
-          présentiel.
+          {{ 'web.contact.coordinates.areaDescription' | kraakTranslate }}
         </p>
       </div>
     </div>
@@ -595,6 +674,6 @@
 </section>
 
 <kraak-cta-banner
-  heading="Parlons de votre prochaine étape."
-  body="Envoyez votre demande via le formulaire ou lancez directement un échange sur WhatsApp."
+  [heading]="'web.contact.closing.heading' | kraakTranslate"
+  [body]="'web.contact.closing.body' | kraakTranslate"
 />

--- a/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.spec.ts
@@ -1,13 +1,16 @@
 // apps\client\projects\web\src\app\features\contact\contact.page.spec.ts
 
+import { ApplicationInitStatus } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { vi } from 'vitest';
+
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
 import { AnalyticsService } from '../../core/analytics/analytics.service';
 import {
   CONTACT_PHONE_DISPLAY,
@@ -33,6 +36,13 @@ function dispatchTrackedClick(link: HTMLAnchorElement): void {
   );
 }
 
+function normalizedText(element: Element | null): string {
+  return (element?.textContent ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([.!?])/g, '$1')
+    .trim();
+}
+
 describe('ContactPage', () => {
   let httpTestingController: HttpTestingController;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -49,9 +59,12 @@ describe('ContactPage', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         provideRouter([]),
+        provideKraakI18n(),
         { provide: AnalyticsService, useValue: analyticsService },
       ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
 
     httpTestingController = TestBed.inject(HttpTestingController);
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
@@ -79,6 +92,199 @@ describe('ContactPage', () => {
     fixture.detectChanges();
     const heading = fixture.nativeElement.querySelector('h1');
     expect(heading?.textContent).toContain('Parlez-nous de votre objectif.');
+  });
+
+  it('Given the French contact route When the page renders Then visitor copy and accessible text preserve the French source content', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      'Parlez-nous de votre objectif.',
+    );
+    expect(normalizedText(page)).toContain('Envoyez votre demande');
+    expect(normalizedText(page)).toContain('Nos coordonnées');
+    expect(page.querySelector('aside')?.getAttribute('aria-label')).toBe(
+      'Informations de contact KRAAK',
+    );
+    expect(page.querySelector('aside img')?.getAttribute('alt')).toBe(
+      "Entretien d'orientation pour clarifier un besoin d'accompagnement",
+    );
+    expect(normalizedText(page)).toContain(
+      'File interne : formation/orientation-public. Workflow : orientation formation sous 48h ouvrées.',
+    );
+    expect(normalizedText(page)).not.toContain('[missing:web.contact.');
+  });
+
+  it('Given the English contact route When every section renders Then visitor copy links and accessible text come from the English catalog', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/en/contact',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const content = normalizedText(page);
+    const serviceLink = page.querySelector(
+      'a[href="/en/services"]',
+    ) as HTMLAnchorElement | null;
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      'Tell us about your goal.',
+    );
+    expect(content).toContain('Send an enquiry');
+    expect(content).toContain('Give us the right information to guide you.');
+    expect(content).toContain('Send your enquiry');
+    expect(content).toContain('Project management');
+    expect(content).toContain('Our contact details');
+    expect(content).toContain('Let’s discuss your next step.');
+    expect(serviceLink?.textContent).toContain('Explore our services');
+    expect(page.querySelector('aside')?.getAttribute('aria-label')).toBe(
+      'KRAAK contact details',
+    );
+    expect(page.querySelector('aside img')?.getAttribute('alt')).toBe(
+      'A guidance meeting to clarify support needs',
+    );
+    expect(
+      page.querySelector('nav[aria-label]')?.getAttribute('aria-label'),
+    ).toBe('KRAAK social media');
+    expect(page.querySelector('#name')?.getAttribute('placeholder')).toBe(
+      'Your name',
+    );
+    expect(page.querySelector('#country')?.getAttribute('placeholder')).toBe(
+      'Your country of residence',
+    );
+    expect(content).toContain(
+      'Internal queue: formation/orientation-public. Workflow: training guidance within 48 business hours.',
+    );
+    expect(content).not.toContain('Envoyez votre demande');
+    expect(content).not.toContain('Nos coordonnées');
+    expect(content).not.toContain('[missing:web.contact.');
+  });
+
+  it('Given an empty English contact form When it is submitted Then every validation message is shown in English and analytics values stay language-neutral', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const content = normalizedText(fixture.nativeElement as HTMLElement);
+
+    expect(content).toContain('Name is required.');
+    expect(content).toContain('Email address is required.');
+    expect(content).toContain('Goal is required.');
+    expect(content).toContain('Country is required.');
+    expect(content).toContain('Message is required.');
+    expect(content).not.toContain('Le nom est requis.');
+    expect(analyticsService.trackEvent).toHaveBeenCalledWith(
+      'contact_submit_failure',
+      expect.objectContaining({
+        contact_category: 'training',
+        failure_type: 'validation',
+        service_type: 'formation',
+      }),
+    );
+  });
+
+  it('Given a valid English contact form When the API accepts it Then the success feedback is displayed in English', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      name: 'Alice Smith',
+      email: 'alice@example.com',
+      subject: 'Discuss training support',
+      country: 'Ghana',
+      serviceType: 'formation',
+      message: 'I would like to discuss the right training programme.',
+    });
+
+    component.onSubmit();
+    const request = httpTestingController.expectOne((candidate) =>
+      candidate.url.endsWith('/contact'),
+    );
+
+    expect(request.request.body.message).toContain('Country: Ghana');
+    expect(request.request.body.message).toContain('Service type: Training');
+    expect(request.request.body.message).toContain(
+      'Internal queue: formation/orientation-public',
+    );
+    expect(request.request.body.message).toContain(
+      'Response workflow: training guidance within 48 business hours',
+    );
+    expect(request.request.body.message).toContain(
+      'Operational fallback: direct email or WhatsApp',
+    );
+
+    request.flush({ success: true, message: 'Request received.' });
+    fixture.detectChanges();
+
+    const content = normalizedText(fixture.nativeElement as HTMLElement);
+
+    expect(content).toContain(
+      'Your message has been sent. We will get back to you as soon as possible.',
+    );
+    expect(content).not.toContain('Votre message a bien été envoyé.');
+  });
+
+  it('Given a valid English contact form When the API returns French-only details Then localized fallback feedback is shown without leaking French copy', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ContactPage);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      name: 'Alice Smith',
+      email: 'alice@example.com',
+      subject: 'Discuss project support',
+      country: 'Ghana',
+      serviceType: 'project',
+      message: 'I would like to discuss support for a new project.',
+    });
+
+    component.onSubmit();
+    httpTestingController
+      .expectOne((request) => request.url.endsWith('/contact'))
+      .flush(
+        {
+          errors: [
+            "Le formulaire est temporairement indisponible. Veuillez utiliser l'e-mail direct ou WhatsApp indiqué sur la page contact.",
+            'Le nom est requis.',
+          ],
+        },
+        { status: 500, statusText: 'Internal Server Error' },
+      );
+    fixture.detectChanges();
+
+    const content = normalizedText(fixture.nativeElement as HTMLElement);
+
+    expect(content).toContain('Something went wrong. Please try again later.');
+    expect(content).toContain(
+      'Alternative contact options: you can continue your enquiry without the form.',
+    );
+    expect(content).not.toContain('Le formulaire est temporairement');
+    expect(content).not.toContain('Fallback opérationnel');
+    expect(content).not.toContain('Le nom est requis.');
+    expect(analyticsService.trackEvent).toHaveBeenCalledWith(
+      'contact_submit_failure',
+      expect.objectContaining({
+        error_count: 2,
+        failure_type: 'api',
+        status: 500,
+      }),
+    );
   });
 
   // Given le formulaire de contact est affiché
@@ -564,7 +770,7 @@ describe('ContactPage', () => {
   // Given un formulaire valide
   // When l'API répond avec une erreur sans tableau errors structuré
   // Then le message d'erreur générique est affiché
-  it('devrait afficher le message générique si la réponse erreur ne contient pas de tableau errors', () => {
+  it("Given un formulaire valide When l'API renvoie une réponse sans tableau errors Then le message générique est affiché", () => {
     const fixture = TestBed.createComponent(ContactPage);
     fixture.detectChanges();
     const component = fixture.componentInstance;

--- a/apps/client/projects/web/src/app/features/contact/contact.page.ts
+++ b/apps/client/projects/web/src/app/features/contact/contact.page.ts
@@ -33,6 +33,10 @@ import { PublicConversionTrackingDirective } from '../../shared/analytics/public
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { RevealOnScrollDirective } from '../../shared/motion/reveal-on-scroll.directive';
 import { LocalizedPublicPathPipe } from '../../routing/localized-public-path.pipe';
+import {
+  KraakI18nService,
+  KraakTranslatePipe,
+} from '../../../../../shared/i18n';
 import { ContactService } from './contact.service';
 
 type ServiceType =
@@ -52,89 +56,60 @@ interface ServiceOption {
   fallbackWorkflow: string;
 }
 
-const GENERIC_CONTACT_ERROR_MESSAGE =
-  'Une erreur est survenue. Veuillez r\u00e9essayer plus tard.';
-
 const CONTACT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/services-coaching.avif',
 );
 
-type ServiceOptionDefinition = readonly [
-  label: string,
-  value: ServiceType,
-  category: ContactFormDto['category'],
-  triagePath: string,
-  responseWorkflow: string,
-  fallbackWorkflow: string,
-];
-
-function createServiceOption([
-  label,
-  value,
-  category,
-  triagePath,
-  responseWorkflow,
-  fallbackWorkflow,
-]: ServiceOptionDefinition): ServiceOption {
-  return {
-    label,
-    value,
-    category,
-    triagePath,
-    responseWorkflow,
-    fallbackWorkflow,
-  };
+interface ServiceOptionDefinition {
+  readonly translationId:
+    | 'training'
+    | 'project'
+    | 'immigration'
+    | 'business'
+    | 'partnership'
+    | 'other';
+  readonly value: ServiceType;
+  readonly category: ContactFormDto['category'];
+  readonly triagePath: string;
 }
 
 const SERVICE_OPTION_DEFINITIONS: readonly ServiceOptionDefinition[] = [
-  [
-    'Formation',
-    'formation',
-    'training',
-    'formation/orientation-public',
-    'orientation formation sous 48h ouvrées',
-    'e-mail direct ou WhatsApp',
-  ],
-  [
-    'Gestion de projets',
-    'project',
-    'project_management',
-    'conseil/gestion-de-projets',
-    'cadrage projet sous 48h ouvrées',
-    'e-mail direct ou WhatsApp',
-  ],
-  [
-    'Conseil en immigration',
-    'immigration',
-    'immigration',
-    'conseil/mobilite-internationale',
-    'orientation mobilité sans dépôt de dossier sensible',
-    'WhatsApp ou e-mail direct',
-  ],
-  [
-    'Solutions entreprises',
-    'business',
-    'business',
-    'partenariats/organisations-et-entreprises',
-    'qualification organisation sous 48h ouvrées',
-    'e-mail direct',
-  ],
-  [
-    'Partenariat',
-    'program',
-    'partnership',
-    'partenariats/institutionnel',
-    'qualification partenariat sous 48h ouvrées',
-    'e-mail direct ou WhatsApp',
-  ],
-  [
-    'Autre demande',
-    'other',
-    'other',
-    'intake/general',
-    'triage général puis réorientation sous 48h ouvrées',
-    'e-mail direct ou WhatsApp',
-  ],
+  {
+    translationId: 'training',
+    value: 'formation',
+    category: 'training',
+    triagePath: 'formation/orientation-public',
+  },
+  {
+    translationId: 'project',
+    value: 'project',
+    category: 'project_management',
+    triagePath: 'conseil/gestion-de-projets',
+  },
+  {
+    translationId: 'immigration',
+    value: 'immigration',
+    category: 'immigration',
+    triagePath: 'conseil/mobilite-internationale',
+  },
+  {
+    translationId: 'business',
+    value: 'business',
+    category: 'business',
+    triagePath: 'partenariats/organisations-et-entreprises',
+  },
+  {
+    translationId: 'partnership',
+    value: 'program',
+    category: 'partnership',
+    triagePath: 'partenariats/institutionnel',
+  },
+  {
+    translationId: 'other',
+    value: 'other',
+    category: 'other',
+    triagePath: 'intake/general',
+  },
 ];
 
 @Component({
@@ -154,6 +129,7 @@ const SERVICE_OPTION_DEFINITIONS: readonly ServiceOptionDefinition[] = [
     PublicConversionTrackingDirective,
     RevealOnScrollDirective,
     LocalizedPublicPathPipe,
+    KraakTranslatePipe,
   ],
   templateUrl: './contact.page.html',
   styles: [
@@ -176,9 +152,33 @@ export default class ContactPage implements OnInit, OnDestroy {
   private readonly contactService = inject(ContactService);
   private readonly gsapService = inject(GsapAnimationsService);
   private readonly analyticsService = inject(AnalyticsService);
+  private readonly i18n = inject(KraakI18nService);
 
-  protected readonly serviceOptions =
-    SERVICE_OPTION_DEFINITIONS.map(createServiceOption);
+  protected get serviceOptions(): readonly ServiceOption[] {
+    this.i18n.locale();
+
+    return SERVICE_OPTION_DEFINITIONS.map((definition) => {
+      const translationPrefix =
+        'web.contact.form.serviceOptions.' + definition.translationId;
+
+      return {
+        value: definition.value,
+        category: definition.category,
+        triagePath: definition.triagePath,
+        label: this.i18n.translate(translationPrefix + '.label'),
+        responseWorkflow: this.i18n.translate(
+          translationPrefix + '.responseWorkflow',
+        ),
+        fallbackWorkflow: this.i18n.translate(
+          translationPrefix + '.fallbackWorkflow',
+        ),
+      };
+    });
+  }
+
+  protected get helpLabelSeparator(): string {
+    return this.i18n.locale() === 'fr-CI' ? ' :' : ':';
+  }
 
   protected readonly socialLinks: readonly SocialLink[] = KRAAK_SOCIAL_LINKS;
   protected readonly whatsappLink =
@@ -274,22 +274,39 @@ export default class ContactPage implements OnInit, OnDestroy {
       },
       error: (errorResponse: HttpErrorResponse) => {
         this.loading.set(false);
-        const extractedErrors = this.extractApiErrors(errorResponse);
-        this.apiErrors.set(extractedErrors);
+        const resolvedErrors = this.resolveApiErrors(errorResponse);
+        this.apiErrors.set(resolvedErrors.messages);
         this.trackContactSubmitFailure('api', selectedOption, {
-          error_count: extractedErrors.length,
+          error_count: resolvedErrors.sourceCount,
           status: errorResponse.status,
         });
         logDebugError('web.contact.submit', errorResponse, {
           route: '/contact',
           status: errorResponse.status,
-          apiErrorCount: extractedErrors.length,
+          apiErrorCount: resolvedErrors.sourceCount,
         });
       },
     });
   }
 
-  private extractApiErrors(errorResponse: HttpErrorResponse): string[] {
+  private resolveApiErrors(errorResponse: HttpErrorResponse): {
+    messages: string[];
+    sourceCount: number;
+  } {
+    const sourceErrors = this.extractSourceApiErrors(errorResponse);
+    const genericError = this.i18n.translate('web.contact.form.genericError');
+    const messages =
+      this.i18n.locale() === 'fr-CI' && sourceErrors.length > 0
+        ? sourceErrors
+        : [genericError];
+
+    return {
+      messages,
+      sourceCount: Math.max(sourceErrors.length, 1),
+    };
+  }
+
+  private extractSourceApiErrors(errorResponse: HttpErrorResponse): string[] {
     const errorBody = errorResponse.error as
       | { errors?: unknown; message?: unknown }
       | undefined;
@@ -311,7 +328,7 @@ export default class ContactPage implements OnInit, OnDestroy {
       return [errorBody.message.trim()];
     }
 
-    return [GENERIC_CONTACT_ERROR_MESSAGE];
+    return [];
   }
 
   private buildPayload(selectedOption: ServiceOption): ContactFormDto {
@@ -326,14 +343,34 @@ export default class ContactPage implements OnInit, OnDestroy {
 
   private buildMessage(selectedOption: ServiceOption): string {
     return [
-      `Pays : ${this.form.value.country!}`,
-      `Type de service : ${selectedOption.label}`,
-      `File interne : ${selectedOption.triagePath}`,
-      `Workflow de réponse : ${selectedOption.responseWorkflow}`,
-      `Fallback opérationnel : ${selectedOption.fallbackWorkflow}`,
+      this.buildMessageLine(
+        'web.contact.form.fields.country.label',
+        this.form.value.country!,
+      ),
+      this.buildMessageLine(
+        'web.contact.form.fields.serviceType.label',
+        selectedOption.label,
+      ),
+      this.buildMessageLine(
+        'web.contact.form.fields.serviceType.internalQueueLabel',
+        selectedOption.triagePath,
+      ),
+      this.buildMessageLine(
+        'web.contact.form.fields.serviceType.responseWorkflowLabel',
+        selectedOption.responseWorkflow,
+      ),
+      this.buildMessageLine(
+        'web.contact.form.fields.serviceType.fallbackWorkflowLabel',
+        selectedOption.fallbackWorkflow,
+      ),
       '',
       this.form.value.message!,
     ].join('\n');
+  }
+
+  private buildMessageLine(labelKey: string, value: string): string {
+    const separator = this.i18n.locale() === 'fr-CI' ? ' : ' : ': ';
+    return this.i18n.translate(labelKey) + separator + value;
   }
 
   protected getSelectedServiceOption(): ServiceOption {

--- a/apps/client/tests/e2e/i18n-contact.spec.ts
+++ b/apps/client/tests/e2e/i18n-contact.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Internationalisation publique de la page Contact', () => {
+  test('Given la route /fr/contact, When la page se charge, Then le contenu et les textes accessibles restent en français', async ({
+    page,
+  }) => {
+    await page.goto('/fr/contact', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Parlez-nous de votre objectif.',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('complementary', {
+        name: 'Informations de contact KRAAK',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByAltText(
+        "Entretien d'orientation pour clarifier un besoin d'accompagnement",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Voir les services', exact: true }),
+    ).toHaveAttribute('href', '/fr/services');
+    await expect(page.getByLabel('Type de service')).toContainText(
+      'Gestion de projets',
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Nos coordonnées' }),
+    ).toBeVisible();
+    await expect(page.locator('body')).not.toContainText(
+      '[missing:web.contact.',
+    );
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="en-GB"]'),
+    ).toHaveCount(0);
+  });
+
+  test('Given la route /en/contact, When every section renders, Then visitor copy links and accessibility text are English while SEO stays noindex', async ({
+    page,
+  }) => {
+    await page.goto('/en/contact', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Tell us about your goal.',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('complementary', { name: 'KRAAK contact details' }),
+    ).toBeVisible();
+    await expect(
+      page.getByAltText('A guidance meeting to clarify support needs'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('navigation', { name: 'KRAAK social media' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Explore our services', exact: true }),
+    ).toHaveAttribute('href', '/en/services');
+    await expect(page.getByLabel('Service type')).toContainText(
+      'Project management',
+    );
+    await expect(
+      page.getByPlaceholder('Your country of residence'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Our contact details' }),
+    ).toBeVisible();
+    await expect(page.getByText('Let’s discuss your next step.')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText(
+      'Envoyez votre demande',
+    );
+    await expect(page.locator('body')).not.toContainText('Nos coordonnées');
+    await expect(page.locator('body')).not.toContainText(
+      '[missing:web.contact.',
+    );
+
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex, nofollow',
+    );
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="x-default"]'),
+    ).toHaveAttribute('href', /\/fr\/contact$/);
+
+    const sitemapResponse = await page.request.get('/sitemap.xml');
+    expect(sitemapResponse.ok()).toBe(true);
+    const sitemap = await sitemapResponse.text();
+    expect(sitemap).toContain('/fr/contact');
+    expect(sitemap).not.toContain('/en/contact');
+  });
+
+  test('Given the English Contact hero action, When it is activated with the keyboard, Then it reaches the localized contact form', async ({
+    page,
+  }) => {
+    await page.goto('/en/contact');
+
+    const enquiryLink = page.getByRole('link', {
+      name: 'Go to the contact form',
+    });
+    await enquiryLink.focus();
+    await expect(enquiryLink).toBeFocused();
+
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/en\/contact#contact-form$/);
+    await expect(
+      page.getByRole('heading', { name: 'Send your enquiry' }),
+    ).toBeVisible();
+  });
+
+  test('Given an English contact form, When validation and a successful submission occur, Then feedback and submitted operational context stay English while identifiers remain stable', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await page.route('**/contact', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          message: 'Request received.',
+        }),
+      });
+    });
+
+    await page.goto('/en/contact');
+    const submitButton = page.getByRole('button', {
+      name: 'Send my enquiry',
+    });
+
+    await expect(async () => {
+      await submitButton.click();
+      await expect(page.getByText('Name is required.')).toBeVisible();
+    }).toPass();
+    await expect(page.getByText('Email address is required.')).toBeVisible();
+    await expect(page.getByText('Goal is required.')).toBeVisible();
+    await expect(page.getByText('Country is required.')).toBeVisible();
+    await expect(page.getByText('Message is required.')).toBeVisible();
+
+    const nameField = page.getByRole('textbox', { name: 'Full name' });
+    const emailField = page.getByRole('textbox', { name: 'Email address' });
+    const subjectField = page.getByRole('textbox', { name: 'Goal' });
+    const countryField = page.getByRole('textbox', { name: 'Country' });
+    const serviceField = page.getByLabel('Service type');
+    const messageField = page.getByRole('textbox', { name: 'Message' });
+
+    await expect(async () => {
+      await nameField.fill('Alice Smith');
+      await emailField.fill('alice@example.com');
+      await subjectField.fill('Discuss training support');
+      await countryField.fill('Ghana');
+      await serviceField.selectOption('formation');
+      await messageField.fill(
+        'I would like to discuss the right training programme.',
+      );
+
+      const submitRequestPromise = page.waitForRequest(
+        (request) =>
+          request.method() === 'POST' && request.url().endsWith('/contact'),
+        { timeout: 10_000 },
+      );
+
+      await submitButton.click();
+      const submitRequest = await submitRequestPromise;
+      const payload = submitRequest.postDataJSON() as { message: string };
+
+      expect(payload.message).toContain('Country: Ghana');
+      expect(payload.message).toContain('Service type: Training');
+      expect(payload.message).toContain(
+        'Internal queue: formation/orientation-public',
+      );
+      expect(payload.message).toContain(
+        'Response workflow: training guidance within 48 business hours',
+      );
+      expect(payload.message).toContain(
+        'Operational fallback: direct email or WhatsApp',
+      );
+      await expect(
+        page.getByText(
+          'Your message has been sent. We will get back to you as soon as possible.',
+        ),
+      ).toBeVisible({ timeout: 10_000 });
+    }).toPass({ timeout: 60_000 });
+  });
+});

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -33,17 +33,18 @@ Le site web KRAAK est l'application Angular publique située dans
   la première locale anglaise selon ARC-19. La page d'accueil `/fr/` ou `/en/`
   et la barre de navigation forment le premier incrément public bilingue. La
   coque publique partagée (pied de page, lien d'accès rapide et commande de
-  retour en haut) forme le deuxième incrément. Les autres pages `/en/...`
-  restent un scaffold technique non indexable tant que leurs contenus anglais
-  ne sont pas traduits et relus.
+  retour en haut) forme le deuxième incrément. La page Contact constitue le
+  troisième incrément localisé. Les autres pages `/en/...` restent un scaffold
+  technique non indexable tant que leurs contenus anglais ne sont pas traduits
+  et relus.
 
 ## Implémentation active
 
 - Routes publiques : [`../../apps/client/projects/web/src/app/app.routes.ts`](../../apps/client/projects/web/src/app/app.routes.ts).
 - Prerender public : [`../../apps/client/projects/web/src/app/app.routes.server.ts`](../../apps/client/projects/web/src/app/app.routes.server.ts).
 - Catalogues runtime : [`../../apps/client/projects/shared/i18n/catalogs/`](../../apps/client/projects/shared/i18n/catalogs/),
-  avec les espaces de clés `web.home`, `web.nav` et `web.shell` pour les deux
-  premiers incréments publics bilingues.
+  avec les espaces de clés `web.home`, `web.nav`, `web.shell` et
+  `web.contact` pour les incréments publics bilingues livrés.
 - Tests de surface : [`../../apps/client/projects/web/src/app/app.routes.spec.ts`](../../apps/client/projects/web/src/app/app.routes.spec.ts)
   et [`../../apps/client/projects/web/src/app/app.routes.server.spec.ts`](../../apps/client/projects/web/src/app/app.routes.server.spec.ts).
 - Historique design : [`../archive/vitrine-design/`](../archive/vitrine-design/),
@@ -60,20 +61,20 @@ Le prerender, les métadonnées SEO, les canonicals, les liens `hreflang`, les
 entrées sitemap et l'attribut `<html lang>` sont générés par locale depuis le
 modèle de routes web localisées.
 
-La page d'accueil, la barre de navigation et la coque publique partagée servent
-désormais leur contenu français ou anglais depuis les catalogues selon la locale
-de l'URL. Un sélecteur de langue relie les variantes d'une même page publique
-lorsque le mapping existe, puis revient à la page d'accueil de la langue cible
-lorsqu'aucune variante publique n'est disponible.
+La page d'accueil, la barre de navigation, la coque publique partagée et la page
+Contact servent désormais leur contenu français ou anglais depuis les catalogues
+selon la locale de l'URL. Un sélecteur de langue relie les variantes d'une même
+page publique lorsque le mapping existe, puis revient à la page d'accueil de la
+langue cible lorsqu'aucune variante publique n'est disponible.
 
 Les prochaines pages de conversion doivent être localisées séparément, avec une
-seule page par PR, dans cet ordre : Contact, Services, Programmes, puis À propos.
+seule page par PR, dans cet ordre : Services, Programmes, puis À propos.
 L'activation de l'indexation anglaise, des entrées sitemap et des liens
 `hreflang` réciproques reste conditionnée à une revue humaine du contenu anglais
 de chaque page.
 
-Ces deux premières tranches de contenu ne modifient pas encore la politique SEO
-du scaffold anglais : les routes anglaises restent `noindex, nofollow`, exclues
+Ces incréments de contenu ne modifient pas encore la politique SEO du scaffold
+anglais : les routes anglaises restent `noindex, nofollow`, exclues
 du sitemap de production et non annoncées en `hreflang="en-GB"` depuis les
 pages françaises indexables. Leurs métadonnées anglaises restent temporaires
 jusqu'à une traduction et une revue SEO dédiées. `x-default` continue de pointer


### PR DESCRIPTION
## Résumé

- sert toute la page Contact depuis les catalogues `fr-CI` et `en-GB`, formulaire et accessibilité compris
- conserve les identifiants techniques de triage tout en localisant les libellés, workflows et retours utilisateur
- protège la page anglaise des messages API français sans fausser les métriques d’erreur
- ajoute des tests Given/When/Then unitaires et Playwright sur Chromium, Firefox et WebKit
- documente Contact comme troisième incrément i18n public

## Validation

- `pnpm.cmd i18n:check`
- `pnpm.cmd typecheck:web`
- tests web : 676/676
- tests mobile : 253/253
- intégration API : 31/31
- Playwright Contact : 12/12 sur les trois navigateurs
- `pnpm.cmd build:web`
- ESLint, Prettier et markdownlint ciblés

## Garde-fou SEO

La copie anglaise proposée n’a pas encore reçu de revue humaine. `/en/contact` reste donc en `noindex, nofollow`, hors sitemap et sans hreflang anglais réciproque.

Closes #642