### PR TITLE
feat(web): localiser la page Services

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,9 +61,11 @@ Les routes publiques localisées et l'adaptateur runtime partagé sont actifs. L
 page d'accueil et la barre de navigation constituent le premier incrément public
 entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. La coque
 publique partagée constitue le deuxième incrément et la page Contact le
-troisième. Les autres pages de conversion seront localisées dans des PR
-distinctes, dans l'ordre Services, Programmes, puis À propos. Les autres pages
-publiques anglaises et leurs
+troisième. La page Services constitue le quatrième incrément public localisé.
+Sa copie anglaise est proposée mais n'a pas encore reçu de revue humaine :
+`/en/services` reste donc `noindex, nofollow`, hors du sitemap et sans lien
+`hreflang="en-GB"` réciproque. Les pages Programmes puis À propos seront
+localisées dans des PR distinctes. Les autres pages publiques anglaises et leurs
 métadonnées SEO restent dans l'état de scaffold non indexable jusqu'à leur
 traduction et leur revue humaine dédiées. L'indexation anglaise, les entrées
 sitemap et les liens `hreflang` réciproques ne sont activés qu'après cette revue

--- a/apps/client/projects/shared/i18n/catalogs/en-GB.json
+++ b/apps/client/projects/shared/i18n/catalogs/en-GB.json
@@ -323,6 +323,134 @@
         "heading": "Let’s discuss your next step.",
         "body": "Send your enquiry through the form or start a conversation directly on WhatsApp."
       }
+    },
+    "services": {
+      "hero": {
+        "eyebrow": "KRAAK Services",
+        "titlePrefix": "Clear",
+        "titleEmphasis": "solutions",
+        "titleSuffix": "to strengthen careers, projects and organisations.",
+        "description": "KRAAK Consulting works across three complementary areas of expertise, alongside a dedicated offer for organisations. Every engagement starts with a concrete need, a clear framework and an identifiable next step."
+      },
+      "cardLabels": {
+        "audience": "Who it is for",
+        "challenge": "Your challenge",
+        "deliverables": "What we deliver",
+        "nextStep": "Next step"
+      },
+      "training": {
+        "eyebrow": "KRAAK Training Centre",
+        "title": "Help people present themselves with confidence, clarity and job-ready skills.",
+        "description": "This area supports young people, students and early-career professionals who need to clarify their direction, strengthen their application toolkit and position themselves more effectively in the job market.",
+        "primaryCta": "Book an initial assessment",
+        "secondaryCta": "Explore our formats",
+        "audience": "Young people, students, early-career professionals and people repositioning themselves or changing careers.",
+        "challenge": "You have potential but need to clarify your plans, strengthen your application toolkit and build confidence.",
+        "deliverables": "Career guidance, CVs and cover letters in French and English, interview preparation, professional English and French, personal development workshops and transferable skills.",
+        "nextStep": "Book an initial assessment to identify the right format: a short workshop, focused support or a more comprehensive programme.",
+        "offers": {
+          "personalDevelopment": "Personal and professional development",
+          "professionalLanguages": "Professional English and French",
+          "languageTests": "Language test preparation",
+          "jobSearch": "Modern job-search strategies",
+          "selfWorth": "Self-confidence and recognising your potential",
+          "careerChange": "Career change support"
+        }
+      },
+      "projects": {
+        "eyebrow": "Research and Innovation Centre",
+        "title": "Structure an idea, mobilise the right resources and move a valuable project forward.",
+        "description": "This area supports businesses, start-ups, organisations and project leaders who need scoping, planning, partnerships or operational support to turn an intention into a manageable path forward.",
+        "primaryCta": "Schedule a scoping session",
+        "secondaryCta": "Tell us about your needs",
+        "audience": "Businesses, start-ups, organisations, associations and project leaders.",
+        "challenge": "You need to turn an idea into a clear, fundable and manageable project that can attract the right people.",
+        "deliverables": "Scoping and planning, partnership development, talent identification, support for businesses and start-ups, workplace preparation and placement.",
+        "nextStep": "Share your needs so we can define the scope, priorities and most useful form of support.",
+        "offers": {
+          "businessSupport": "Business and start-up support",
+          "projectManagement": "Project management",
+          "partnershipDevelopment": "Partnership development",
+          "talentRecruitment": "Talent identification and recruitment",
+          "workplacePlacement": "Workplace preparation and placement",
+          "operationalSupport": "Operational support for initiatives"
+        }
+      },
+      "mobility": {
+        "eyebrow": "Immigration Advisory Centre",
+        "title": "Prepare for international study, work and mobility with a clear method.",
+        "description": "This area supports individuals and organisations that need to clarify an international plan, understand the available options and prepare appropriate steps for the profile, goal and destination.",
+        "complianceLabel": "Compliance note:",
+        "complianceBody": "the information provided in this context is intended to guide and prepare your plans. Official requirements may vary by country or programme and may change as procedures evolve.",
+        "primaryCta": "Book a guidance session",
+        "secondaryCta": "Assess my plans",
+        "audience": "People seeking to study or work abroad, business opportunity seekers and organisations needing international guidance.",
+        "challenge": "You need to clarify the options, understand the procedures and prepare plans that fit your profile.",
+        "deliverables": "Strategic guidance, advice on studying and working abroad, exploration of business opportunities, immigration policies and strategies, and preparation for social and professional integration.",
+        "nextStep": "Book a consultation to clarify your goal, target country and preparatory steps."
+      },
+      "business": {
+        "eyebrow": "Business solutions",
+        "title": "Targeted solutions for human capital, team cohesion and performance.",
+        "description": "This dedicated offer is for organisations seeking to recruit more effectively, improve collaboration, strengthen internal leadership or raise organisational performance.",
+        "primaryCta": "Discuss a business need",
+        "secondaryCta": "Request a proposal",
+        "audience": "SMEs, start-ups, organisations, leadership teams and HR teams.",
+        "challenge": "You need to recruit and onboard more effectively, improve collaboration or help your teams progress.",
+        "deliverables": "Talent identification, recruitment support, professional development workshops, staff training, organisational leadership, performance improvement and team cohesion.",
+        "nextStep": "Tell us about your context to receive a tailored proposal or focused intervention.",
+        "offers": {
+          "staffTraining": "Staff training",
+          "teamCohesion": "Team cohesion",
+          "conflictManagement": "Conflict management",
+          "organisationalLeadership": "Organisational leadership",
+          "businessPerformance": "Business performance",
+          "workplaceCulture": "Workplace culture and healthy working relationships"
+        }
+      },
+      "method": {
+        "title": "Our approach",
+        "items": {
+          "clarify": {
+            "title": "Clarify",
+            "description": "We start with the real need, the level of maturity and the decision that needs to be made."
+          },
+          "structure": {
+            "title": "Structure",
+            "description": "We define the right format, expected deliverables and operational priorities."
+          },
+          "advance": {
+            "title": "Move forward",
+            "description": "We put the next step into motion within a clear framework for follow-up."
+          }
+        }
+      },
+      "faq": {
+        "eyebrow": "Frequently asked questions",
+        "title": "Identify the right service before you begin.",
+        "description": "KRAAK helps turn your goal into a clear, practical and useful form of support.",
+        "panelTitle": "Frequently asked questions",
+        "panelDescription": "Find quick answers to common questions about our services, support formats and response times.",
+        "items": {
+          "serviceChoice": {
+            "question": "How do I choose the service best suited to my goal?",
+            "answer": "We start with your main goal, your context and your most important constraint. Where needed, we guide you towards the right combination of training, project support, immigration guidance or business services."
+          },
+          "initialGuidance": {
+            "question": "Do you offer an initial guidance session before we begin?",
+            "answer": "Yes. An initial consultation helps clarify the need, identify the right format and define the next useful step."
+          },
+          "organisationSupport": {
+            "question": "Is your support only available to individuals?",
+            "answer": "No. KRAAK also supports businesses, start-ups, organisations and HR teams according to the type of need and the level of structure required."
+          }
+        }
+      },
+      "closing": {
+        "title": "Choose the right starting point for your needs.",
+        "description": "One consultation is often enough to identify the most relevant offer, format and next step.",
+        "cta": "Book a consultation"
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/shared/i18n/catalogs/fr-CI.json
+++ b/apps/client/projects/shared/i18n/catalogs/fr-CI.json
@@ -323,6 +323,134 @@
         "heading": "Parlons de votre prochaine étape.",
         "body": "Envoyez votre demande via le formulaire ou lancez directement un échange sur WhatsApp."
       }
+    },
+    "services": {
+      "hero": {
+        "eyebrow": "Services KRAAK",
+        "titlePrefix": "Des offres",
+        "titleEmphasis": "claires",
+        "titleSuffix": "pour renforcer les parcours, les projets et les organisations.",
+        "description": "KRAAK Consulting intervient à travers trois pôles complémentaires et une offre dédiée aux entreprises. Chaque intervention part d'un besoin concret, d'un cadre clair et d'une prochaine étape identifiable."
+      },
+      "cardLabels": {
+        "audience": "Pour qui",
+        "challenge": "Problématique",
+        "deliverables": "Ce que nous livrons",
+        "nextStep": "Prochaine étape"
+      },
+      "training": {
+        "eyebrow": "KRAAK Training Centre",
+        "title": "Former des profils plus confiants, plus lisibles et plus prêts pour l'emploi.",
+        "description": "Ce pôle accompagne les jeunes, les étudiants et les jeunes professionnels qui doivent clarifier leur trajectoire, renforcer leurs outils de candidature et mieux se positionner sur le marché du travail.",
+        "primaryCta": "Demander un diagnostic",
+        "secondaryCta": "Recevoir les formats",
+        "audience": "Jeunes, étudiants, jeunes professionnels, profils en repositionnement ou en reconversion.",
+        "challenge": "Vous avez du potentiel mais devez clarifier votre projet, renforcer vos outils de candidature et gagner en assurance.",
+        "deliverables": "Orientation de carrière, CV et lettres en français et en anglais, préparation aux entretiens, anglais / français professionnel, ateliers de développement personnel et compétences transférables.",
+        "nextStep": "Réserver un diagnostic pour identifier le bon format : atelier court, accompagnement ciblé ou programme plus complet.",
+        "offers": {
+          "personalDevelopment": "Développement personnel et professionnel",
+          "professionalLanguages": "Anglais / français professionnel",
+          "languageTests": "Préparation aux tests de langue",
+          "jobSearch": "Stratégies modernes de recherche d'emploi",
+          "selfWorth": "Estime de soi et valorisation du potentiel",
+          "careerChange": "Reconversion professionnelle"
+        }
+      },
+      "projects": {
+        "eyebrow": "Centre de Recherche et d'Innovation",
+        "title": "Structurer une idée, mobiliser les bonnes ressources, faire avancer un projet utile.",
+        "description": "Ce pôle accompagne les entreprises, startups, organisations et porteurs de projets qui ont besoin de cadrage, de planification, de partenariats ou d'un appui opérationnel pour passer d'une intention à une trajectoire pilotable.",
+        "primaryCta": "Planifier un cadrage",
+        "secondaryCta": "Présenter mon besoin",
+        "audience": "Entreprises, startups, organisations, associations et porteurs de projets.",
+        "challenge": "Vous devez passer d'une intention à un projet lisible, finançable, pilotable ou recrutable.",
+        "deliverables": "Cadrage et planification, développement de partenariats, identification de talents, accompagnement d'entreprises et de startups, préparation et placement en entreprise.",
+        "nextStep": "Partager votre besoin pour définir le périmètre, les priorités et le type d'appui le plus utile.",
+        "offers": {
+          "businessSupport": "Accompagnement d'entreprise et de startup",
+          "projectManagement": "Gestion de projets",
+          "partnershipDevelopment": "Développement de partenariats",
+          "talentRecruitment": "Identification et recrutement de talents",
+          "workplacePlacement": "Préparation et placement en entreprise",
+          "operationalSupport": "Accompagnement opérationnel des initiatives"
+        }
+      },
+      "mobility": {
+        "eyebrow": "Centre de Conseils en Immigration",
+        "title": "Études, travail et mobilité internationale préparés avec méthode.",
+        "description": "Ce pôle accompagne les personnes et les organisations qui doivent clarifier un projet international, comprendre les options disponibles et préparer les étapes cohérentes selon le profil, l'objectif et la destination.",
+        "complianceLabel": "Note de conformité :",
+        "complianceBody": "les informations fournies dans ce cadre servent à l'orientation et à la préparation du projet. Les exigences officielles peuvent varier selon le pays, le programme et l'évolution des procédures.",
+        "primaryCta": "Réserver une orientation",
+        "secondaryCta": "Qualifier mon projet",
+        "audience": "Personnes visant les études ou le travail à l'étranger, porteurs d'opportunités d'affaires et structures qui ont un besoin d'orientation internationale.",
+        "challenge": "Vous devez clarifier les options, comprendre les démarches et préparer un projet cohérent avec votre profil.",
+        "deliverables": "Orientation stratégique, conseils sur les études et le travail à l'étranger, exploration d'opportunités d'affaires, politiques et stratégies d'immigration, préparation à l'intégration socio-professionnelle.",
+        "nextStep": "Réserver une consultation pour qualifier votre objectif, votre pays cible et les étapes préparatoires."
+      },
+      "business": {
+        "eyebrow": "Offres entreprises",
+        "title": "Des solutions ciblées pour le capital humain, la cohésion et la performance.",
+        "description": "Cette offre dédiée s'adresse aux structures qui veulent mieux recruter, mieux faire collaborer leurs équipes, renforcer leur leadership interne ou améliorer la performance organisationnelle.",
+        "primaryCta": "Partager un besoin entreprise",
+        "secondaryCta": "Demander une proposition",
+        "audience": "PME, startups, organisations, directions et fonctions RH.",
+        "challenge": "Vous avez besoin de mieux recruter, mieux intégrer, mieux faire collaborer ou faire progresser vos équipes.",
+        "deliverables": "Détection de talents, appui au recrutement, ateliers de développement professionnel, formation du personnel, leadership organisationnel, amélioration de la performance et cohésion d'équipe.",
+        "nextStep": "Exposer votre contexte pour recevoir une proposition sur mesure ou une intervention ciblée.",
+        "offers": {
+          "staffTraining": "Formation du personnel",
+          "teamCohesion": "Cohésion d'équipe",
+          "conflictManagement": "Gestion des conflits",
+          "organisationalLeadership": "Leadership organisationnel",
+          "businessPerformance": "Performance en entreprise",
+          "workplaceCulture": "Culture de travail et santé relationnelle"
+        }
+      },
+      "method": {
+        "title": "Notre méthode d'intervention",
+        "items": {
+          "clarify": {
+            "title": "Clarifier",
+            "description": "Nous partons du besoin réel, du niveau de maturité et de la décision à prendre."
+          },
+          "structure": {
+            "title": "Structurer",
+            "description": "Nous définissons le bon format, les livrables attendus et les priorités opérationnelles."
+          },
+          "advance": {
+            "title": "Avancer",
+            "description": "Nous mettons en mouvement la prochaine étape avec un cadre de suivi lisible."
+          }
+        }
+      },
+      "faq": {
+        "eyebrow": "Questions fréquentes",
+        "title": "Clarifiez le bon service avant de démarrer.",
+        "description": "KRAAK vous aide à traduire votre objectif en un format d'accompagnement clair, lisible et utile.",
+        "panelTitle": "Questions fréquentes",
+        "panelDescription": "Retrouvez ici les réponses rapides aux questions les plus posées sur nos parcours, nos modalités d'accompagnement et nos délais de réponse.",
+        "items": {
+          "serviceChoice": {
+            "question": "Comment choisir le service le plus adapté à mon objectif ?",
+            "answer": "Nous commençons par votre objectif principal, votre contexte et votre contrainte prioritaire. Si besoin, nous vous orientons vers la bonne combinaison entre formation, projet, immigration ou offre entreprise."
+          },
+          "initialGuidance": {
+            "question": "Proposez-vous une première orientation avant de démarrer ?",
+            "answer": "Oui. Une première consultation permet de clarifier le besoin, d'identifier le bon format et de définir la prochaine étape utile."
+          },
+          "organisationSupport": {
+            "question": "Les accompagnements sont-ils réservés aux particuliers ?",
+            "answer": "Non. KRAAK accompagne aussi les entreprises, startups, organisations et fonctions RH selon le type de besoin et le niveau de structuration attendu."
+          }
+        }
+      },
+      "closing": {
+        "title": "Choisissez le bon point d'entrée pour votre besoin.",
+        "description": "Une consultation suffit souvent à définir l'offre, le format et la prochaine étape les plus pertinents.",
+        "cta": "Réserver une consultation"
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/web/src/app/features/services/services.page.html
+++ b/apps/client/projects/web/src/app/features/services/services.page.html
@@ -15,20 +15,21 @@
       <p
         class="text-brand-cyan text-[11px] font-semibold tracking-[0.26em] uppercase sm:text-xs"
       >
-        Services KRAAK
+        {{ 'web.services.hero.eyebrow' | kraakTranslate }}
       </p>
       <h1
         class="text-brand-white mt-3 text-4xl leading-[1.08] font-black sm:mt-4 sm:text-5xl lg:text-6xl lg:leading-[1.04]"
       >
-        Des offres <span class="text-brand-cyan">claires</span> pour renforcer
-        les parcours, les projets et les organisations.
+        {{ 'web.services.hero.titlePrefix' | kraakTranslate }}
+        <span class="text-brand-cyan">{{
+          'web.services.hero.titleEmphasis' | kraakTranslate
+        }}</span>
+        {{ 'web.services.hero.titleSuffix' | kraakTranslate }}
       </h1>
       <p
         class="mt-6 max-w-2xl text-base leading-relaxed text-neutral-200 sm:mt-7 sm:text-lg lg:text-xl"
       >
-        KRAAK Consulting intervient à travers trois pôles complémentaires et une
-        offre dédiée aux entreprises. Chaque intervention part d'un besoin
-        concret, d'un cadre clair et d'une prochaine étape identifiable.
+        {{ 'web.services.hero.description' | kraakTranslate }}
       </p>
     </div>
   </div>
@@ -43,17 +44,13 @@
           aria-hidden="true"
         ></i>
         <p class="text-brand-navy-soft mt-4 text-sm font-semibold uppercase">
-          KRAAK Training Centre
+          {{ 'web.services.training.eyebrow' | kraakTranslate }}
         </p>
         <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-          Former des profils plus confiants, plus lisibles et plus prêts pour
-          l'emploi.
+          {{ 'web.services.training.title' | kraakTranslate }}
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
-          Ce pôle accompagne les jeunes, les étudiants et les jeunes
-          professionnels qui doivent clarifier leur trajectoire, renforcer leurs
-          outils de candidature et mieux se positionner sur le marché du
-          travail.
+          {{ 'web.services.training.description' | kraakTranslate }}
         </p>
         <div
           class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row"
@@ -61,19 +58,23 @@
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Demander un diagnostic"
+            [label]="'web.services.training.primaryCta' | kraakTranslate"
             icon="pi pi-comments"
             size="large"
-            aria-label="Demander un diagnostic"
+            [attr.aria-label]="
+              'web.services.training.primaryCta' | kraakTranslate
+            "
             class="kr-button-primary"
           ></a>
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Recevoir les formats"
+            [label]="'web.services.training.secondaryCta' | kraakTranslate"
             icon="pi pi-file"
             size="large"
-            aria-label="Recevoir les formats"
+            [attr.aria-label]="
+              'web.services.training.secondaryCta' | kraakTranslate
+            "
             class="kr-button-ghost"
           ></a>
         </div>
@@ -82,11 +83,10 @@
       <div class="grid gap-4 sm:grid-cols-2">
         <article class="rounded-card bg-neutral-50 p-5" kraakRevealOnScroll>
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Pour qui
+            {{ 'web.services.cardLabels.audience' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Jeunes, étudiants, jeunes professionnels, profils en
-            repositionnement ou en reconversion.
+            {{ 'web.services.training.audience' | kraakTranslate }}
           </p>
         </article>
         <article
@@ -96,30 +96,26 @@
           [revealDelayMobileMs]="25"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Problématique
+            {{ 'web.services.cardLabels.challenge' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Vous avez du potentiel mais devez clarifier votre projet, renforcer
-            vos outils de candidature et gagner en assurance.
+            {{ 'web.services.training.challenge' | kraakTranslate }}
           </p>
         </article>
         <article class="rounded-card bg-neutral-50 p-5 sm:col-span-2">
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Ce que nous livrons
+            {{ 'web.services.cardLabels.deliverables' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Orientation de carrière, CV et lettres en français et en anglais,
-            préparation aux entretiens, anglais / français professionnel,
-            ateliers de développement personnel et compétences transférables.
+            {{ 'web.services.training.deliverables' | kraakTranslate }}
           </p>
         </article>
         <article class="rounded-card bg-neutral-50 p-5 sm:col-span-2">
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Prochaine étape
+            {{ 'web.services.cardLabels.nextStep' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Réserver un diagnostic pour identifier le bon format : atelier
-            court, accompagnement ciblé ou programme plus complet.
+            {{ 'web.services.training.nextStep' | kraakTranslate }}
           </p>
         </article>
       </div>
@@ -127,22 +123,26 @@
 
     <div class="mt-8 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
       <p class="rounded-card bg-neutral-50 p-4 text-sm font-semibold">
-        Développement personnel et professionnel
+        {{
+          'web.services.training.offers.personalDevelopment' | kraakTranslate
+        }}
       </p>
       <p class="rounded-card bg-neutral-50 p-4 text-sm font-semibold">
-        Anglais / français professionnel
+        {{
+          'web.services.training.offers.professionalLanguages' | kraakTranslate
+        }}
       </p>
       <p class="rounded-card bg-neutral-50 p-4 text-sm font-semibold">
-        Préparation aux tests de langue
+        {{ 'web.services.training.offers.languageTests' | kraakTranslate }}
       </p>
       <p class="rounded-card bg-neutral-50 p-4 text-sm font-semibold">
-        Stratégies modernes de recherche d'emploi
+        {{ 'web.services.training.offers.jobSearch' | kraakTranslate }}
       </p>
       <p class="rounded-card bg-neutral-50 p-4 text-sm font-semibold">
-        Estime de soi et valorisation du potentiel
+        {{ 'web.services.training.offers.selfWorth' | kraakTranslate }}
       </p>
       <p class="rounded-card bg-neutral-50 p-4 text-sm font-semibold">
-        Reconversion professionnelle
+        {{ 'web.services.training.offers.careerChange' | kraakTranslate }}
       </p>
     </div>
   </div>
@@ -157,17 +157,13 @@
           aria-hidden="true"
         ></i>
         <p class="text-brand-navy-soft mt-4 text-sm font-semibold uppercase">
-          Centre de Recherche et d'Innovation
+          {{ 'web.services.projects.eyebrow' | kraakTranslate }}
         </p>
         <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-          Structurer une idée, mobiliser les bonnes ressources, faire avancer un
-          projet utile.
+          {{ 'web.services.projects.title' | kraakTranslate }}
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
-          Ce pôle accompagne les entreprises, startups, organisations et
-          porteurs de projets qui ont besoin de cadrage, de planification, de
-          partenariats ou d'un appui opérationnel pour passer d'une intention à
-          une trajectoire pilotable.
+          {{ 'web.services.projects.description' | kraakTranslate }}
         </p>
         <div
           class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row"
@@ -175,19 +171,23 @@
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Planifier un cadrage"
+            [label]="'web.services.projects.primaryCta' | kraakTranslate"
             icon="pi pi-rocket"
             size="large"
-            aria-label="Planifier un cadrage"
+            [attr.aria-label]="
+              'web.services.projects.primaryCta' | kraakTranslate
+            "
             class="kr-button-primary"
           ></a>
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Présenter mon besoin"
+            [label]="'web.services.projects.secondaryCta' | kraakTranslate"
             icon="pi pi-briefcase"
             size="large"
-            aria-label="Présenter mon besoin"
+            [attr.aria-label]="
+              'web.services.projects.secondaryCta' | kraakTranslate
+            "
             class="kr-button-ghost"
           ></a>
         </div>
@@ -199,11 +199,10 @@
           kraakRevealOnScroll
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Pour qui
+            {{ 'web.services.cardLabels.audience' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Entreprises, startups, organisations, associations et porteurs de
-            projets.
+            {{ 'web.services.projects.audience' | kraakTranslate }}
           </p>
         </article>
         <article
@@ -213,34 +212,30 @@
           [revealDelayMobileMs]="25"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Problématique
+            {{ 'web.services.cardLabels.challenge' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Vous devez passer d'une intention à un projet lisible, finançable,
-            pilotable ou recrutable.
+            {{ 'web.services.projects.challenge' | kraakTranslate }}
           </p>
         </article>
         <article
           class="rounded-card bg-brand-white p-5 shadow-sm sm:col-span-2"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Ce que nous livrons
+            {{ 'web.services.cardLabels.deliverables' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Cadrage et planification, développement de partenariats,
-            identification de talents, accompagnement d'entreprises et de
-            startups, préparation et placement en entreprise.
+            {{ 'web.services.projects.deliverables' | kraakTranslate }}
           </p>
         </article>
         <article
           class="rounded-card bg-brand-white p-5 shadow-sm sm:col-span-2"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Prochaine étape
+            {{ 'web.services.cardLabels.nextStep' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Partager votre besoin pour définir le périmètre, les priorités et le
-            type d'appui le plus utile.
+            {{ 'web.services.projects.nextStep' | kraakTranslate }}
           </p>
         </article>
       </div>
@@ -250,32 +245,34 @@
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Accompagnement d'entreprise et de startup
+        {{ 'web.services.projects.offers.businessSupport' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Gestion de projets
+        {{ 'web.services.projects.offers.projectManagement' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Développement de partenariats
+        {{
+          'web.services.projects.offers.partnershipDevelopment' | kraakTranslate
+        }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Identification et recrutement de talents
+        {{ 'web.services.projects.offers.talentRecruitment' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Préparation et placement en entreprise
+        {{ 'web.services.projects.offers.workplacePlacement' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Accompagnement opérationnel des initiatives
+        {{ 'web.services.projects.offers.operationalSupport' | kraakTranslate }}
       </p>
     </div>
   </div>
@@ -290,22 +287,19 @@
           aria-hidden="true"
         ></i>
         <p class="text-brand-navy-soft mt-4 text-sm font-semibold uppercase">
-          Centre de Conseils en Immigration
+          {{ 'web.services.mobility.eyebrow' | kraakTranslate }}
         </p>
         <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-          Études, travail et mobilité internationale préparés avec méthode.
+          {{ 'web.services.mobility.title' | kraakTranslate }}
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
-          Ce pôle accompagne les personnes et les organisations qui doivent
-          clarifier un projet international, comprendre les options disponibles
-          et préparer les étapes cohérentes selon le profil, l'objectif et la
-          destination.
+          {{ 'web.services.mobility.description' | kraakTranslate }}
         </p>
         <p class="rounded-card text-brand-navy mt-4 bg-neutral-50 p-5">
-          <strong>Note de conformité :</strong> les informations fournies dans
-          ce cadre servent à l'orientation et à la préparation du projet. Les
-          exigences officielles peuvent varier selon le pays, le programme et
-          l'évolution des procédures.
+          <strong>{{
+            'web.services.mobility.complianceLabel' | kraakTranslate
+          }}</strong>
+          {{ 'web.services.mobility.complianceBody' | kraakTranslate }}
         </p>
         <div
           class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row"
@@ -313,19 +307,23 @@
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Réserver une orientation"
+            [label]="'web.services.mobility.primaryCta' | kraakTranslate"
             icon="pi pi-calendar"
             size="large"
-            aria-label="Réserver une orientation"
+            [attr.aria-label]="
+              'web.services.mobility.primaryCta' | kraakTranslate
+            "
             class="kr-button-primary"
           ></a>
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Qualifier mon projet"
+            [label]="'web.services.mobility.secondaryCta' | kraakTranslate"
             icon="pi pi-send"
             size="large"
-            aria-label="Qualifier mon projet"
+            [attr.aria-label]="
+              'web.services.mobility.secondaryCta' | kraakTranslate
+            "
             class="kr-button-ghost"
           ></a>
         </div>
@@ -334,12 +332,10 @@
       <div class="grid gap-4 sm:grid-cols-2">
         <article class="rounded-card bg-neutral-50 p-5" kraakRevealOnScroll>
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Pour qui
+            {{ 'web.services.cardLabels.audience' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Personnes visant les études ou le travail à l'étranger, porteurs
-            d'opportunités d'affaires et structures qui ont un besoin
-            d'orientation internationale.
+            {{ 'web.services.mobility.audience' | kraakTranslate }}
           </p>
         </article>
         <article
@@ -349,31 +345,26 @@
           [revealDelayMobileMs]="25"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Problématique
+            {{ 'web.services.cardLabels.challenge' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Vous devez clarifier les options, comprendre les démarches et
-            préparer un projet cohérent avec votre profil.
+            {{ 'web.services.mobility.challenge' | kraakTranslate }}
           </p>
         </article>
         <article class="rounded-card bg-neutral-50 p-5 sm:col-span-2">
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Ce que nous livrons
+            {{ 'web.services.cardLabels.deliverables' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Orientation stratégique, conseils sur les études et le travail à
-            l'étranger, exploration d'opportunités d'affaires, politiques et
-            stratégies d'immigration, préparation à l'intégration
-            socio-professionnelle.
+            {{ 'web.services.mobility.deliverables' | kraakTranslate }}
           </p>
         </article>
         <article class="rounded-card bg-neutral-50 p-5 sm:col-span-2">
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Prochaine étape
+            {{ 'web.services.cardLabels.nextStep' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Réserver une consultation pour qualifier votre objectif, votre pays
-            cible et les étapes préparatoires.
+            {{ 'web.services.mobility.nextStep' | kraakTranslate }}
           </p>
         </article>
       </div>
@@ -390,16 +381,13 @@
           aria-hidden="true"
         ></i>
         <p class="text-brand-navy-soft mt-4 text-sm font-semibold uppercase">
-          Offres entreprises
+          {{ 'web.services.business.eyebrow' | kraakTranslate }}
         </p>
         <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-          Des solutions ciblées pour le capital humain, la cohésion et la
-          performance.
+          {{ 'web.services.business.title' | kraakTranslate }}
         </h2>
         <p class="text-brand-navy mt-4 text-lg">
-          Cette offre dédiée s'adresse aux structures qui veulent mieux
-          recruter, mieux faire collaborer leurs équipes, renforcer leur
-          leadership interne ou améliorer la performance organisationnelle.
+          {{ 'web.services.business.description' | kraakTranslate }}
         </p>
         <div
           class="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row"
@@ -407,19 +395,23 @@
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Partager un besoin entreprise"
+            [label]="'web.services.business.primaryCta' | kraakTranslate"
             icon="pi pi-building"
             size="large"
-            aria-label="Partager un besoin entreprise"
+            [attr.aria-label]="
+              'web.services.business.primaryCta' | kraakTranslate
+            "
             class="kr-button-primary"
           ></a>
           <a
             pButton
             [routerLink]="'contact' | localizedPublicPath"
-            label="Demander une proposition"
+            [label]="'web.services.business.secondaryCta' | kraakTranslate"
             icon="pi pi-cog"
             size="large"
-            aria-label="Demander une proposition"
+            [attr.aria-label]="
+              'web.services.business.secondaryCta' | kraakTranslate
+            "
             class="kr-button-secondary"
           ></a>
         </div>
@@ -428,43 +420,38 @@
       <div class="grid gap-4 sm:grid-cols-2">
         <article class="rounded-card bg-brand-white p-5 shadow-sm">
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Pour qui
+            {{ 'web.services.cardLabels.audience' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            PME, startups, organisations, directions et fonctions RH.
+            {{ 'web.services.business.audience' | kraakTranslate }}
           </p>
         </article>
         <article class="rounded-card bg-brand-white p-5 shadow-sm">
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Problématique
+            {{ 'web.services.cardLabels.challenge' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Vous avez besoin de mieux recruter, mieux intégrer, mieux faire
-            collaborer ou faire progresser vos équipes.
+            {{ 'web.services.business.challenge' | kraakTranslate }}
           </p>
         </article>
         <article
           class="rounded-card bg-brand-white p-5 shadow-sm sm:col-span-2"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Ce que nous livrons
+            {{ 'web.services.cardLabels.deliverables' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Détection de talents, appui au recrutement, ateliers de
-            développement professionnel, formation du personnel, leadership
-            organisationnel, amélioration de la performance et cohésion
-            d'équipe.
+            {{ 'web.services.business.deliverables' | kraakTranslate }}
           </p>
         </article>
         <article
           class="rounded-card bg-brand-white p-5 shadow-sm sm:col-span-2"
         >
           <p class="text-brand-navy-soft text-xs font-semibold uppercase">
-            Prochaine étape
+            {{ 'web.services.cardLabels.nextStep' | kraakTranslate }}
           </p>
           <p class="text-brand-navy mt-2 text-sm">
-            Exposer votre contexte pour recevoir une proposition sur mesure ou
-            une intervention ciblée.
+            {{ 'web.services.business.nextStep' | kraakTranslate }}
           </p>
         </article>
       </div>
@@ -474,32 +461,37 @@
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Formation du personnel
+        {{ 'web.services.business.offers.staffTraining' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Cohésion d'équipe
+        {{ 'web.services.business.offers.teamCohesion' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Gestion des conflits
+        {{ 'web.services.business.offers.conflictManagement' | kraakTranslate }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Leadership organisationnel
+        {{
+          'web.services.business.offers.organisationalLeadership'
+            | kraakTranslate
+        }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Performance en entreprise
+        {{
+          'web.services.business.offers.businessPerformance' | kraakTranslate
+        }}
       </p>
       <p
         class="rounded-card bg-brand-white p-4 text-sm font-semibold shadow-sm"
       >
-        Culture de travail et santé relationnelle
+        {{ 'web.services.business.offers.workplaceCulture' | kraakTranslate }}
       </p>
     </div>
   </div>
@@ -508,7 +500,7 @@
 <section class="bg-brand-white py-16">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Notre méthode d'intervention
+      {{ 'web.services.method.title' | kraakTranslate }}
     </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-3">
       <div
@@ -516,10 +508,11 @@
         class="services-method-step gsap-reversible-on-scroll text-center"
       >
         <p class="text-brand-navy-soft text-3xl font-bold">1</p>
-        <h3 class="mt-2 text-lg font-bold">Clarifier</h3>
+        <h3 class="mt-2 text-lg font-bold">
+          {{ 'web.services.method.items.clarify.title' | kraakTranslate }}
+        </h3>
         <p class="text-brand-navy mt-1">
-          Nous partons du besoin réel, du niveau de maturité et de la décision à
-          prendre.
+          {{ 'web.services.method.items.clarify.description' | kraakTranslate }}
         </p>
       </div>
       <div
@@ -527,10 +520,13 @@
         class="services-method-step gsap-reversible-on-scroll text-center"
       >
         <p class="text-brand-navy-soft text-3xl font-bold">2</p>
-        <h3 class="mt-2 text-lg font-bold">Structurer</h3>
+        <h3 class="mt-2 text-lg font-bold">
+          {{ 'web.services.method.items.structure.title' | kraakTranslate }}
+        </h3>
         <p class="text-brand-navy mt-1">
-          Nous définissons le bon format, les livrables attendus et les
-          priorités opérationnelles.
+          {{
+            'web.services.method.items.structure.description' | kraakTranslate
+          }}
         </p>
       </div>
       <div
@@ -538,10 +534,11 @@
         class="services-method-step gsap-reversible-on-scroll text-center"
       >
         <p class="text-brand-navy-soft text-3xl font-bold">3</p>
-        <h3 class="mt-2 text-lg font-bold">Avancer</h3>
+        <h3 class="mt-2 text-lg font-bold">
+          {{ 'web.services.method.items.advance.title' | kraakTranslate }}
+        </h3>
         <p class="text-brand-navy mt-1">
-          Nous mettons en mouvement la prochaine étape avec un cadre de suivi
-          lisible.
+          {{ 'web.services.method.items.advance.description' | kraakTranslate }}
         </p>
       </div>
     </div>
@@ -554,27 +551,31 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.18em] uppercase"
       >
-        Questions fréquentes
+        {{ 'web.services.faq.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Clarifiez le bon service avant de démarrer.
+        {{ 'web.services.faq.title' | kraakTranslate }}
       </h2>
       <p class="text-brand-navy mx-auto mt-4 max-w-3xl text-lg">
-        KRAAK vous aide à traduire votre objectif en un format d'accompagnement
-        clair, lisible et utile.
+        {{ 'web.services.faq.description' | kraakTranslate }}
       </p>
     </div>
 
     <div class="mt-10">
-      <kraak-faq-accordion [items]="faqItems" />
+      <kraak-faq-accordion
+        [items]="faqItems()"
+        [heading]="'web.services.faq.panelTitle' | kraakTranslate"
+        [description]="'web.services.faq.panelDescription' | kraakTranslate"
+        backgroundAlt=""
+      />
     </div>
   </div>
 </section>
 
 <kraak-cta-banner
-  heading="Choisissez le bon point d'entrée pour votre besoin."
-  body="Une consultation suffit souvent à définir l'offre, le format et la prochaine étape les plus pertinents."
-  ctaLabel="Réserver une consultation"
+  [heading]="'web.services.closing.title' | kraakTranslate"
+  [body]="'web.services.closing.description' | kraakTranslate"
+  [ctaLabel]="'web.services.closing.cta' | kraakTranslate"
   ctaLink="/contact"
   ctaContext="services_main_cta"
 />

--- a/apps/client/projects/web/src/app/features/services/services.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.spec.ts
@@ -1,14 +1,65 @@
+import { ApplicationInitStatus } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { Router, provideRouter } from '@angular/router';
+import { vi } from 'vitest';
+
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { AnalyticsService } from '../../core/analytics/analytics.service';
+import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
+import { FaqAccordion } from '../../shared/faq-accordion/faq-accordion.component';
 
 import ServicesPage from './services.page';
 
+function normalizedText(element: Element | null): string {
+  return (element?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+const gsapAnimationsServiceMock: Pick<
+  GsapAnimationsService,
+  | 'animatePageIn'
+  | 'initializeFigureAnimations'
+  | 'initializeInteractiveCardAnimations'
+  | 'initializeButtonTransitions'
+  | 'initializeIconAnimations'
+  | 'initializeReversibleScrollAnimations'
+  | 'killAllAnimations'
+> = {
+  animatePageIn: () => undefined,
+  initializeFigureAnimations: () => undefined,
+  initializeInteractiveCardAnimations: () => undefined,
+  initializeButtonTransitions: () => undefined,
+  initializeIconAnimations: () => undefined,
+  initializeReversibleScrollAnimations: () => undefined,
+  killAllAnimations: () => undefined,
+};
+
 describe('ServicesPage', () => {
+  let analyticsService: Pick<AnalyticsService, 'trackEvent'>;
+
   beforeEach(async () => {
+    analyticsService = {
+      trackEvent: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ServicesPage],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        provideKraakI18n(),
+        {
+          provide: AnalyticsService,
+          useValue: analyticsService,
+        },
+        {
+          provide: GsapAnimationsService,
+          useValue: gsapAnimationsServiceMock,
+        },
+      ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
   });
 
   it('Given the services page When the component is created Then the instance exists', () => {
@@ -24,6 +75,169 @@ describe('ServicesPage', () => {
       'Des offres claires pour renforcer les parcours, les projets et les organisations',
     );
   }, 45000);
+
+  it('Given the French Services route When the complete page renders Then representative source copy FAQ chrome and the localized CTA remain French', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(ServicesPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const content = normalizedText(page);
+    const finalCta = page.querySelector(
+      'kraak-cta-banner a',
+    ) as HTMLAnchorElement | null;
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      'Des offres claires pour renforcer les parcours, les projets et les organisations.',
+    );
+    expect(content).toContain('KRAAK Training Centre');
+    expect(content).toContain("Centre de Recherche et d'Innovation");
+    expect(content).toContain('Centre de Conseils en Immigration');
+    expect(content).toContain('Offres entreprises');
+    expect(content).toContain('Pour qui');
+    expect(content).toContain('Problématique');
+    expect(content).toContain('Ce que nous livrons');
+    expect(content).toContain('Prochaine étape');
+    expect(content).toContain("Notre méthode d'intervention");
+    expect(content).toContain('Clarifier');
+    expect(content).toContain('Structurer');
+    expect(content).toContain('Avancer');
+    expect(content).toContain('Questions fréquentes');
+    expect(content).toContain(
+      'Comment choisir le service le plus adapté à mon objectif ?',
+    );
+    expect(content).toContain(
+      "Choisissez le bon point d'entrée pour votre besoin.",
+    );
+    expect(finalCta?.textContent).toContain('Réserver une consultation');
+    expect(finalCta?.getAttribute('href')).toBe('/fr/contact');
+    expect(content).not.toContain('[missing:web.services.');
+  });
+
+  it('Given the English Services route When every service family method FAQ and CTA render Then all visitor-facing content comes from the English catalog', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/en/services',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ServicesPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const content = normalizedText(page);
+    const finalCta = page.querySelector(
+      'kraak-cta-banner a',
+    ) as HTMLAnchorElement | null;
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      'Clear solutions to strengthen careers, projects and organisations.',
+    );
+    expect(content).toContain('KRAAK Training Centre');
+    expect(content).toContain('Research and Innovation Centre');
+    expect(content).toContain('Immigration Advisory Centre');
+    expect(content).toContain('Business solutions');
+    expect(content).toContain('Who it is for');
+    expect(content).toContain('Your challenge');
+    expect(content).toContain('What we deliver');
+    expect(content).toContain('Next step');
+    expect(content).toContain(
+      'Help people present themselves with confidence, clarity and job-ready skills.',
+    );
+    expect(content).toContain('Business and start-up support');
+    expect(content).toContain(
+      'Prepare for international study, work and mobility with a clear method.',
+    );
+    expect(content).toContain(
+      'Workplace culture and healthy working relationships',
+    );
+    expect(content).toContain('Our approach');
+    expect(content).toContain('Clarify');
+    expect(content).toContain('Structure');
+    expect(content).toContain('Move forward');
+    expect(content).toContain('Frequently asked questions');
+    expect(content).toContain(
+      'How do I choose the service best suited to my goal?',
+    );
+    expect(content).toContain(
+      'Choose the right starting point for your needs.',
+    );
+    expect(finalCta?.textContent).toContain('Book a consultation');
+    expect(finalCta?.getAttribute('href')).toBe('/en/contact');
+    expect(content).not.toContain('Des offres claires');
+    expect(content).not.toContain('Pour qui');
+    expect(content).not.toContain('Questions fréquentes');
+    expect(content).not.toContain('[missing:web.services.');
+  });
+
+  it('Given one rendered French Services fixture When the locale changes to English Then FAQ inputs and shared card chrome react without recreating the page', async () => {
+    const i18n = TestBed.inject(KraakI18nService);
+    await i18n.setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(ServicesPage);
+    fixture.detectChanges();
+
+    const faqDebugElement = fixture.debugElement.query(
+      By.directive(FaqAccordion),
+    );
+    const faq = faqDebugElement.componentInstance as FaqAccordion;
+
+    expect(faq.heading).toBe('Questions fréquentes');
+    expect(faq.items[0]?.question).toBe(
+      'Comment choisir le service le plus adapté à mon objectif ?',
+    );
+    expect(normalizedText(fixture.nativeElement as HTMLElement)).toContain(
+      'Pour qui',
+    );
+
+    await i18n.setLocale('en-GB');
+    fixture.detectChanges();
+
+    const content = normalizedText(fixture.nativeElement as HTMLElement);
+
+    expect(faq.heading).toBe('Frequently asked questions');
+    expect(faq.description).toBe(
+      'Find quick answers to common questions about our services, support formats and response times.',
+    );
+    expect(faq.backgroundAlt).toBe('');
+    expect(faq.items[0]?.question).toBe(
+      'How do I choose the service best suited to my goal?',
+    );
+    expect(content).toContain('Who it is for');
+    expect(content).toContain('Your challenge');
+    expect(content).not.toContain('Pour qui');
+    expect(content).not.toContain(
+      'Comment choisir le service le plus adapté à mon objectif ?',
+    );
+    expect(content).not.toContain('[missing:web.services.');
+  });
+
+  it('Given the English Services CTA When its conversion handler runs Then analytics keeps a stable event and context with localized label and URL', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/en/services',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ServicesPage);
+    fixture.detectChanges();
+
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+
+    expect(cta.ctaLabel).toBe('Book a consultation');
+    expect(cta.ctaLink).toBe('/contact');
+
+    cta.onCtaClick();
+
+    expect(analyticsService.trackEvent).toHaveBeenCalledWith(
+      'conversion_cta_click',
+      {
+        cta_context: 'services_main_cta',
+        cta_label: 'Book a consultation',
+        cta_link: '/en/contact',
+      },
+    );
+  });
 
   it('Given the services page When it renders Then the four consulting service families are visible', () => {
     const fixture = TestBed.createComponent(ServicesPage);
@@ -51,7 +265,7 @@ describe('ServicesPage', () => {
     expect(element.textContent).toContain('Questions fréquentes');
   });
 
-  it('should render service-specific FAQ section', () => {
+  it('Given the services page When its FAQ renders Then the service-specific question is visible', () => {
     const fixture = TestBed.createComponent(ServicesPage);
     fixture.detectChanges();
     const content = fixture.nativeElement.textContent as string;

--- a/apps/client/projects/web/src/app/features/services/services.page.ts
+++ b/apps/client/projects/web/src/app/features/services/services.page.ts
@@ -1,6 +1,14 @@
-import { Component, Injector, OnDestroy, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  Injector,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+} from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
 
 import {
   initializeMarketingPageAnimations,
@@ -15,10 +23,29 @@ import {
   type FaqItem,
 } from '../../shared/faq-accordion/faq-accordion.component';
 import { LocalizedPublicPathPipe } from '../../routing/localized-public-path.pipe';
+import {
+  KraakI18nService,
+  KraakTranslatePipe,
+} from '../../../../../shared/i18n';
 
 const SERVICES_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/services-hero-project-planning.avif',
 );
+
+const SERVICES_FAQ_TRANSLATIONS = [
+  {
+    questionKey: 'web.services.faq.items.serviceChoice.question',
+    answerKey: 'web.services.faq.items.serviceChoice.answer',
+  },
+  {
+    questionKey: 'web.services.faq.items.initialGuidance.question',
+    answerKey: 'web.services.faq.items.initialGuidance.answer',
+  },
+  {
+    questionKey: 'web.services.faq.items.organisationSupport.question',
+    answerKey: 'web.services.faq.items.organisationSupport.answer',
+  },
+] as const;
 
 @Component({
   selector: 'kraak-services-page',
@@ -26,36 +53,31 @@ const SERVICES_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   imports: [
     NgStyle,
     RouterLink,
+    ButtonDirective,
     FaqAccordion,
     CtaBanner,
     RevealOnScrollDirective,
     LocalizedPublicPathPipe,
+    KraakTranslatePipe,
   ],
   templateUrl: './services.page.html',
 })
 export default class ServicesPage implements OnInit, OnDestroy {
   protected readonly heroBackgroundStyle = SERVICES_HERO_BACKGROUND_STYLE;
-  protected readonly faqItems: FaqItem[] = [
-    {
-      question: 'Comment choisir le service le plus adapté à mon objectif ?',
-      answer:
-        'Nous commençons par votre objectif principal, votre contexte et votre contrainte prioritaire. Si besoin, nous vous orientons vers la bonne combinaison entre formation, projet, immigration ou offre entreprise.',
-    },
-    {
-      question: 'Proposez-vous une première orientation avant de démarrer ?',
-      answer:
-        "Oui. Une première consultation permet de clarifier le besoin, d'identifier le bon format et de définir la prochaine étape utile.",
-    },
-    {
-      question: 'Les accompagnements sont-ils réservés aux particuliers ?',
-      answer:
-        'Non. KRAAK accompagne aussi les entreprises, startups, organisations et fonctions RH selon le type de besoin et le niveau de structuration attendu.',
-    },
-  ];
 
+  private readonly i18n = inject(KraakI18nService);
   private readonly injector = inject(Injector);
   private gsapService: GsapAnimationsService | null = null;
   private isDestroyed = false;
+
+  protected readonly faqItems = computed<readonly FaqItem[]>(() => {
+    this.i18n.locale();
+
+    return SERVICES_FAQ_TRANSLATIONS.map(({ questionKey, answerKey }) => ({
+      question: this.i18n.translate(questionKey),
+      answer: this.i18n.translate(answerKey),
+    }));
+  });
 
   ngOnInit(): void {
     void this.initializeAnimations();

--- a/apps/client/tests/e2e/i18n-services.spec.ts
+++ b/apps/client/tests/e2e/i18n-services.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test, type Page } from '@playwright/test';
+
+function getLanguageSelector(page: Page, accessibleName: RegExp) {
+  return page.getByRole('group', { name: accessibleName });
+}
+
+test.describe('Internationalisation publique de la page Services', () => {
+  test('Given la route /fr/services, When la page se charge, Then les quatre familles la méthode la FAQ et le CTA restent en français', async ({
+    page,
+  }) => {
+    await page.goto('/fr/services', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Des offres claires pour renforcer les parcours, les projets et les organisations.',
+      }),
+    ).toBeVisible();
+    await expect(page.locator('body')).toContainText('KRAAK Training Centre');
+    await expect(page.locator('body')).toContainText(
+      "Centre de Recherche et d'Innovation",
+    );
+    await expect(page.locator('body')).toContainText(
+      'Centre de Conseils en Immigration',
+    );
+    await expect(page.locator('body')).toContainText('Offres entreprises');
+    await expect(
+      page.getByRole('heading', { name: "Notre méthode d'intervention" }),
+    ).toBeVisible();
+    await expect(page.getByText('Clarifier', { exact: true })).toBeVisible();
+    await expect(page.getByText('Structurer', { exact: true })).toBeVisible();
+    await expect(page.getByText('Avancer', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(
+        'Comment choisir le service le plus adapté à mon objectif ?',
+        { exact: true },
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', {
+        name: 'Réserver une consultation',
+        exact: true,
+      }),
+    ).toHaveAttribute('href', '/fr/contact');
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText(
+      '[missing:web.services.',
+    );
+  });
+
+  test('Given la route /en/services, When every section renders, Then all service families method FAQ CTAs and accessible copy are English while SEO stays noindex', async ({
+    page,
+  }) => {
+    await page.goto('/en/services', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Clear solutions to strengthen careers, projects and organisations.',
+      }),
+    ).toBeVisible();
+    await expect(page.locator('body')).toContainText('KRAAK Training Centre');
+    await expect(page.locator('body')).toContainText(
+      'Research and Innovation Centre',
+    );
+    await expect(page.locator('body')).toContainText(
+      'Immigration Advisory Centre',
+    );
+    await expect(page.locator('body')).toContainText('Business solutions');
+    await expect(page.locator('body')).toContainText('Who it is for');
+    await expect(page.locator('body')).toContainText('Your challenge');
+    await expect(page.locator('body')).toContainText('What we deliver');
+    await expect(page.locator('body')).toContainText('Next step');
+    await expect(
+      page.getByRole('heading', { name: 'Our approach' }),
+    ).toBeVisible();
+    await expect(page.getByText('Clarify', { exact: true })).toBeVisible();
+    await expect(page.getByText('Structure', { exact: true })).toBeVisible();
+    await expect(page.getByText('Move forward', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText('How do I choose the service best suited to my goal?', {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(page.locator('kraak-faq-accordion img[alt=""]')).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Book a consultation', exact: true }),
+    ).toHaveAttribute('href', '/en/contact');
+    await expect(page.locator('main a[href="/en/contact"]')).toHaveCount(9);
+    await expect(page.locator('body')).not.toContainText('Des offres claires');
+    await expect(page.locator('body')).not.toContainText('Pour qui');
+    await expect(page.locator('body')).not.toContainText(
+      'Questions fréquentes',
+    );
+    await expect(page.locator('body')).not.toContainText(
+      '[missing:web.services.',
+    );
+
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex, nofollow',
+    );
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="x-default"]'),
+    ).toHaveAttribute('href', /\/fr\/services$/);
+
+    const sitemapResponse = await page.request.get('/sitemap.xml');
+    expect(sitemapResponse.ok()).toBe(true);
+    const sitemap = await sitemapResponse.text();
+    expect(sitemap).toContain('/fr/services');
+    expect(sitemap).not.toContain('/en/services');
+  });
+
+  test('Given the English Services final CTA, When it is activated with the keyboard, Then it opens the localized Contact route', async ({
+    page,
+  }) => {
+    await page.goto('/en/services');
+
+    const consultationLink = page.getByRole('link', {
+      name: 'Book a consultation',
+      exact: true,
+    });
+    await expect(consultationLink).toBeVisible();
+    await consultationLink.focus();
+    await expect(consultationLink).toBeFocused();
+
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/en\/contact$/);
+  });
+
+  test('Given the French Services route with query and fragment, When the visitor switches to English, Then the equivalent route state and English content are preserved', async ({
+    page,
+  }) => {
+    await page.goto('/fr/services?campaign=services#method', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const englishLink = getLanguageSelector(page, /langue|language/i).getByRole(
+      'link',
+      { name: /anglais|english/i },
+    );
+    await englishLink.click();
+
+    await expect(page).toHaveURL(/\/en\/services\?campaign=services#method$/);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Clear solutions to strengthen careers, projects and organisations.',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('How do I choose the service best suited to my goal?', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+});

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -34,17 +34,17 @@ Le site web KRAAK est l'application Angular publique située dans
   et la barre de navigation forment le premier incrément public bilingue. La
   coque publique partagée (pied de page, lien d'accès rapide et commande de
   retour en haut) forme le deuxième incrément. La page Contact constitue le
-  troisième incrément localisé. Les autres pages `/en/...` restent un scaffold
-  technique non indexable tant que leurs contenus anglais ne sont pas traduits
-  et relus.
+  troisième incrément localisé et la page Services le quatrième. Les autres
+  pages `/en/...` restent un scaffold technique non indexable tant que leurs
+  contenus anglais ne sont pas traduits et relus.
 
 ## Implémentation active
 
 - Routes publiques : [`../../apps/client/projects/web/src/app/app.routes.ts`](../../apps/client/projects/web/src/app/app.routes.ts).
 - Prerender public : [`../../apps/client/projects/web/src/app/app.routes.server.ts`](../../apps/client/projects/web/src/app/app.routes.server.ts).
 - Catalogues runtime : [`../../apps/client/projects/shared/i18n/catalogs/`](../../apps/client/projects/shared/i18n/catalogs/),
-  avec les espaces de clés `web.home`, `web.nav`, `web.shell` et
-  `web.contact` pour les incréments publics bilingues livrés.
+  avec les espaces de clés `web.home`, `web.nav`, `web.shell`, `web.contact` et
+  `web.services` pour les incréments publics bilingues livrés.
 - Tests de surface : [`../../apps/client/projects/web/src/app/app.routes.spec.ts`](../../apps/client/projects/web/src/app/app.routes.spec.ts)
   et [`../../apps/client/projects/web/src/app/app.routes.server.spec.ts`](../../apps/client/projects/web/src/app/app.routes.server.spec.ts).
 - Historique design : [`../archive/vitrine-design/`](../archive/vitrine-design/),
@@ -61,17 +61,22 @@ Le prerender, les métadonnées SEO, les canonicals, les liens `hreflang`, les
 entrées sitemap et l'attribut `<html lang>` sont générés par locale depuis le
 modèle de routes web localisées.
 
-La page d'accueil, la barre de navigation, la coque publique partagée et la page
-Contact servent désormais leur contenu français ou anglais depuis les catalogues
-selon la locale de l'URL. Un sélecteur de langue relie les variantes d'une même
-page publique lorsque le mapping existe, puis revient à la page d'accueil de la
-langue cible lorsqu'aucune variante publique n'est disponible.
+La page d'accueil, la barre de navigation, la coque publique partagée, la page
+Contact et la page Services servent désormais leur contenu français ou anglais
+depuis les catalogues selon la locale de l'URL. Un sélecteur de langue relie les
+variantes d'une même page publique lorsque le mapping existe, puis revient à la
+page d'accueil de la langue cible lorsqu'aucune variante publique n'est
+disponible.
 
 Les prochaines pages de conversion doivent être localisées séparément, avec une
-seule page par PR, dans cet ordre : Services, Programmes, puis À propos.
-L'activation de l'indexation anglaise, des entrées sitemap et des liens
-`hreflang` réciproques reste conditionnée à une revue humaine du contenu anglais
-de chaque page.
+seule page par PR, dans cet ordre : Programmes, puis À propos. L'activation de
+l'indexation anglaise, des entrées sitemap et des liens `hreflang` réciproques
+reste conditionnée à une revue humaine du contenu anglais de chaque page.
+
+La copie anglaise de Services est proposée mais n'a pas encore reçu cette revue
+humaine. En conséquence, `/en/services` reste `noindex, nofollow`, hors du
+sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis
+`/fr/services`.
 
 Ces incréments de contenu ne modifient pas encore la politique SEO du scaffold
 anglais : les routes anglaises restent `noindex, nofollow`, exclues


### PR DESCRIPTION
## Résumé

- sert les quatre familles de services, la méthode, la FAQ et les CTA depuis les catalogues `fr-CI` et `en-GB`
- rend la FAQ réactive lors d’un changement de locale dans la même page
- localise les libellés visibles, noms accessibles, liens et données analytics des CTA sans modifier leurs identifiants techniques
- marque l’image de fond FAQ comme décorative
- ajoute des tests Given/When/Then unitaires et Playwright sur Chromium, Firefox et WebKit
- documente Services comme quatrième incrément i18n public

## Validation

- `pnpm.cmd i18n:check` — 283 clés symétriques
- `pnpm.cmd typecheck:web`
- tests web complets : 680/680
- tests mobile complets : 253/253
- intégration API : 31/31
- tests Services ciblés : 9/9
- Playwright Services : 12/12 sur les trois navigateurs
- `pnpm.cmd build:web` — 26 routes pré-rendues
- ESLint, Prettier, markdownlint et `git diff --check`

## Garde-fou SEO

La copie anglaise proposée n’a pas encore reçu de revue humaine. `/en/services` reste donc en `noindex, nofollow`, hors sitemap et sans hreflang anglais réciproque.

Closes #644