### PR TITLE
feat(web): localiser la page Programmes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,14 +62,16 @@ page d'accueil et la barre de navigation constituent le premier incrément publi
 entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. La coque
 publique partagée constitue le deuxième incrément et la page Contact le
 troisième. La page Services constitue le quatrième incrément public localisé.
-Sa copie anglaise est proposée mais n'a pas encore reçu de revue humaine :
-`/en/services` reste donc `noindex, nofollow`, hors du sitemap et sans lien
-`hreflang="en-GB"` réciproque. Les pages Programmes puis À propos seront
-localisées dans des PR distinctes. Les autres pages publiques anglaises et leurs
-métadonnées SEO restent dans l'état de scaffold non indexable jusqu'à leur
-traduction et leur revue humaine dédiées. L'indexation anglaise, les entrées
-sitemap et les liens `hreflang` réciproques ne sont activés qu'après cette revue
-pour chaque page.
+La page Programmes constitue le cinquième. Les copies anglaises proposées de
+Services et de Programmes n'ont pas encore reçu de revue humaine :
+`/en/services` et `/en/programs` restent donc `noindex, nofollow`, hors du
+sitemap et sans lien `hreflang="en-GB"` réciproque depuis leur page française.
+Parmi les pages de conversion de cette série, seule la page À propos reste à
+localiser dans une PR distincte. Les autres pages publiques anglaises et leurs
+métadonnées SEO restent dans l'état de scaffold non
+indexable jusqu'à leur traduction et leur revue humaine dédiées. L'indexation
+anglaise, les entrées sitemap et les liens `hreflang` réciproques ne sont activés
+qu'après cette revue pour chaque page.
 
 Les incréments suivants doivent rester courts, documentés et validés sans
 localiser implicitement les routes privées, admin ou mobiles.

--- a/apps/client/projects/shared/i18n/catalogs/en-GB.json
+++ b/apps/client/projects/shared/i18n/catalogs/en-GB.json
@@ -451,6 +451,99 @@
         "description": "One consultation is often enough to identify the most relevant offer, format and next step.",
         "cta": "Book a consultation"
       }
+    },
+    "programs": {
+      "hero": {
+        "eyebrow": "KRAAK programmes",
+        "titlePrefix": "Guidance first. The",
+        "titleHighlight": "right format",
+        "titleSuffix": "follows.",
+        "description": "Our detailed public catalogue is currently being finalised. For now, KRAAK guides each enquiry towards the right format based on the goal, profile, country involved and the availability of cohorts or partners."
+      },
+      "formats": {
+        "eyebrow": "Formats currently offered",
+        "title": "What we can already recommend with confidence.",
+        "description": "Here are the formats we already offer. Detailed titles, schedules and exact arrangements are confirmed after a guidance conversation.",
+        "items": {
+          "employability": {
+            "title": "Employability and professional presence workshops",
+            "format": "Format: short workshop or mini-programme.",
+            "audience": "Audience: young people, students and early-career professionals.",
+            "cadence": "Schedule: one-off sessions or cohorts, depending on the calendar."
+          },
+          "languagePreparation": {
+            "title": "Language preparation and language testing",
+            "format": "Format: targeted support or a workshop.",
+            "audience": "Audience: people preparing for work, study or mobility.",
+            "cadence": "Schedule: based on level, goal and availability."
+          },
+          "internationalMobility": {
+            "title": "Guidance for study, work and international mobility",
+            "format": "Format: guidance consultation and preparation.",
+            "audience": "Audience: people pursuing an international plan.",
+            "cadence": "Schedule: by appointment or as part of a support cohort."
+          },
+          "collectiveInterventions": {
+            "title": "Group sessions for schools, associations and businesses",
+            "format": "Format: conference, forum, workshop or tailored module.",
+            "audience": "Audience: educational, community or professional organisations.",
+            "cadence": "Schedule: on request or through a partnership."
+          }
+        }
+      },
+      "catalog": {
+        "eyebrow": "Public catalogue",
+        "title": "What we confirm after your guidance conversation.",
+        "description": "To be transparent about our offer, we do not yet publish a fixed catalogue with every detail. The guidance stage allows us to confirm the right information at the right time.",
+        "items": {
+          "exactTitle": {
+            "title": "Exact title",
+            "description": "The specific format or programme that matches your needs."
+          },
+          "schedule": {
+            "title": "Schedule",
+            "description": "Upcoming dates, cohorts or available delivery windows."
+          },
+          "eligibility": {
+            "title": "Eligibility",
+            "description": "Prerequisites, intended audience and expected level of support."
+          },
+          "arrangements": {
+            "title": "Practical arrangements",
+            "description": "Pace, setting, useful documents and practical requirements."
+          }
+        }
+      },
+      "process": {
+        "title": "How do you find the right programme?",
+        "steps": {
+          "contactRequest": {
+            "title": "Contact request",
+            "description": "Tell us your goal, your country and the type of need you want to clarify."
+          },
+          "guidanceConversation": {
+            "title": "Guidance conversation",
+            "description": "A short conversation helps us understand your situation and identify the right level of support."
+          },
+          "formatProposal": {
+            "title": "Format recommendation",
+            "description": "We guide you towards a workshop, cohort, consultation or group session."
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "description": "You receive the practical details you need to confirm your place or next step."
+          }
+        }
+      },
+      "reassurance": {
+        "title": "You should not have to choose alone from an unfinished catalogue.",
+        "description": "The right programme often depends on your goal, schedule, level of preparation and the context of your project. We take responsibility for guiding you so that you receive useful information, not a vague list."
+      },
+      "cta": {
+        "heading": "Ask KRAAK for guidance.",
+        "body": "Tell us your goal and we will recommend the most suitable format, pace and next step.",
+        "label": "Request guidance"
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/shared/i18n/catalogs/fr-CI.json
+++ b/apps/client/projects/shared/i18n/catalogs/fr-CI.json
@@ -451,6 +451,99 @@
         "description": "Une consultation suffit souvent à définir l'offre, le format et la prochaine étape les plus pertinents.",
         "cta": "Réserver une consultation"
       }
+    },
+    "programs": {
+      "hero": {
+        "eyebrow": "Programmes KRAAK",
+        "titlePrefix": "Orientation d'abord, format",
+        "titleHighlight": "adapté",
+        "titleSuffix": "ensuite.",
+        "description": "Le catalogue public détaillé est en cours de finalisation. Aujourd'hui, KRAAK oriente chaque demande vers le bon format selon l'objectif, le profil, le pays concerné et la disponibilité des cohortes ou des partenaires."
+      },
+      "formats": {
+        "eyebrow": "Formats actuellement proposés",
+        "title": "Ce que nous pouvons déjà orienter avec clarté.",
+        "description": "Nous publions ici les formats que nous activons déjà. Les intitulés détaillés, calendriers et modalités exactes sont confirmés après orientation.",
+        "items": {
+          "employability": {
+            "title": "Ateliers d'employabilité et de posture professionnelle",
+            "format": "Format : atelier court ou mini-parcours.",
+            "audience": "Public : jeunes, étudiants, jeunes professionnels.",
+            "cadence": "Cadence : sessions ponctuelles ou cohortes selon calendrier."
+          },
+          "languagePreparation": {
+            "title": "Préparation linguistique et tests de langue",
+            "format": "Format : accompagnement ciblé ou atelier.",
+            "audience": "Public : profils visant emploi, études ou mobilité.",
+            "cadence": "Cadence : selon niveau, objectif et disponibilité."
+          },
+          "internationalMobility": {
+            "title": "Orientation études, travail et mobilité internationale",
+            "format": "Format : consultation d'orientation et préparation.",
+            "audience": "Public : candidats à un projet international.",
+            "cadence": "Cadence : sur rendez-vous ou selon cohorte d'accompagnement."
+          },
+          "collectiveInterventions": {
+            "title": "Interventions collectives pour écoles, associations et entreprises",
+            "format": "Format : conférence, forum, atelier ou module sur mesure.",
+            "audience": "Public : structures éducatives, communautaires ou professionnelles.",
+            "cadence": "Cadence : sur demande ou via partenariat."
+          }
+        }
+      },
+      "catalog": {
+        "eyebrow": "Catalogue public",
+        "title": "Ce que nous confirmons après orientation.",
+        "description": "Pour rester honnêtes sur l'offre, nous ne publions pas encore un catalogue figé avec tous les détails. L'orientation permet de confirmer les bonnes informations au bon moment.",
+        "items": {
+          "exactTitle": {
+            "title": "Intitulé exact",
+            "description": "Le format ou le programme précis correspondant à votre besoin."
+          },
+          "schedule": {
+            "title": "Calendrier",
+            "description": "Les prochaines dates, cohortes ou fenêtres d'intervention disponibles."
+          },
+          "eligibility": {
+            "title": "Éligibilité",
+            "description": "Les prérequis, le public visé et le niveau d'appui attendu."
+          },
+          "arrangements": {
+            "title": "Modalités",
+            "description": "Le rythme, le cadre, les documents utiles et les conditions pratiques."
+          }
+        }
+      },
+      "process": {
+        "title": "Comment être orienté vers le bon programme ?",
+        "steps": {
+          "contactRequest": {
+            "title": "Demande de contact",
+            "description": "Dites-nous votre objectif, votre pays et le type de besoin que vous cherchez à clarifier."
+          },
+          "guidanceConversation": {
+            "title": "Entretien d'orientation",
+            "description": "Un échange rapide permet de qualifier votre situation et le bon niveau d'appui."
+          },
+          "formatProposal": {
+            "title": "Proposition de format",
+            "description": "Nous vous orientons vers un atelier, une cohorte, une consultation ou une intervention collective."
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "description": "Vous recevez les modalités utiles pour confirmer votre place ou votre prochaine étape."
+          }
+        }
+      },
+      "reassurance": {
+        "title": "Vous n'avez pas à choisir seul dans un catalogue inachevé.",
+        "description": "Le bon programme dépend souvent de votre objectif, de votre calendrier, de votre niveau de préparation et du cadre de votre projet. Nous assumons cette posture d'orientation pour vous donner une information utile, pas une liste floue."
+      },
+      "cta": {
+        "heading": "Demandez une orientation KRAAK.",
+        "body": "Expliquez votre objectif et nous vous dirons quel format, quel rythme et quelle prochaine étape sont les plus pertinents.",
+        "label": "Demander une orientation"
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/web/src/app/features/programs/programs.page.html
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.html
@@ -15,21 +15,21 @@
       <p
         class="text-brand-cyan text-[11px] font-semibold tracking-[0.26em] uppercase sm:text-xs"
       >
-        Programmes KRAAK
+        {{ 'web.programs.hero.eyebrow' | kraakTranslate }}
       </p>
       <h1
         class="text-brand-white mt-3 text-4xl leading-[1.08] font-black sm:mt-4 sm:text-5xl lg:text-6xl lg:leading-[1.04]"
       >
-        Orientation d'abord, format
-        <span class="text-brand-cyan">adapté</span> ensuite.
+        {{ 'web.programs.hero.titlePrefix' | kraakTranslate }}
+        <span class="text-brand-cyan">
+          {{ 'web.programs.hero.titleHighlight' | kraakTranslate }}
+        </span>
+        {{ 'web.programs.hero.titleSuffix' | kraakTranslate }}
       </h1>
       <p
         class="mt-6 max-w-2xl text-base leading-relaxed text-neutral-200 sm:mt-7 sm:text-lg lg:text-xl"
       >
-        Le catalogue public détaillé est en cours de finalisation. Aujourd'hui,
-        KRAAK oriente chaque demande vers le bon format selon l'objectif, le
-        profil, le pays concerné et la disponibilité des cohortes ou des
-        partenaires.
+        {{ 'web.programs.hero.description' | kraakTranslate }}
       </p>
     </div>
   </div>
@@ -41,106 +41,41 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.18em] uppercase"
       >
-        Formats actuellement proposés
+        {{ 'web.programs.formats.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Ce que nous pouvons déjà orienter avec clarté.
+        {{ 'web.programs.formats.title' | kraakTranslate }}
       </h2>
       <p class="text-brand-navy mt-4 text-lg">
-        Nous publions ici les formats que nous activons déjà. Les intitulés
-        détaillés, calendriers et modalités exactes sont confirmés après
-        orientation.
+        {{ 'web.programs.formats.description' | kraakTranslate }}
       </p>
     </div>
 
     <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-      <article
-        data-motion="reversible"
-        class="gsap-reversible-on-scroll rounded-card shadow-card bg-neutral-50 p-6"
-      >
-        <i
-          class="pi pi-briefcase text-brand-navy-soft text-3xl"
-          aria-hidden="true"
-        ></i>
-        <h2 class="mt-4 text-xl font-bold">
-          Ateliers d'employabilité et de posture professionnelle
-        </h2>
-        <p class="text-brand-navy mt-3 text-sm">
-          Format : atelier court ou mini-parcours.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Public : jeunes, étudiants, jeunes professionnels.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Cadence : sessions ponctuelles ou cohortes selon calendrier.
-        </p>
-      </article>
-
-      <article
-        data-motion="reversible"
-        class="gsap-reversible-on-scroll rounded-card shadow-card bg-neutral-50 p-6"
-      >
-        <i
-          class="pi pi-language text-brand-navy-soft text-3xl"
-          aria-hidden="true"
-        ></i>
-        <h2 class="mt-4 text-xl font-bold">
-          Préparation linguistique et tests de langue
-        </h2>
-        <p class="text-brand-navy mt-3 text-sm">
-          Format : accompagnement ciblé ou atelier.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Public : profils visant emploi, études ou mobilité.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Cadence : selon niveau, objectif et disponibilité.
-        </p>
-      </article>
-
-      <article
-        data-motion="reversible"
-        class="gsap-reversible-on-scroll rounded-card shadow-card bg-neutral-50 p-6"
-      >
-        <i
-          class="pi pi-globe text-brand-navy-soft text-3xl"
-          aria-hidden="true"
-        ></i>
-        <h2 class="mt-4 text-xl font-bold">
-          Orientation études, travail et mobilité internationale
-        </h2>
-        <p class="text-brand-navy mt-3 text-sm">
-          Format : consultation d'orientation et préparation.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Public : candidats à un projet international.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Cadence : sur rendez-vous ou selon cohorte d'accompagnement.
-        </p>
-      </article>
-
-      <article
-        data-motion="reversible"
-        class="gsap-reversible-on-scroll rounded-card shadow-card bg-neutral-50 p-6"
-      >
-        <i
-          class="pi pi-users text-brand-navy-soft text-3xl"
-          aria-hidden="true"
-        ></i>
-        <h2 class="mt-4 text-xl font-bold">
-          Interventions collectives pour écoles, associations et entreprises
-        </h2>
-        <p class="text-brand-navy mt-3 text-sm">
-          Format : conférence, forum, atelier ou module sur mesure.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Public : structures éducatives, communautaires ou professionnelles.
-        </p>
-        <p class="text-brand-navy mt-2 text-sm">
-          Cadence : sur demande ou via partenariat.
-        </p>
-      </article>
+      @for (programFormat of programFormats; track programFormat.titleKey) {
+        <article
+          data-motion="reversible"
+          class="gsap-reversible-on-scroll rounded-card shadow-card bg-neutral-50 p-6"
+        >
+          <i
+            class="pi text-brand-navy-soft text-3xl"
+            [ngClass]="programFormat.iconClass"
+            aria-hidden="true"
+          ></i>
+          <h2 class="mt-4 text-xl font-bold">
+            {{ programFormat.titleKey | kraakTranslate }}
+          </h2>
+          <p class="text-brand-navy mt-3 text-sm">
+            {{ programFormat.formatKey | kraakTranslate }}
+          </p>
+          <p class="text-brand-navy mt-2 text-sm">
+            {{ programFormat.audienceKey | kraakTranslate }}
+          </p>
+          <p class="text-brand-navy mt-2 text-sm">
+            {{ programFormat.cadenceKey | kraakTranslate }}
+          </p>
+        </article>
+      }
     </div>
   </div>
 </section>
@@ -151,45 +86,27 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.18em] uppercase"
       >
-        Catalogue public
+        {{ 'web.programs.catalog.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Ce que nous confirmons après orientation.
+        {{ 'web.programs.catalog.title' | kraakTranslate }}
       </h2>
       <p class="text-brand-navy mt-4 text-lg">
-        Pour rester honnêtes sur l'offre, nous ne publions pas encore un
-        catalogue figé avec tous les détails. L'orientation permet de confirmer
-        les bonnes informations au bon moment.
+        {{ 'web.programs.catalog.description' | kraakTranslate }}
       </p>
     </div>
 
     <div class="mt-10 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">
-          Intitulé exact
-        </p>
-        <p class="text-brand-navy mt-3 text-sm">
-          Le format ou le programme précis correspondant à votre besoin.
-        </p>
-      </article>
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">Calendrier</p>
-        <p class="text-brand-navy mt-3 text-sm">
-          Les prochaines dates, cohortes ou fenêtres d'intervention disponibles.
-        </p>
-      </article>
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">Éligibilité</p>
-        <p class="text-brand-navy mt-3 text-sm">
-          Les prérequis, le public visé et le niveau d'appui attendu.
-        </p>
-      </article>
-      <article class="rounded-card bg-brand-white p-6 shadow-sm">
-        <p class="text-primary text-sm font-semibold uppercase">Modalités</p>
-        <p class="text-brand-navy mt-3 text-sm">
-          Le rythme, le cadre, les documents utiles et les conditions pratiques.
-        </p>
-      </article>
+      @for (catalogItem of catalogItems; track catalogItem.titleKey) {
+        <article class="rounded-card bg-brand-white p-6 shadow-sm">
+          <p class="text-primary text-sm font-semibold uppercase">
+            {{ catalogItem.titleKey | kraakTranslate }}
+          </p>
+          <p class="text-brand-navy mt-3 text-sm">
+            {{ catalogItem.descriptionKey | kraakTranslate }}
+          </p>
+        </article>
+      }
     </div>
   </div>
 </section>
@@ -197,41 +114,22 @@
 <section class="bg-brand-white py-16" kraakRevealOnScroll [revealDelayMs]="80">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
     <h2 class="text-center text-3xl font-bold lg:text-4xl">
-      Comment être orienté vers le bon programme ?
+      {{ 'web.programs.process.title' | kraakTranslate }}
     </h2>
     <div class="mt-10 grid gap-8 md:grid-cols-4">
-      <div class="text-center">
-        <p class="text-brand-navy-soft text-3xl font-bold">1</p>
-        <h3 class="mt-2 text-lg font-bold">Demande de contact</h3>
-        <p class="text-brand-navy mt-1">
-          Dites-nous votre objectif, votre pays et le type de besoin que vous
-          cherchez à clarifier.
-        </p>
-      </div>
-      <div class="text-center">
-        <p class="text-brand-navy-soft text-3xl font-bold">2</p>
-        <h3 class="mt-2 text-lg font-bold">Entretien d'orientation</h3>
-        <p class="text-brand-navy mt-1">
-          Un échange rapide permet de qualifier votre situation et le bon niveau
-          d'appui.
-        </p>
-      </div>
-      <div class="text-center">
-        <p class="text-brand-navy-soft text-3xl font-bold">3</p>
-        <h3 class="mt-2 text-lg font-bold">Proposition de format</h3>
-        <p class="text-brand-navy mt-1">
-          Nous vous orientons vers un atelier, une cohorte, une consultation ou
-          une intervention collective.
-        </p>
-      </div>
-      <div class="text-center">
-        <p class="text-brand-navy-soft text-3xl font-bold">4</p>
-        <h3 class="mt-2 text-lg font-bold">Confirmation</h3>
-        <p class="text-brand-navy mt-1">
-          Vous recevez les modalités utiles pour confirmer votre place ou votre
-          prochaine étape.
-        </p>
-      </div>
+      @for (processStep of processSteps; track processStep.step) {
+        <div class="text-center">
+          <p class="text-brand-navy-soft text-3xl font-bold">
+            {{ processStep.step }}
+          </p>
+          <h3 class="mt-2 text-lg font-bold">
+            {{ processStep.titleKey | kraakTranslate }}
+          </h3>
+          <p class="text-brand-navy mt-1">
+            {{ processStep.descriptionKey | kraakTranslate }}
+          </p>
+        </div>
+      }
     </div>
   </div>
 </section>
@@ -239,21 +137,18 @@
 <section class="bg-brand-white py-16" kraakRevealOnScroll [revealDelayMs]="100">
   <div class="mx-auto max-w-4xl px-4 text-center lg:px-6">
     <h2 class="text-3xl font-bold lg:text-4xl">
-      Vous n'avez pas à choisir seul dans un catalogue inachevé.
+      {{ 'web.programs.reassurance.title' | kraakTranslate }}
     </h2>
     <p class="text-brand-navy mt-4">
-      Le bon programme dépend souvent de votre objectif, de votre calendrier, de
-      votre niveau de préparation et du cadre de votre projet. Nous assumons
-      cette posture d'orientation pour vous donner une information utile, pas
-      une liste floue.
+      {{ 'web.programs.reassurance.description' | kraakTranslate }}
     </p>
   </div>
 </section>
 
 <kraak-cta-banner
-  heading="Demandez une orientation KRAAK."
-  body="Expliquez votre objectif et nous vous dirons quel format, quel rythme et quelle prochaine étape sont les plus pertinents."
-  ctaLabel="Demander une orientation"
+  [heading]="'web.programs.cta.heading' | kraakTranslate"
+  [body]="'web.programs.cta.body' | kraakTranslate"
+  [ctaLabel]="'web.programs.cta.label' | kraakTranslate"
   ctaLink="/contact"
   ctaContext="programs_main_cta"
 />

--- a/apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.spec.ts
@@ -1,69 +1,377 @@
+import { ApplicationInitStatus } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { Router, provideRouter } from '@angular/router';
+import { vi } from 'vitest';
+
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { AnalyticsService } from '../../core/analytics/analytics.service';
+import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
+
 import ProgramsPage from './programs.page';
 
+const FRENCH_FORMAT_TITLES = [
+  "Ateliers d'employabilité et de posture professionnelle",
+  'Préparation linguistique et tests de langue',
+  'Orientation études, travail et mobilité internationale',
+  'Interventions collectives pour écoles, associations et entreprises',
+] as const;
+
+const ENGLISH_FORMAT_TITLES = [
+  'Employability and professional presence workshops',
+  'Language preparation and language testing',
+  'Guidance for study, work and international mobility',
+  'Group sessions for schools, associations and businesses',
+] as const;
+
+const FRENCH_CATALOG_TITLES = [
+  'Intitulé exact',
+  'Calendrier',
+  'Éligibilité',
+  'Modalités',
+] as const;
+
+const ENGLISH_CATALOG_TITLES = [
+  'Exact title',
+  'Schedule',
+  'Eligibility',
+  'Practical arrangements',
+] as const;
+
+const FRENCH_PROCESS_TITLES = [
+  'Demande de contact',
+  "Entretien d'orientation",
+  'Proposition de format',
+  'Confirmation',
+] as const;
+
+const ENGLISH_PROCESS_TITLES = [
+  'Contact request',
+  'Guidance conversation',
+  'Format recommendation',
+  'Confirmation',
+] as const;
+
+const FRENCH_COMPLETE_COPY = [
+  'Programmes KRAAK',
+  "Le catalogue public détaillé est en cours de finalisation. Aujourd'hui, KRAAK oriente chaque demande vers le bon format selon l'objectif, le profil, le pays concerné et la disponibilité des cohortes ou des partenaires.",
+  'Formats actuellement proposés',
+  'Ce que nous pouvons déjà orienter avec clarté.',
+  'Nous publions ici les formats que nous activons déjà. Les intitulés détaillés, calendriers et modalités exactes sont confirmés après orientation.',
+  "Ateliers d'employabilité et de posture professionnelle",
+  'Format : atelier court ou mini-parcours.',
+  'Public : jeunes, étudiants, jeunes professionnels.',
+  'Cadence : sessions ponctuelles ou cohortes selon calendrier.',
+  'Préparation linguistique et tests de langue',
+  'Format : accompagnement ciblé ou atelier.',
+  'Public : profils visant emploi, études ou mobilité.',
+  'Cadence : selon niveau, objectif et disponibilité.',
+  'Orientation études, travail et mobilité internationale',
+  "Format : consultation d'orientation et préparation.",
+  'Public : candidats à un projet international.',
+  "Cadence : sur rendez-vous ou selon cohorte d'accompagnement.",
+  'Interventions collectives pour écoles, associations et entreprises',
+  'Format : conférence, forum, atelier ou module sur mesure.',
+  'Public : structures éducatives, communautaires ou professionnelles.',
+  'Cadence : sur demande ou via partenariat.',
+  'Catalogue public',
+  'Ce que nous confirmons après orientation.',
+  "Pour rester honnêtes sur l'offre, nous ne publions pas encore un catalogue figé avec tous les détails. L'orientation permet de confirmer les bonnes informations au bon moment.",
+  'Intitulé exact',
+  'Le format ou le programme précis correspondant à votre besoin.',
+  'Calendrier',
+  "Les prochaines dates, cohortes ou fenêtres d'intervention disponibles.",
+  'Éligibilité',
+  "Les prérequis, le public visé et le niveau d'appui attendu.",
+  'Modalités',
+  'Le rythme, le cadre, les documents utiles et les conditions pratiques.',
+  'Comment être orienté vers le bon programme ?',
+  'Demande de contact',
+  'Dites-nous votre objectif, votre pays et le type de besoin que vous cherchez à clarifier.',
+  "Entretien d'orientation",
+  "Un échange rapide permet de qualifier votre situation et le bon niveau d'appui.",
+  'Proposition de format',
+  'Nous vous orientons vers un atelier, une cohorte, une consultation ou une intervention collective.',
+  'Confirmation',
+  'Vous recevez les modalités utiles pour confirmer votre place ou votre prochaine étape.',
+  "Vous n'avez pas à choisir seul dans un catalogue inachevé.",
+  "Le bon programme dépend souvent de votre objectif, de votre calendrier, de votre niveau de préparation et du cadre de votre projet. Nous assumons cette posture d'orientation pour vous donner une information utile, pas une liste floue.",
+  'Demandez une orientation KRAAK.',
+  'Expliquez votre objectif et nous vous dirons quel format, quel rythme et quelle prochaine étape sont les plus pertinents.',
+  'Demander une orientation',
+] as const;
+
+const ENGLISH_COMPLETE_COPY = [
+  'KRAAK programmes',
+  'Our detailed public catalogue is currently being finalised. For now, KRAAK guides each enquiry towards the right format based on the goal, profile, country involved and the availability of cohorts or partners.',
+  'Formats currently offered',
+  'What we can already recommend with confidence.',
+  'Here are the formats we already offer. Detailed titles, schedules and exact arrangements are confirmed after a guidance conversation.',
+  'Employability and professional presence workshops',
+  'Format: short workshop or mini-programme.',
+  'Audience: young people, students and early-career professionals.',
+  'Schedule: one-off sessions or cohorts, depending on the calendar.',
+  'Language preparation and language testing',
+  'Format: targeted support or a workshop.',
+  'Audience: people preparing for work, study or mobility.',
+  'Schedule: based on level, goal and availability.',
+  'Guidance for study, work and international mobility',
+  'Format: guidance consultation and preparation.',
+  'Audience: people pursuing an international plan.',
+  'Schedule: by appointment or as part of a support cohort.',
+  'Group sessions for schools, associations and businesses',
+  'Format: conference, forum, workshop or tailored module.',
+  'Audience: educational, community or professional organisations.',
+  'Schedule: on request or through a partnership.',
+  'Public catalogue',
+  'What we confirm after your guidance conversation.',
+  'To be transparent about our offer, we do not yet publish a fixed catalogue with every detail. The guidance stage allows us to confirm the right information at the right time.',
+  'Exact title',
+  'The specific format or programme that matches your needs.',
+  'Schedule',
+  'Upcoming dates, cohorts or available delivery windows.',
+  'Eligibility',
+  'Prerequisites, intended audience and expected level of support.',
+  'Practical arrangements',
+  'Pace, setting, useful documents and practical requirements.',
+  'How do you find the right programme?',
+  'Contact request',
+  'Tell us your goal, your country and the type of need you want to clarify.',
+  'Guidance conversation',
+  'A short conversation helps us understand your situation and identify the right level of support.',
+  'Format recommendation',
+  'We guide you towards a workshop, cohort, consultation or group session.',
+  'Confirmation',
+  'You receive the practical details you need to confirm your place or next step.',
+  'You should not have to choose alone from an unfinished catalogue.',
+  'The right programme often depends on your goal, schedule, level of preparation and the context of your project. We take responsibility for guiding you so that you receive useful information, not a vague list.',
+  'Ask KRAAK for guidance.',
+  'Tell us your goal and we will recommend the most suitable format, pace and next step.',
+  'Request guidance',
+] as const;
+
+function normalizedText(element: Element | null): string {
+  return (element?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function textList(page: HTMLElement, selector: string): string[] {
+  return Array.from(page.querySelectorAll(selector)).map((element) =>
+    normalizedText(element),
+  );
+}
+
+const gsapAnimationsServiceMock: Pick<
+  GsapAnimationsService,
+  | 'animatePageIn'
+  | 'initializeFigureAnimations'
+  | 'initializeReversibleScrollAnimations'
+  | 'initializeInteractiveCardAnimations'
+  | 'initializeButtonTransitions'
+  | 'initializeListItemAnimations'
+  | 'killAllAnimations'
+> = {
+  animatePageIn: () => undefined,
+  initializeFigureAnimations: () => undefined,
+  initializeReversibleScrollAnimations: () => undefined,
+  initializeInteractiveCardAnimations: () => undefined,
+  initializeButtonTransitions: () => undefined,
+  initializeListItemAnimations: () => undefined,
+  killAllAnimations: () => undefined,
+};
+
 describe('ProgramsPage', () => {
+  let analyticsService: Pick<AnalyticsService, 'trackEvent'>;
+
   beforeEach(async () => {
+    analyticsService = {
+      trackEvent: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ProgramsPage],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        provideKraakI18n(),
+        {
+          provide: AnalyticsService,
+          useValue: analyticsService,
+        },
+        {
+          provide: GsapAnimationsService,
+          useValue: gsapAnimationsServiceMock,
+        },
+      ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
   });
 
-  it('Given the Programs page route, when the component initializes, then the page instance is created', () => {
+  it('Given the Programs page route When the component initializes Then the page instance is created', () => {
     const fixture = TestBed.createComponent(ProgramsPage);
+
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given the Programs page, when the view is rendered, then the heading and key program cards are visible', () => {
+  it('Given the canonical French Programs route When the complete page renders Then all historical copy and the localized CTA remain French', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/fr/programmes',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
     const fixture = TestBed.createComponent(ProgramsPage);
     fixture.detectChanges();
+
     const page = fixture.nativeElement as HTMLElement;
-
-    expect(page.querySelector('h1')?.textContent).toContain(
-      "Orientation d'abord, format adapt\u00e9 ensuite.",
-    );
-    expect(page.textContent).toContain(
-      "Ateliers d'employabilité et de posture professionnelle",
-    );
-    expect(page.textContent).toContain(
-      'Préparation linguistique et tests de langue',
-    );
-    expect(page.textContent).toContain(
-      'Orientation études, travail et mobilité internationale',
-    );
-    expect(page.textContent).toContain(
-      'Interventions collectives pour écoles, associations et entreprises',
-    );
-  });
-
-  it('Given the registration process section, when the Programs page is rendered, then the four expected steps are displayed in order', () => {
-    const fixture = TestBed.createComponent(ProgramsPage);
-    fixture.detectChanges();
-    const page = fixture.nativeElement as HTMLElement;
-
-    const content = page.textContent ?? '';
-    const candidatureIndex = content.indexOf('Demande de contact');
-    const entretienIndex = content.indexOf("Entretien d'orientation");
-    const inscriptionIndex = content.indexOf('Proposition de format');
-    const demarrageIndex = content.indexOf('Confirmation');
-
-    expect(candidatureIndex).toBeGreaterThan(-1);
-    expect(entretienIndex).toBeGreaterThan(candidatureIndex);
-    expect(inscriptionIndex).toBeGreaterThan(entretienIndex);
-    expect(demarrageIndex).toBeGreaterThan(inscriptionIndex);
-  });
-
-  it('Given the Programs page CTA, when a visitor reaches the end of the page, then the registration call-to-action points to contact', () => {
-    const fixture = TestBed.createComponent(ProgramsPage);
-    fixture.detectChanges();
-    const page = fixture.nativeElement as HTMLElement;
-
-    const registrationLink = page.querySelector(
-      'a[href="/fr/contact"]',
+    const content = normalizedText(page);
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+    const ctaLink = page.querySelector(
+      'kraak-cta-banner a',
     ) as HTMLAnchorElement | null;
 
-    expect(registrationLink).toBeTruthy();
-    expect(registrationLink?.textContent).toContain('Demander une orientation');
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      "Orientation d'abord, format adapté ensuite.",
+    );
+    for (const expectedCopy of FRENCH_COMPLETE_COPY) {
+      expect(content).toContain(expectedCopy);
+    }
+    expect(cta.heading).toBe('Demandez une orientation KRAAK.');
+    expect(cta.body).toBe(
+      'Expliquez votre objectif et nous vous dirons quel format, quel rythme et quelle prochaine étape sont les plus pertinents.',
+    );
+    expect(cta.ctaLabel).toBe('Demander une orientation');
+    expect(cta.ctaLink).toBe('/contact');
+    expect(cta.ctaContext).toBe('programs_main_cta');
+    expect(ctaLink?.getAttribute('href')).toBe('/fr/contact');
+    expect(content).not.toContain('[missing:web.programs.');
+  });
+
+  it('Given the English Programs route When the hero formats catalogue process reassurance and CTA render Then all visitor-facing content comes from the English catalog', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/en/programs',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ProgramsPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const content = normalizedText(page);
+    const ctaLink = page.querySelector(
+      'kraak-cta-banner a',
+    ) as HTMLAnchorElement | null;
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      'Guidance first. The right format follows.',
+    );
+    for (const expectedCopy of ENGLISH_COMPLETE_COPY) {
+      expect(content).toContain(expectedCopy);
+    }
+    expect(textList(page, 'article[data-motion="reversible"] h2')).toEqual(
+      ENGLISH_FORMAT_TITLES,
+    );
+    expect(textList(page, 'h3')).toEqual(ENGLISH_PROCESS_TITLES);
+    expect(ctaLink?.textContent).toContain('Request guidance');
+    expect(ctaLink?.getAttribute('href')).toBe('/en/contact');
+    expect(content).not.toContain("Orientation d'abord");
+    expect(content).not.toContain('Format :');
+    expect(content).not.toContain('Catalogue public');
+    expect(content).not.toContain('Demande de contact');
+    expect(content).not.toContain('Demander une orientation');
+    expect(content).not.toContain('[missing:web.programs.');
+  });
+
+  it('Given one rendered French Programs fixture with the English route stubbed When the locale changes to English Then collections and the CTA react without recreating the page', async () => {
+    const router = TestBed.inject(Router);
+    const i18n = TestBed.inject(KraakI18nService);
+    vi.spyOn(router, 'url', 'get').mockReturnValue('/en/programs');
+    await i18n.setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(ProgramsPage);
+    const programsPage = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+
+    expect(textList(page, 'article[data-motion="reversible"] h2')).toEqual(
+      FRENCH_FORMAT_TITLES,
+    );
+    expect(textList(page, 'h3')).toEqual(FRENCH_PROCESS_TITLES);
+    expect(cta.ctaLabel).toBe('Demander une orientation');
+
+    await i18n.setLocale('en-GB');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance).toBe(programsPage);
+    expect(
+      fixture.debugElement.query(By.directive(CtaBanner)).componentInstance,
+    ).toBe(cta);
+    expect(textList(page, 'article[data-motion="reversible"] h2')).toEqual(
+      ENGLISH_FORMAT_TITLES,
+    );
+    expect(
+      textList(page, 'article:not([data-motion]) > p:first-child'),
+    ).toEqual(ENGLISH_CATALOG_TITLES);
+    expect(textList(page, 'h3')).toEqual(ENGLISH_PROCESS_TITLES);
+    expect(cta.heading).toBe('Ask KRAAK for guidance.');
+    expect(cta.body).toBe(
+      'Tell us your goal and we will recommend the most suitable format, pace and next step.',
+    );
+    expect(cta.ctaLabel).toBe('Request guidance');
+    expect(page.querySelector('kraak-cta-banner a')?.getAttribute('href')).toBe(
+      '/en/contact',
+    );
+    expect(normalizedText(page)).not.toContain('Formats actuellement proposés');
+    expect(normalizedText(page)).not.toContain('[missing:web.programs.');
+  });
+
+  it('Given the Programs content collections When the French page renders Then four reversible format articles and four ordered process steps remain intact', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(ProgramsPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+
+    expect(
+      page.querySelectorAll('article[data-motion="reversible"]'),
+    ).toHaveLength(4);
+    expect(textList(page, 'article[data-motion="reversible"] h2')).toEqual(
+      FRENCH_FORMAT_TITLES,
+    );
+    expect(
+      textList(page, 'article:not([data-motion]) > p:first-child'),
+    ).toEqual(FRENCH_CATALOG_TITLES);
+    expect(textList(page, 'h3')).toEqual(FRENCH_PROCESS_TITLES);
+  });
+
+  it('Given the English Programs CTA When its conversion handler runs Then analytics keeps a stable event and context with a localized label and URL', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/en/programs',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(ProgramsPage);
+    fixture.detectChanges();
+
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+
+    expect(cta.ctaLabel).toBe('Request guidance');
+    expect(cta.ctaLink).toBe('/contact');
+
+    cta.onCtaClick();
+
+    expect(analyticsService.trackEvent).toHaveBeenCalledWith(
+      'conversion_cta_click',
+      {
+        cta_context: 'programs_main_cta',
+        cta_label: 'Request guidance',
+        cta_link: '/en/contact',
+      },
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/programs/programs.page.ts
+++ b/apps/client/projects/web/src/app/features/programs/programs.page.ts
@@ -1,6 +1,10 @@
 import { Component, Injector, OnInit, OnDestroy, inject } from '@angular/core';
-import { NgStyle } from '@angular/common';
+import { NgClass, NgStyle } from '@angular/common';
 
+import {
+  KraakTranslatePipe,
+  type TranslationKey,
+} from '../../../../../shared/i18n';
 import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { RevealOnScrollDirective } from '../../shared/motion/reveal-on-scroll.directive';
@@ -10,14 +14,114 @@ const PROGRAMS_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/programs-hero-adult-learning.avif',
 );
 
+interface ProgramFormatTranslation {
+  readonly iconClass: string;
+  readonly titleKey: TranslationKey;
+  readonly formatKey: TranslationKey;
+  readonly audienceKey: TranslationKey;
+  readonly cadenceKey: TranslationKey;
+}
+
+interface ProgramCatalogTranslation {
+  readonly titleKey: TranslationKey;
+  readonly descriptionKey: TranslationKey;
+}
+
+interface ProgramProcessTranslation extends ProgramCatalogTranslation {
+  readonly step: number;
+}
+
+const PROGRAM_FORMAT_TRANSLATIONS = [
+  {
+    iconClass: 'pi-briefcase',
+    titleKey: 'web.programs.formats.items.employability.title',
+    formatKey: 'web.programs.formats.items.employability.format',
+    audienceKey: 'web.programs.formats.items.employability.audience',
+    cadenceKey: 'web.programs.formats.items.employability.cadence',
+  },
+  {
+    iconClass: 'pi-language',
+    titleKey: 'web.programs.formats.items.languagePreparation.title',
+    formatKey: 'web.programs.formats.items.languagePreparation.format',
+    audienceKey: 'web.programs.formats.items.languagePreparation.audience',
+    cadenceKey: 'web.programs.formats.items.languagePreparation.cadence',
+  },
+  {
+    iconClass: 'pi-globe',
+    titleKey: 'web.programs.formats.items.internationalMobility.title',
+    formatKey: 'web.programs.formats.items.internationalMobility.format',
+    audienceKey: 'web.programs.formats.items.internationalMobility.audience',
+    cadenceKey: 'web.programs.formats.items.internationalMobility.cadence',
+  },
+  {
+    iconClass: 'pi-users',
+    titleKey: 'web.programs.formats.items.collectiveInterventions.title',
+    formatKey: 'web.programs.formats.items.collectiveInterventions.format',
+    audienceKey: 'web.programs.formats.items.collectiveInterventions.audience',
+    cadenceKey: 'web.programs.formats.items.collectiveInterventions.cadence',
+  },
+] as const satisfies readonly ProgramFormatTranslation[];
+
+const PROGRAM_CATALOG_TRANSLATIONS = [
+  {
+    titleKey: 'web.programs.catalog.items.exactTitle.title',
+    descriptionKey: 'web.programs.catalog.items.exactTitle.description',
+  },
+  {
+    titleKey: 'web.programs.catalog.items.schedule.title',
+    descriptionKey: 'web.programs.catalog.items.schedule.description',
+  },
+  {
+    titleKey: 'web.programs.catalog.items.eligibility.title',
+    descriptionKey: 'web.programs.catalog.items.eligibility.description',
+  },
+  {
+    titleKey: 'web.programs.catalog.items.arrangements.title',
+    descriptionKey: 'web.programs.catalog.items.arrangements.description',
+  },
+] as const satisfies readonly ProgramCatalogTranslation[];
+
+const PROGRAM_PROCESS_TRANSLATIONS = [
+  {
+    step: 1,
+    titleKey: 'web.programs.process.steps.contactRequest.title',
+    descriptionKey: 'web.programs.process.steps.contactRequest.description',
+  },
+  {
+    step: 2,
+    titleKey: 'web.programs.process.steps.guidanceConversation.title',
+    descriptionKey:
+      'web.programs.process.steps.guidanceConversation.description',
+  },
+  {
+    step: 3,
+    titleKey: 'web.programs.process.steps.formatProposal.title',
+    descriptionKey: 'web.programs.process.steps.formatProposal.description',
+  },
+  {
+    step: 4,
+    titleKey: 'web.programs.process.steps.confirmation.title',
+    descriptionKey: 'web.programs.process.steps.confirmation.description',
+  },
+] as const satisfies readonly ProgramProcessTranslation[];
+
 @Component({
   selector: 'kraak-programs-page',
   standalone: true,
-  imports: [NgStyle, CtaBanner, RevealOnScrollDirective],
+  imports: [
+    NgClass,
+    NgStyle,
+    CtaBanner,
+    RevealOnScrollDirective,
+    KraakTranslatePipe,
+  ],
   templateUrl: './programs.page.html',
 })
 export default class ProgramsPage implements OnInit, OnDestroy {
   protected readonly heroBackgroundStyle = PROGRAMS_HERO_BACKGROUND_STYLE;
+  protected readonly programFormats = PROGRAM_FORMAT_TRANSLATIONS;
+  protected readonly catalogItems = PROGRAM_CATALOG_TRANSLATIONS;
+  protected readonly processSteps = PROGRAM_PROCESS_TRANSLATIONS;
 
   private readonly injector = inject(Injector);
   private gsapService: GsapAnimationsService | null = null;

--- a/apps/client/tests/e2e/programs.spec.ts
+++ b/apps/client/tests/e2e/programs.spec.ts
@@ -1,63 +1,208 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-test.describe('Page programmes - parcours vitrine', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/programmes', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { level: 1 })).toContainText(
-      "Orientation d'abord, format adapté ensuite.",
-    );
-  });
+const FRENCH_FORMAT_TITLES = [
+  "Ateliers d'employabilité et de posture professionnelle",
+  'Préparation linguistique et tests de langue',
+  'Orientation études, travail et mobilité internationale',
+  'Interventions collectives pour écoles, associations et entreprises',
+] as const;
 
-  test('Given la page Programmes, When elle se charge, Then le titre principal et les formats clés sont visibles', async ({
+const ENGLISH_FORMAT_TITLES = [
+  'Employability and professional presence workshops',
+  'Language preparation and language testing',
+  'Guidance for study, work and international mobility',
+  'Group sessions for schools, associations and businesses',
+] as const;
+
+const FRENCH_PROCESS_TITLES = [
+  'Demande de contact',
+  "Entretien d'orientation",
+  'Proposition de format',
+  'Confirmation',
+] as const;
+
+const ENGLISH_PROCESS_TITLES = [
+  'Contact request',
+  'Guidance conversation',
+  'Format recommendation',
+  'Confirmation',
+] as const;
+
+function getLanguageSelector(page: Page, accessibleName: RegExp) {
+  return page.getByRole('group', { name: accessibleName });
+}
+
+test.describe('Internationalisation publique de la page Programmes', () => {
+  test('Given the canonical French Programs route When the page loads Then the complete conversion journey and localized CTA remain French', async ({
     page,
   }) => {
-    await expect(page.getByRole('heading', { level: 1 })).toContainText(
-      "Orientation d'abord, format adapté ensuite.",
-    );
+    await page.goto('/fr/programmes', { waitUntil: 'domcontentloaded' });
 
-    await expect(
-      page.getByText("Ateliers d'employabilité et de posture professionnelle"),
-    ).toBeVisible();
-    await expect(
-      page.getByText('Préparation linguistique et tests de langue'),
-    ).toBeVisible();
-    await expect(
-      page.getByText('Orientation études, travail et mobilité internationale'),
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        'Interventions collectives pour écoles, associations et entreprises',
-      ),
-    ).toBeVisible();
-  });
-
-  test("Given la section d'orientation, When elle est lue, Then les quatre étapes de parcours sont présentées", async ({
-    page,
-  }) => {
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
     await expect(
       page.getByRole('heading', {
-        name: 'Comment être orienté vers le bon programme ?',
+        level: 1,
+        name: "Orientation d'abord, format adapté ensuite.",
+      }),
+    ).toBeVisible();
+    for (const title of FRENCH_FORMAT_TITLES) {
+      await expect(
+        page.getByRole('heading', { name: title, exact: true }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByRole('heading', {
+        name: 'Ce que nous confirmons après orientation.',
+        exact: true,
       }),
     ).toBeVisible();
     await expect(
-      page.getByRole('heading', { name: 'Demande de contact' }),
+      page.getByRole('heading', {
+        name: 'Comment être orienté vers le bon programme ?',
+        exact: true,
+      }),
+    ).toBeVisible();
+    for (const title of FRENCH_PROCESS_TITLES) {
+      await expect(
+        page.getByRole('heading', { name: title, exact: true }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByRole('heading', {
+        name: "Vous n'avez pas à choisir seul dans un catalogue inachevé.",
+        exact: true,
+      }),
     ).toBeVisible();
     await expect(
-      page.getByRole('heading', { name: "Entretien d'orientation" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Proposition de format' }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Confirmation' }),
-    ).toBeVisible();
+      page.getByRole('link', {
+        name: 'Demander une orientation',
+        exact: true,
+      }),
+    ).toHaveAttribute('href', '/fr/contact');
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText(
+      '[missing:web.programs.',
+    );
   });
 
-  test("Given le call-to-action de fin de page, When un visiteur veut être orienté, Then l'action mène vers la page contact", async ({
+  test('Given the English Programs route When every conversion section renders Then formats catalogue process reassurance and CTA are English while SEO remains locked', async ({
     page,
   }) => {
-    const cta = page.getByRole('link', { name: 'Demander une orientation' });
-    await expect(cta).toBeVisible();
-    await expect(cta).toHaveAttribute('href', '/contact');
+    await page.goto('/en/programs', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Guidance first. The right format follows.',
+      }),
+    ).toBeVisible();
+    for (const title of ENGLISH_FORMAT_TITLES) {
+      await expect(
+        page.getByRole('heading', { name: title, exact: true }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByRole('heading', {
+        name: 'What we confirm after your guidance conversation.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'How do you find the right programme?',
+        exact: true,
+      }),
+    ).toBeVisible();
+    for (const title of ENGLISH_PROCESS_TITLES) {
+      await expect(
+        page.getByRole('heading', { name: title, exact: true }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByRole('heading', {
+        name: 'You should not have to choose alone from an unfinished catalogue.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Request guidance', exact: true }),
+    ).toHaveAttribute('href', '/en/contact');
+    await expect(page.locator('body')).not.toContainText("Orientation d'abord");
+    await expect(page.locator('body')).not.toContainText(
+      'Formats actuellement proposés',
+    );
+    await expect(page.locator('body')).not.toContainText('Demande de contact');
+    await expect(page.locator('body')).not.toContainText(
+      'Demander une orientation',
+    );
+    await expect(page.locator('body')).not.toContainText(
+      '[missing:web.programs.',
+    );
+
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex, nofollow',
+    );
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="x-default"]'),
+    ).toHaveAttribute('href', /\/fr\/programmes$/);
+
+    const sitemapResponse = await page.request.get('/sitemap.xml');
+    expect(sitemapResponse.ok()).toBe(true);
+    const sitemap = await sitemapResponse.text();
+    expect(sitemap).toContain('/fr/programmes');
+    expect(sitemap).not.toContain('/en/programs');
+  });
+
+  test('Given the English Programs CTA When it is activated with the keyboard Then it opens the localized Contact route', async ({
+    page,
+  }) => {
+    await page.goto('/en/programs');
+
+    const guidanceLink = page.getByRole('link', {
+      name: 'Request guidance',
+      exact: true,
+    });
+    await expect(guidanceLink).toBeVisible();
+    await guidanceLink.focus();
+    await expect(guidanceLink).toBeFocused();
+
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/en\/contact$/);
+  });
+
+  test('Given the French Programs route with query and fragment When the visitor switches to English Then the equivalent route state and English collections are preserved', async ({
+    page,
+  }) => {
+    await page.goto('/fr/programmes?campaign=programs#process', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const englishLink = getLanguageSelector(page, /langue|language/i).getByRole(
+      'link',
+      { name: /anglais|english/i },
+    );
+    await englishLink.click();
+
+    await expect(page).toHaveURL(/\/en\/programs\?campaign=programs#process$/);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Guidance first. The right format follows.',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Language preparation and language testing',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Request guidance', exact: true }),
+    ).toHaveAttribute('href', '/en/contact');
   });
 });

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -34,17 +34,19 @@ Le site web KRAAK est l'application Angular publique située dans
   et la barre de navigation forment le premier incrément public bilingue. La
   coque publique partagée (pied de page, lien d'accès rapide et commande de
   retour en haut) forme le deuxième incrément. La page Contact constitue le
-  troisième incrément localisé et la page Services le quatrième. Les autres
-  pages `/en/...` restent un scaffold technique non indexable tant que leurs
-  contenus anglais ne sont pas traduits et relus.
+  troisième incrément localisé, la page Services le quatrième et la page
+  Programmes le cinquième. Parmi les pages de conversion de cette série, seule
+  la page À propos reste à localiser dans une PR dédiée. Les autres pages
+  `/en/...` restent un scaffold technique non indexable tant que leurs contenus
+  anglais ne sont pas traduits et relus.
 
 ## Implémentation active
 
 - Routes publiques : [`../../apps/client/projects/web/src/app/app.routes.ts`](../../apps/client/projects/web/src/app/app.routes.ts).
 - Prerender public : [`../../apps/client/projects/web/src/app/app.routes.server.ts`](../../apps/client/projects/web/src/app/app.routes.server.ts).
 - Catalogues runtime : [`../../apps/client/projects/shared/i18n/catalogs/`](../../apps/client/projects/shared/i18n/catalogs/),
-  avec les espaces de clés `web.home`, `web.nav`, `web.shell`, `web.contact` et
-  `web.services` pour les incréments publics bilingues livrés.
+  avec les espaces de clés `web.home`, `web.nav`, `web.shell`, `web.contact`,
+  `web.services` et `web.programs` pour les incréments publics bilingues livrés.
 - Tests de surface : [`../../apps/client/projects/web/src/app/app.routes.spec.ts`](../../apps/client/projects/web/src/app/app.routes.spec.ts)
   et [`../../apps/client/projects/web/src/app/app.routes.server.spec.ts`](../../apps/client/projects/web/src/app/app.routes.server.spec.ts).
 - Historique design : [`../archive/vitrine-design/`](../archive/vitrine-design/),
@@ -61,22 +63,27 @@ Le prerender, les métadonnées SEO, les canonicals, les liens `hreflang`, les
 entrées sitemap et l'attribut `<html lang>` sont générés par locale depuis le
 modèle de routes web localisées.
 
-La page d'accueil, la barre de navigation, la coque publique partagée, la page
-Contact et la page Services servent désormais leur contenu français ou anglais
-depuis les catalogues selon la locale de l'URL. Un sélecteur de langue relie les
-variantes d'une même page publique lorsque le mapping existe, puis revient à la
-page d'accueil de la langue cible lorsqu'aucune variante publique n'est
-disponible.
+La page d'accueil, la barre de navigation, la coque publique partagée, les pages
+Contact, Services et Programmes servent désormais leur contenu français ou
+anglais depuis les catalogues selon la locale de l'URL. Un sélecteur de langue
+relie les variantes d'une même page publique lorsque le mapping existe, puis
+revient à la page d'accueil de la langue cible lorsqu'aucune variante publique
+n'est disponible.
 
-Les prochaines pages de conversion doivent être localisées séparément, avec une
-seule page par PR, dans cet ordre : Programmes, puis À propos. L'activation de
-l'indexation anglaise, des entrées sitemap et des liens `hreflang` réciproques
-reste conditionnée à une revue humaine du contenu anglais de chaque page.
+Parmi les pages de conversion de cette série, seule la page À propos reste à
+localiser dans une PR distincte. L'activation de l'indexation anglaise, des
+entrées sitemap et des liens `hreflang` réciproques reste conditionnée à une
+revue humaine du contenu anglais de chaque page.
 
 La copie anglaise de Services est proposée mais n'a pas encore reçu cette revue
 humaine. En conséquence, `/en/services` reste `noindex, nofollow`, hors du
 sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis
 `/fr/services`.
+
+La copie anglaise de Programmes est elle aussi proposée mais n'a pas encore reçu
+de revue humaine. En conséquence, `/en/programs` reste `noindex, nofollow`, hors
+du sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis
+`/fr/programmes`.
 
 Ces incréments de contenu ne modifient pas encore la politique SEO du scaffold
 anglais : les routes anglaises restent `noindex, nofollow`, exclues


### PR DESCRIPTION
## Résumé

- sert le hero, les formats, le catalogue, le processus, la réassurance et le CTA depuis les catalogues `fr-CI` / `en-GB`
- refactorise les collections en descripteurs de clés stables tout en préservant les sélecteurs GSAP
- met à jour le contenu lors d’un changement de langue dans la même fixture et localise le libellé analytics du CTA
- ajoute des tests unitaires et Playwright Given/When/Then sur Chromium, Firefox et WebKit
- documente le cinquième incrément i18n public

## Validation

- `pnpm i18n:check` — 332 clés partagées
- `pnpm typecheck:web`
- tests unitaires Programmes — 6/6
- Playwright Programmes — 12/12 sur Chromium, Firefox et WebKit
- tests web complets — 682/682
- tests mobile complets — 253/253
- tests d’intégration API — 31/31
- build/prerender web — 26 routes

## Garde-fou SEO

La copie anglaise reste proposée et non revue humainement. `/en/programs` reste donc `noindex, nofollow`, hors sitemap et sans hreflang `en-GB` réciproque.

Closes #646