### PR TITLE
feat(web): localiser la page À propos

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,16 +62,16 @@ page d'accueil et la barre de navigation constituent le premier incrément publi
 entièrement bilingue alimenté par les catalogues `fr-CI` et `en-GB`. La coque
 publique partagée constitue le deuxième incrément et la page Contact le
 troisième. La page Services constitue le quatrième incrément public localisé.
-La page Programmes constitue le cinquième. Les copies anglaises proposées de
-Services et de Programmes n'ont pas encore reçu de revue humaine :
-`/en/services` et `/en/programs` restent donc `noindex, nofollow`, hors du
-sitemap et sans lien `hreflang="en-GB"` réciproque depuis leur page française.
-Parmi les pages de conversion de cette série, seule la page À propos reste à
-localiser dans une PR distincte. Les autres pages publiques anglaises et leurs
-métadonnées SEO restent dans l'état de scaffold non
-indexable jusqu'à leur traduction et leur revue humaine dédiées. L'indexation
-anglaise, les entrées sitemap et les liens `hreflang` réciproques ne sont activés
-qu'après cette revue pour chaque page.
+La page Programmes constitue le cinquième et la page À propos le sixième. Les
+quatre pages de conversion de cette série, Contact, Services, Programmes et À
+propos, sont désormais localisées. Leurs copies anglaises restent proposées et
+n'ont pas encore reçu de revue humaine : `/en/contact`, `/en/services`,
+`/en/programs` et `/en/about` restent donc `noindex, nofollow`, hors du sitemap
+et sans lien `hreflang="en-GB"` réciproque depuis leur page française. Les autres
+pages publiques anglaises et leurs métadonnées SEO restent dans l'état de
+scaffold non indexable jusqu'à leur traduction et leur revue humaine dédiées.
+L'indexation anglaise, les entrées sitemap et les liens `hreflang` réciproques ne
+sont activés qu'après cette revue pour chaque page.
 
 Les incréments suivants doivent rester courts, documentés et validés sans
 localiser implicitement les routes privées, admin ou mobiles.

--- a/apps/client/projects/shared/i18n/catalogs/en-GB.json
+++ b/apps/client/projects/shared/i18n/catalogs/en-GB.json
@@ -544,6 +544,97 @@
         "body": "Tell us your goal and we will recommend the most suitable format, pace and next step.",
         "label": "Request guidance"
       }
+    },
+    "about": {
+      "hero": {
+        "eyebrow": "About KRAAK",
+        "titlePrefix": "A",
+        "titleEmphasis": "purpose-driven organisation",
+        "titleSuffix": "for human capital and sustainable pathways.",
+        "description": "KRAAK Consulting builds young people's capabilities, supports organisations and creates valuable bridges between potential, opportunity and lasting impact in Côte d'Ivoire and internationally."
+      },
+      "focusAreas": {
+        "skillsDevelopment": {
+          "title": "Skills development",
+          "description": "Practical training to build clarity, confidence and professional competitiveness."
+        },
+        "projectStructuring": {
+          "title": "Project structuring",
+          "description": "A method for turning intentions into clear, monitored initiatives capable of delivering results."
+        },
+        "internationalOpportunities": {
+          "title": "Access to international opportunities",
+          "description": "Reliable support for approaching study, work and mobility with a coherent strategy."
+        }
+      },
+      "direction": {
+        "eyebrow": "Our direction",
+        "title": "A clear mission and a meaningful vision.",
+        "description": "These guideposts give our support and partnerships a clear direction.",
+        "mission": {
+          "label": "Mission",
+          "title": "Unlock potential, build skills and support young people through transformation.",
+          "description": "KRAAK Consulting's mission is to unlock young people's potential, build strong technical and interpersonal skills, help them integrate into demanding environments and support lasting value creation for themselves, their communities and future generations.",
+          "activationLabel": "What we set in motion",
+          "activationItems": {
+            "potential": "Discovering and asserting potential",
+            "skills": "Strong, practical skills"
+          },
+          "outcomeLabel": "Intended outcome",
+          "outcomeDescription": "Clearer, more confident and more sustainable pathways for the young people we support."
+        },
+        "vision": {
+          "label": "Vision",
+          "title": "A leading partner for young African professionals.",
+          "description": "KRAAK Consulting aims to become a leading organisation in the training and support of young African professionals, helping to shape a generation that understands its value, is ready to practise purposeful leadership and contributes to a fairer, more inclusive society that is open to opportunity.",
+          "ambitionLabel": "Ambition",
+          "ambitionDescription": "Develop leaders who understand their value and serve their communities.",
+          "impactLabel": "Impact",
+          "impactDescription": "Contribute to a more inclusive society with sustainable opportunities."
+        }
+      },
+      "values": {
+        "title": "Our values",
+        "items": {
+          "humanism": {
+            "title": "Humanism",
+            "description": "We uphold respect for every individual, human dignity and inclusion, without discrimination."
+          },
+          "personalResponsibility": {
+            "title": "Personal responsibility",
+            "description": "We encourage everyone to take ownership of their development, choices and future."
+          },
+          "servantLeadership": {
+            "title": "Servant leadership",
+            "description": "We develop leaders who rise, lift others and create positive impact."
+          },
+          "solidarity": {
+            "title": "Solidarity and collective strength",
+            "description": "We believe in collective strength, collaboration and mutual support."
+          },
+          "resilience": {
+            "title": "Resilience and courage",
+            "description": "We prepare young people and organisations to face challenges, overcome barriers and make progress."
+          },
+          "globalConnection": {
+            "title": "Openness and global connection",
+            "description": "We foster intercultural exchange, lifelong learning and transferable skills."
+          }
+        }
+      },
+      "quote": {
+        "ariaLabel": "Quote from the Chief Executive Officer",
+        "portraitAlt": "Portrait of Mr AKA, Chief Executive Officer and Co-Founder of KRAAK",
+        "symbolAlt": "KRAAK symbol",
+        "text": "\"KRAAK Consulting is more than a business venture; it is a life mission. We are here to break down the barriers that prevent African talent from expressing itself on the global stage.\"",
+        "author": "Mr AKA",
+        "role": "Chief Executive Officer / Co-Founder"
+      },
+      "closing": {
+        "title": "Do you share this ambition?",
+        "description": "Let us explore how KRAAK can contribute to your journey or organisation.",
+        "cta": "Contact us"
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/shared/i18n/catalogs/fr-CI.json
+++ b/apps/client/projects/shared/i18n/catalogs/fr-CI.json
@@ -544,6 +544,97 @@
         "body": "Expliquez votre objectif et nous vous dirons quel format, quel rythme et quelle prochaine étape sont les plus pertinents.",
         "label": "Demander une orientation"
       }
+    },
+    "about": {
+      "hero": {
+        "eyebrow": "À propos de KRAAK",
+        "titlePrefix": "Une structure",
+        "titleEmphasis": "engagée",
+        "titleSuffix": "pour le capital humain et les trajectoires durables.",
+        "description": "KRAAK Consulting renforce les capacités des jeunes, accompagne les organisations et construit des passerelles utiles entre potentiel, opportunités et impact durable en Côte d'Ivoire et à l'international."
+      },
+      "focusAreas": {
+        "skillsDevelopment": {
+          "title": "Développement des compétences",
+          "description": "Des formations utiles pour gagner en clarté, en confiance et en compétitivité professionnelle."
+        },
+        "projectStructuring": {
+          "title": "Structuration des projets",
+          "description": "Une méthode pour transformer les intentions en initiatives lisibles, suivies et capables de produire des résultats."
+        },
+        "internationalOpportunities": {
+          "title": "Accès aux opportunités internationales",
+          "description": "Un accompagnement fiable pour aborder les études, le travail et la mobilité avec une stratégie cohérente."
+        }
+      },
+      "direction": {
+        "eyebrow": "Notre cap",
+        "title": "Une mission claire, une vision utile.",
+        "description": "Ces repères donnent une direction lisible à nos accompagnements et à nos partenariats.",
+        "mission": {
+          "label": "Mission",
+          "title": "Révéler, former et accompagner les jeunes dans leur transformation.",
+          "description": "KRAAK Consulting a pour mission de révéler le potentiel des jeunes, de développer des compétences techniques et interpersonnelles solides, de faciliter leur intégration dans des environnements exigeants et de soutenir la création de valeur durable pour eux-mêmes, leurs communautés et les générations futures.",
+          "activationLabel": "Ce que nous activons",
+          "activationItems": {
+            "potential": "Découverte et affirmation du potentiel",
+            "skills": "Compétences solides et utiles"
+          },
+          "outcomeLabel": "Résultat attendu",
+          "outcomeDescription": "Des trajectoires plus lisibles, plus confiantes et plus durables pour les jeunes que nous accompagnons."
+        },
+        "vision": {
+          "label": "Vision",
+          "title": "Un acteur de référence pour les jeunes professionnels africains.",
+          "description": "KRAAK Consulting se projette comme un acteur de référence dans la formation et l'accompagnement des jeunes professionnels africains, capable de faire émerger une génération consciente de sa valeur, prête à exercer un leadership utile et à contribuer à une société plus juste, plus inclusive et plus ouverte aux opportunités.",
+          "ambitionLabel": "Ambition",
+          "ambitionDescription": "Former des leaders conscients de leur valeur et utiles à leur environnement.",
+          "impactLabel": "Impact",
+          "impactDescription": "Contribuer à une société plus inclusive et porteuse d'opportunités durables."
+        }
+      },
+      "values": {
+        "title": "Nos valeurs",
+        "items": {
+          "humanism": {
+            "title": "Humanisme",
+            "description": "Nous défendons le respect de chaque individu, la dignité humaine et l'inclusion, sans discrimination."
+          },
+          "personalResponsibility": {
+            "title": "Responsabilité personnelle",
+            "description": "Nous encourageons chacun à prendre en main son développement, ses choix et son avenir."
+          },
+          "servantLeadership": {
+            "title": "Leadership par le service",
+            "description": "Nous formons des leaders qui s'élèvent, élèvent les autres et créent un impact positif."
+          },
+          "solidarity": {
+            "title": "Solidarité et esprit collectif",
+            "description": "Nous croyons à la force du collectif, de la collaboration et de l'entraide."
+          },
+          "resilience": {
+            "title": "Résilience et courage",
+            "description": "Nous préparons les jeunes et les organisations à affronter les défis, dépasser les barrières et progresser."
+          },
+          "globalConnection": {
+            "title": "Ouverture et connexion globale",
+            "description": "Nous favorisons les échanges interculturels, l'apprentissage continu et les compétences transférables."
+          }
+        }
+      },
+      "quote": {
+        "ariaLabel": "Citation du Directeur Général",
+        "portraitAlt": "Portrait de Mr AKA, Directeur Général et Co-Fondateur de KRAAK",
+        "symbolAlt": "Symbole KRAAK",
+        "text": "\"KRAAK Consulting n'est pas qu'un projet commercial, c'est une mission de vie. Nous sommes ici pour briser les barrières qui empêchent le talent africain de s'exprimer sur la scène mondiale.\"",
+        "author": "Mr AKA",
+        "role": "Directeur Général /Co-Fondateur"
+      },
+      "closing": {
+        "title": "Vous partagez cette ambition ?",
+        "description": "Découvrons ensemble comment KRAAK peut contribuer à votre trajectoire ou à votre organisation.",
+        "cta": "Nous contacter"
+      }
     }
   },
   "primeng": {

--- a/apps/client/projects/web/src/app/features/about/about.page.html
+++ b/apps/client/projects/web/src/app/features/about/about.page.html
@@ -15,20 +15,21 @@
       <p
         class="text-brand-cyan text-[11px] font-semibold tracking-[0.26em] uppercase sm:text-xs"
       >
-        À propos de KRAAK
+        {{ 'web.about.hero.eyebrow' | kraakTranslate }}
       </p>
       <h1
         class="text-brand-white mt-3 text-4xl leading-[1.08] font-black sm:mt-4 sm:text-5xl lg:text-6xl lg:leading-[1.04]"
       >
-        Une structure <span class="text-brand-cyan">engagée</span> pour le
-        capital humain et les trajectoires durables.
+        {{ 'web.about.hero.titlePrefix' | kraakTranslate }}
+        <span class="text-brand-cyan">{{
+          'web.about.hero.titleEmphasis' | kraakTranslate
+        }}</span>
+        {{ 'web.about.hero.titleSuffix' | kraakTranslate }}
       </h1>
       <p
         class="mt-6 max-w-2xl text-base leading-relaxed text-neutral-200 sm:mt-7 sm:text-lg lg:text-xl"
       >
-        KRAAK Consulting renforce les capacités des jeunes, accompagne les
-        organisations et construit des passerelles utiles entre potentiel,
-        opportunités et impact durable en Côte d'Ivoire et à l'international.
+        {{ 'web.about.hero.description' | kraakTranslate }}
       </p>
     </div>
   </div>
@@ -42,10 +43,14 @@
           class="pi pi-graduation-cap text-brand-navy-soft text-3xl"
           aria-hidden="true"
         ></i>
-        <h2 class="mt-4 text-xl font-bold">Développement des compétences</h2>
+        <h2 class="mt-4 text-xl font-bold">
+          {{ 'web.about.focusAreas.skillsDevelopment.title' | kraakTranslate }}
+        </h2>
         <p class="mt-3 text-neutral-700">
-          Des formations utiles pour gagner en clarté, en confiance et en
-          compétitivité professionnelle.
+          {{
+            'web.about.focusAreas.skillsDevelopment.description'
+              | kraakTranslate
+          }}
         </p>
       </article>
       <article
@@ -58,10 +63,14 @@
           class="pi pi-sitemap text-brand-navy-soft text-3xl"
           aria-hidden="true"
         ></i>
-        <h2 class="mt-4 text-xl font-bold">Structuration des projets</h2>
+        <h2 class="mt-4 text-xl font-bold">
+          {{ 'web.about.focusAreas.projectStructuring.title' | kraakTranslate }}
+        </h2>
         <p class="mt-3 text-neutral-700">
-          Une méthode pour transformer les intentions en initiatives lisibles,
-          suivies et capables de produire des résultats.
+          {{
+            'web.about.focusAreas.projectStructuring.description'
+              | kraakTranslate
+          }}
         </p>
       </article>
       <article
@@ -75,11 +84,16 @@
           aria-hidden="true"
         ></i>
         <h2 class="mt-4 text-xl font-bold">
-          Accès aux opportunités internationales
+          {{
+            'web.about.focusAreas.internationalOpportunities.title'
+              | kraakTranslate
+          }}
         </h2>
         <p class="mt-3 text-neutral-700">
-          Un accompagnement fiable pour aborder les études, le travail et la
-          mobilité avec une stratégie cohérente.
+          {{
+            'web.about.focusAreas.internationalOpportunities.description'
+              | kraakTranslate
+          }}
         </p>
       </article>
     </div>
@@ -99,14 +113,13 @@
       <p
         class="text-brand-navy-soft text-sm font-semibold tracking-[0.2em] uppercase"
       >
-        Notre cap
+        {{ 'web.about.direction.eyebrow' | kraakTranslate }}
       </p>
       <h2 class="mt-3 text-3xl font-bold lg:text-4xl">
-        Une mission claire, une vision utile.
+        {{ 'web.about.direction.title' | kraakTranslate }}
       </h2>
       <p class="mt-4 text-lg text-neutral-700">
-        Ces repères donnent une direction lisible à nos accompagnements et à nos
-        partenariats.
+        {{ 'web.about.direction.description' | kraakTranslate }}
       </p>
     </div>
 
@@ -123,17 +136,13 @@
             class="bg-primary/10 text-primary inline-flex items-center gap-3 rounded-full px-4 py-2 text-sm font-semibold"
           >
             <i class="pi pi-compass" aria-hidden="true"></i>
-            Mission
+            {{ 'web.about.direction.mission.label' | kraakTranslate }}
           </div>
           <h3 class="text-brand-navy mt-5 text-2xl font-bold lg:text-3xl">
-            Révéler, former et accompagner les jeunes dans leur transformation.
+            {{ 'web.about.direction.mission.title' | kraakTranslate }}
           </h3>
           <p class="mt-4 text-lg text-neutral-700">
-            KRAAK Consulting a pour mission de révéler le potentiel des jeunes,
-            de développer des compétences techniques et interpersonnelles
-            solides, de faciliter leur intégration dans des environnements
-            exigeants et de soutenir la création de valeur durable pour
-            eux-mêmes, leurs communautés et les générations futures.
+            {{ 'web.about.direction.mission.description' | kraakTranslate }}
           </p>
 
           <div class="mt-6 grid gap-3 sm:grid-cols-2">
@@ -141,7 +150,9 @@
               <p
                 class="text-brand-navy-soft text-xs font-semibold tracking-[0.18em] uppercase"
               >
-                Ce que nous activons
+                {{
+                  'web.about.direction.mission.activationLabel' | kraakTranslate
+                }}
               </p>
               <ul class="mt-3 space-y-2 text-sm text-neutral-700">
                 <li class="flex gap-3">
@@ -149,14 +160,20 @@
                     class="pi pi-check text-primary mt-0.5"
                     aria-hidden="true"
                   ></i>
-                  <span>Découverte et affirmation du potentiel</span>
+                  <span>{{
+                    'web.about.direction.mission.activationItems.potential'
+                      | kraakTranslate
+                  }}</span>
                 </li>
                 <li class="flex gap-3">
                   <i
                     class="pi pi-check text-primary mt-0.5"
                     aria-hidden="true"
                   ></i>
-                  <span>Compétences solides et utiles</span>
+                  <span>{{
+                    'web.about.direction.mission.activationItems.skills'
+                      | kraakTranslate
+                  }}</span>
                 </li>
               </ul>
             </div>
@@ -165,11 +182,15 @@
               <p
                 class="text-brand-navy-soft text-xs font-semibold tracking-[0.18em] uppercase"
               >
-                Résultat attendu
+                {{
+                  'web.about.direction.mission.outcomeLabel' | kraakTranslate
+                }}
               </p>
               <p class="mt-3 text-sm text-neutral-700">
-                Des trajectoires plus lisibles, plus confiantes et plus durables
-                pour les jeunes que nous accompagnons.
+                {{
+                  'web.about.direction.mission.outcomeDescription'
+                    | kraakTranslate
+                }}
               </p>
             </div>
           </div>
@@ -188,17 +209,13 @@
             class="inline-flex items-center gap-3 rounded-full bg-white/10 px-4 py-2 text-sm font-semibold text-white/90"
           >
             <i class="pi pi-eye" aria-hidden="true"></i>
-            Vision
+            {{ 'web.about.direction.vision.label' | kraakTranslate }}
           </div>
           <h3 class="mt-5 text-2xl font-bold text-white lg:text-3xl">
-            Un acteur de référence pour les jeunes professionnels africains.
+            {{ 'web.about.direction.vision.title' | kraakTranslate }}
           </h3>
           <p class="mt-4 text-lg text-white/80">
-            KRAAK Consulting se projette comme un acteur de référence dans la
-            formation et l'accompagnement des jeunes professionnels africains,
-            capable de faire émerger une génération consciente de sa valeur,
-            prête à exercer un leadership utile et à contribuer à une société
-            plus juste, plus inclusive et plus ouverte aux opportunités.
+            {{ 'web.about.direction.vision.description' | kraakTranslate }}
           </p>
 
           <div
@@ -208,11 +225,15 @@
               <p
                 class="text-xs font-semibold tracking-[0.18em] text-white/70 uppercase"
               >
-                Ambition
+                {{
+                  'web.about.direction.vision.ambitionLabel' | kraakTranslate
+                }}
               </p>
               <p class="mt-3 text-sm text-white/80">
-                Former des leaders conscients de leur valeur et utiles à leur
-                environnement.
+                {{
+                  'web.about.direction.vision.ambitionDescription'
+                    | kraakTranslate
+                }}
               </p>
             </div>
 
@@ -220,11 +241,13 @@
               <p
                 class="text-xs font-semibold tracking-[0.18em] text-white/70 uppercase"
               >
-                Impact
+                {{ 'web.about.direction.vision.impactLabel' | kraakTranslate }}
               </p>
               <p class="mt-3 text-sm text-white/80">
-                Contribuer à une société plus inclusive et porteuse
-                d'opportunités durables.
+                {{
+                  'web.about.direction.vision.impactDescription'
+                    | kraakTranslate
+                }}
               </p>
             </div>
           </div>
@@ -236,13 +259,16 @@
 
 <section class="bg-brand-white py-16" kraakRevealOnScroll [revealDelayMs]="80">
   <div class="mx-auto max-w-6xl px-4 lg:px-6">
-    <h2 class="text-center text-3xl font-bold lg:text-4xl">Nos valeurs</h2>
+    <h2 class="text-center text-3xl font-bold lg:text-4xl">
+      {{ 'web.about.values.title' | kraakTranslate }}
+    </h2>
     <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <article class="rounded-card bg-neutral-50 p-5" kraakRevealOnScroll>
-        <p class="text-primary text-center text-lg font-bold">Humanisme</p>
+        <p class="text-primary text-center text-lg font-bold">
+          {{ 'web.about.values.items.humanism.title' | kraakTranslate }}
+        </p>
         <p class="text-brand-navy mt-3 text-sm">
-          Nous défendons le respect de chaque individu, la dignité humaine et
-          l'inclusion, sans discrimination.
+          {{ 'web.about.values.items.humanism.description' | kraakTranslate }}
         </p>
       </article>
       <article
@@ -251,11 +277,16 @@
         [revealDelayMs]="50"
       >
         <p class="text-primary text-center text-lg font-bold">
-          Responsabilité personnelle
+          {{
+            'web.about.values.items.personalResponsibility.title'
+              | kraakTranslate
+          }}
         </p>
         <p class="text-brand-navy mt-3 text-sm">
-          Nous encourageons chacun à prendre en main son développement, ses
-          choix et son avenir.
+          {{
+            'web.about.values.items.personalResponsibility.description'
+              | kraakTranslate
+          }}
         </p>
       </article>
       <article
@@ -264,38 +295,42 @@
         [revealDelayMs]="100"
       >
         <p class="text-primary text-center text-lg font-bold">
-          Leadership par le service
+          {{
+            'web.about.values.items.servantLeadership.title' | kraakTranslate
+          }}
         </p>
         <p class="text-brand-navy mt-3 text-sm">
-          Nous formons des leaders qui s'élèvent, élèvent les autres et créent
-          un impact positif.
+          {{
+            'web.about.values.items.servantLeadership.description'
+              | kraakTranslate
+          }}
         </p>
       </article>
       <article class="rounded-card bg-neutral-50 p-5">
         <p class="text-primary text-center text-lg font-bold">
-          Solidarité et esprit collectif
+          {{ 'web.about.values.items.solidarity.title' | kraakTranslate }}
         </p>
         <p class="text-brand-navy mt-3 text-sm">
-          Nous croyons à la force du collectif, de la collaboration et de
-          l'entraide.
+          {{ 'web.about.values.items.solidarity.description' | kraakTranslate }}
         </p>
       </article>
       <article class="rounded-card bg-neutral-50 p-5">
         <p class="text-primary text-center text-lg font-bold">
-          Résilience et courage
+          {{ 'web.about.values.items.resilience.title' | kraakTranslate }}
         </p>
         <p class="text-brand-navy mt-3 text-sm">
-          Nous préparons les jeunes et les organisations à affronter les défis,
-          dépasser les barrières et progresser.
+          {{ 'web.about.values.items.resilience.description' | kraakTranslate }}
         </p>
       </article>
       <article class="rounded-card bg-neutral-50 p-5">
         <p class="text-primary text-center text-lg font-bold">
-          Ouverture et connexion globale
+          {{ 'web.about.values.items.globalConnection.title' | kraakTranslate }}
         </p>
         <p class="text-brand-navy mt-3 text-sm">
-          Nous favorisons les échanges interculturels, l'apprentissage continu
-          et les compétences transférables.
+          {{
+            'web.about.values.items.globalConnection.description'
+              | kraakTranslate
+          }}
         </p>
       </article>
     </div>
@@ -310,7 +345,7 @@
   <div class="mx-auto max-w-5xl px-4 lg:px-6">
     <article
       class="relative flex flex-col items-center gap-8 rounded-[3rem] border border-neutral-200 bg-neutral-50 p-8 md:flex-row md:items-stretch md:gap-10 md:p-12"
-      aria-label="Citation du Directeur Général"
+      [attr.aria-label]="'web.about.quote.ariaLabel' | kraakTranslate"
       kraakRevealOnScroll
       [revealDelayMs]="80"
       [revealDelayMobileMs]="30"
@@ -318,7 +353,7 @@
       <div class="md:max-w-[36%] md:flex-1">
         <img
           src="/assets/site-visuals/photos/about-ceo-mr-aka.png"
-          alt="Portrait de Mr AKA, Directeur Général et Co-Fondateur de KRAAK"
+          [alt]="'web.about.quote.portraitAlt' | kraakTranslate"
           class="h-56 w-full rounded-3xl object-cover object-[52%_18%] sm:h-64 md:h-full md:min-h-[280px] md:object-[50%_30%] lg:object-[50%_26%]"
           loading="lazy"
           decoding="async"
@@ -331,7 +366,7 @@
         >
           <img
             src="/kraak-symbol.png"
-            alt="Symbole KRAAK"
+            [alt]="'web.about.quote.symbolAlt' | kraakTranslate"
             width="30"
             height="30"
             loading="lazy"
@@ -343,19 +378,17 @@
         <blockquote
           class="mt-5 max-w-[40ch] text-lg leading-relaxed text-neutral-700 italic sm:text-xl"
         >
-          "KRAAK Consulting n'est pas qu'un projet commercial, c'est une mission
-          de vie. Nous sommes ici pour briser les barrières qui empêchent le
-          talent africain de s'exprimer sur la scène mondiale."
+          {{ 'web.about.quote.text' | kraakTranslate }}
         </blockquote>
 
         <div class="mt-6 border-t border-neutral-200 pt-4">
           <p class="text-brand-navy text-base font-bold tracking-tight">
-            Mr AKA
+            {{ 'web.about.quote.author' | kraakTranslate }}
           </p>
           <p
             class="text-brand-navy-soft mt-1 text-xs font-semibold tracking-[0.12em] uppercase"
           >
-            Directeur Général /Co-Fondateur
+            {{ 'web.about.quote.role' | kraakTranslate }}
           </p>
         </div>
       </div>
@@ -364,9 +397,9 @@
 </section>
 
 <kraak-cta-banner
-  heading="Vous partagez cette ambition ?"
-  body="Découvrons ensemble comment KRAAK peut contribuer à votre trajectoire ou à votre organisation."
-  ctaLabel="Nous contacter"
+  [heading]="'web.about.closing.title' | kraakTranslate"
+  [body]="'web.about.closing.description' | kraakTranslate"
+  [ctaLabel]="'web.about.closing.cta' | kraakTranslate"
   ctaLink="/contact"
   ctaContext="about_main_cta"
 />

--- a/apps/client/projects/web/src/app/features/about/about.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.spec.ts
@@ -1,62 +1,382 @@
+import { ApplicationInitStatus } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { Router, provideRouter } from '@angular/router';
+import { afterEach, vi } from 'vitest';
+
+import { KraakI18nService, provideKraakI18n } from '../../../../../shared/i18n';
+import { AnalyticsService } from '../../core/analytics/analytics.service';
+import { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
+
 import AboutPage from './about.page';
 
+const FRENCH_FOCUS_TITLES = [
+  'Développement des compétences',
+  'Structuration des projets',
+  'Accès aux opportunités internationales',
+] as const;
+
+const ENGLISH_FOCUS_TITLES = [
+  'Skills development',
+  'Project structuring',
+  'Access to international opportunities',
+] as const;
+
+const FRENCH_VALUE_TITLES = [
+  'Humanisme',
+  'Responsabilité personnelle',
+  'Leadership par le service',
+  'Solidarité et esprit collectif',
+  'Résilience et courage',
+  'Ouverture et connexion globale',
+] as const;
+
+const ENGLISH_VALUE_TITLES = [
+  'Humanism',
+  'Personal responsibility',
+  'Servant leadership',
+  'Solidarity and collective strength',
+  'Resilience and courage',
+  'Openness and global connection',
+] as const;
+
+const FRENCH_COMPLETE_COPY = [
+  'À propos de KRAAK',
+  "KRAAK Consulting renforce les capacités des jeunes, accompagne les organisations et construit des passerelles utiles entre potentiel, opportunités et impact durable en Côte d'Ivoire et à l'international.",
+  'Développement des compétences',
+  'Des formations utiles pour gagner en clarté, en confiance et en compétitivité professionnelle.',
+  'Structuration des projets',
+  'Une méthode pour transformer les intentions en initiatives lisibles, suivies et capables de produire des résultats.',
+  'Accès aux opportunités internationales',
+  'Un accompagnement fiable pour aborder les études, le travail et la mobilité avec une stratégie cohérente.',
+  'Notre cap',
+  'Une mission claire, une vision utile.',
+  'Ces repères donnent une direction lisible à nos accompagnements et à nos partenariats.',
+  'Révéler, former et accompagner les jeunes dans leur transformation.',
+  'KRAAK Consulting a pour mission de révéler le potentiel des jeunes, de développer des compétences techniques et interpersonnelles solides, de faciliter leur intégration dans des environnements exigeants et de soutenir la création de valeur durable pour eux-mêmes, leurs communautés et les générations futures.',
+  'Ce que nous activons',
+  'Découverte et affirmation du potentiel',
+  'Compétences solides et utiles',
+  'Résultat attendu',
+  'Des trajectoires plus lisibles, plus confiantes et plus durables pour les jeunes que nous accompagnons.',
+  'Un acteur de référence pour les jeunes professionnels africains.',
+  "KRAAK Consulting se projette comme un acteur de référence dans la formation et l'accompagnement des jeunes professionnels africains, capable de faire émerger une génération consciente de sa valeur, prête à exercer un leadership utile et à contribuer à une société plus juste, plus inclusive et plus ouverte aux opportunités.",
+  'Ambition',
+  'Former des leaders conscients de leur valeur et utiles à leur environnement.',
+  'Impact',
+  "Contribuer à une société plus inclusive et porteuse d'opportunités durables.",
+  'Nos valeurs',
+  'Humanisme',
+  "Nous défendons le respect de chaque individu, la dignité humaine et l'inclusion, sans discrimination.",
+  'Responsabilité personnelle',
+  'Nous encourageons chacun à prendre en main son développement, ses choix et son avenir.',
+  'Leadership par le service',
+  "Nous formons des leaders qui s'élèvent, élèvent les autres et créent un impact positif.",
+  'Solidarité et esprit collectif',
+  "Nous croyons à la force du collectif, de la collaboration et de l'entraide.",
+  'Résilience et courage',
+  'Nous préparons les jeunes et les organisations à affronter les défis, dépasser les barrières et progresser.',
+  'Ouverture et connexion globale',
+  "Nous favorisons les échanges interculturels, l'apprentissage continu et les compétences transférables.",
+  "\"KRAAK Consulting n'est pas qu'un projet commercial, c'est une mission de vie. Nous sommes ici pour briser les barrières qui empêchent le talent africain de s'exprimer sur la scène mondiale.\"",
+  'Mr AKA',
+  'Directeur Général /Co-Fondateur',
+  'Vous partagez cette ambition ?',
+  'Découvrons ensemble comment KRAAK peut contribuer à votre trajectoire ou à votre organisation.',
+  'Nous contacter',
+] as const;
+
+const ENGLISH_COMPLETE_COPY = [
+  'About KRAAK',
+  "KRAAK Consulting builds young people's capabilities, supports organisations and creates valuable bridges between potential, opportunity and lasting impact in Côte d'Ivoire and internationally.",
+  'Skills development',
+  'Practical training to build clarity, confidence and professional competitiveness.',
+  'Project structuring',
+  'A method for turning intentions into clear, monitored initiatives capable of delivering results.',
+  'Access to international opportunities',
+  'Reliable support for approaching study, work and mobility with a coherent strategy.',
+  'Our direction',
+  'A clear mission and a meaningful vision.',
+  'These guideposts give our support and partnerships a clear direction.',
+  'Unlock potential, build skills and support young people through transformation.',
+  "KRAAK Consulting's mission is to unlock young people's potential, build strong technical and interpersonal skills, help them integrate into demanding environments and support lasting value creation for themselves, their communities and future generations.",
+  'What we set in motion',
+  'Discovering and asserting potential',
+  'Strong, practical skills',
+  'Intended outcome',
+  'Clearer, more confident and more sustainable pathways for the young people we support.',
+  'A leading partner for young African professionals.',
+  'KRAAK Consulting aims to become a leading organisation in the training and support of young African professionals, helping to shape a generation that understands its value, is ready to practise purposeful leadership and contributes to a fairer, more inclusive society that is open to opportunity.',
+  'Ambition',
+  'Develop leaders who understand their value and serve their communities.',
+  'Impact',
+  'Contribute to a more inclusive society with sustainable opportunities.',
+  'Our values',
+  'Humanism',
+  'We uphold respect for every individual, human dignity and inclusion, without discrimination.',
+  'Personal responsibility',
+  'We encourage everyone to take ownership of their development, choices and future.',
+  'Servant leadership',
+  'We develop leaders who rise, lift others and create positive impact.',
+  'Solidarity and collective strength',
+  'We believe in collective strength, collaboration and mutual support.',
+  'Resilience and courage',
+  'We prepare young people and organisations to face challenges, overcome barriers and make progress.',
+  'Openness and global connection',
+  'We foster intercultural exchange, lifelong learning and transferable skills.',
+  '"KRAAK Consulting is more than a business venture; it is a life mission. We are here to break down the barriers that prevent African talent from expressing itself on the global stage."',
+  'Mr AKA',
+  'Chief Executive Officer / Co-Founder',
+  'Do you share this ambition?',
+  'Let us explore how KRAAK can contribute to your journey or organisation.',
+  'Contact us',
+] as const;
+
+function normalizedText(element: Element | null): string {
+  return (element?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function textList(page: HTMLElement, selector: string): string[] {
+  return Array.from(page.querySelectorAll(selector)).map((element) =>
+    normalizedText(element),
+  );
+}
+
+const gsapAnimationsServiceMock: Pick<
+  GsapAnimationsService,
+  | 'animatePageIn'
+  | 'initializeFigureAnimations'
+  | 'initializeReversibleScrollAnimations'
+  | 'initializeInteractiveCardAnimations'
+  | 'initializeButtonTransitions'
+  | 'initializeIconAnimations'
+  | 'killAllAnimations'
+> = {
+  animatePageIn: () => undefined,
+  initializeFigureAnimations: () => undefined,
+  initializeReversibleScrollAnimations: () => undefined,
+  initializeInteractiveCardAnimations: () => undefined,
+  initializeButtonTransitions: () => undefined,
+  initializeIconAnimations: () => undefined,
+  killAllAnimations: () => undefined,
+};
+
 describe('AboutPage', () => {
+  let analyticsService: Pick<AnalyticsService, 'trackEvent'>;
+
   beforeEach(async () => {
+    analyticsService = { trackEvent: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [AboutPage],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        provideKraakI18n(),
+        { provide: AnalyticsService, useValue: analyticsService },
+        {
+          provide: GsapAnimationsService,
+          useValue: gsapAnimationsServiceMock,
+        },
+      ],
     }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
   });
 
-  it('Given the about page component When it is created Then the instance exists', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Given the About page route When the component initializes Then the page instance is created', () => {
     const fixture = TestBed.createComponent(AboutPage);
+
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('Given the about page When it renders Then it shows the page heading', () => {
+  it('Given the canonical French About route When the complete page renders Then all historical narrative accessibility copy and CTA remain French', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue(
+      '/fr/a-propos',
+    );
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
-    const heading = fixture.nativeElement.querySelector('h1');
-    expect(heading?.textContent).toContain(
+
+    const page = fixture.nativeElement as HTMLElement;
+    const content = normalizedText(page);
+    const quote = page.querySelector('section:nth-of-type(5) article');
+    const images = page.querySelectorAll('section:nth-of-type(5) img');
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
       'Une structure engagée pour le capital humain et les trajectoires durables.',
     );
-  });
-
-  it('Given the about page When it renders Then it shows the mission, intervention levels and values', () => {
-    const fixture = TestBed.createComponent(AboutPage);
-    fixture.detectChanges();
-    const content = fixture.nativeElement.textContent as string;
-
-    expect(content).toContain(
-      'Révéler, former et accompagner les jeunes dans leur transformation',
+    for (const expectedCopy of FRENCH_COMPLETE_COPY) {
+      expect(content).toContain(expectedCopy);
+    }
+    expect(quote?.getAttribute('aria-label')).toBe(
+      'Citation du Directeur Général',
     );
-    expect(content).toContain('Développement des compétences');
-    expect(content).toContain('Structuration des projets');
-    expect(content).toContain('Accès aux opportunités internationales');
-    expect(content).toContain('Ouverture et connexion globale');
-  });
-
-  it('Given the about page When it renders Then it keeps the mission-first narrative without a team block', () => {
-    const fixture = TestBed.createComponent(AboutPage);
-    fixture.detectChanges();
-    const content = fixture.nativeElement.textContent as string;
-
-    expect(content).toContain('Une mission claire, une vision utile.');
-    expect(content).toContain('Nos valeurs');
+    expect(images[0]?.getAttribute('alt')).toBe(
+      'Portrait de Mr AKA, Directeur Général et Co-Fondateur de KRAAK',
+    );
+    expect(images[1]?.getAttribute('alt')).toBe('Symbole KRAAK');
+    expect(cta.ctaLink).toBe('/contact');
+    expect(cta.ctaContext).toBe('about_main_cta');
+    expect(page.querySelector('kraak-cta-banner a')?.getAttribute('href')).toBe(
+      '/fr/contact',
+    );
     expect(content).not.toContain("L'équipe KRAAK");
+    expect(content).not.toContain('[missing:web.about.');
   });
 
-  it('Given the about page When it renders Then it shows the CEO quote section', () => {
+  it('Given the English About route When every narrative and leadership section renders Then all visitor-facing and accessibility copy comes from the English catalog', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue('/en/about');
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
     const fixture = TestBed.createComponent(AboutPage);
     fixture.detectChanges();
-    const content = fixture.nativeElement.textContent as string;
 
-    expect(content).toContain(
-      "KRAAK Consulting n'est pas qu'un projet commercial, c'est une mission de vie.",
+    const page = fixture.nativeElement as HTMLElement;
+    const content = normalizedText(page);
+    const quote = page.querySelector('section:nth-of-type(5) article');
+    const images = page.querySelectorAll('section:nth-of-type(5) img');
+
+    expect(normalizedText(page.querySelector('h1'))).toBe(
+      'A purpose-driven organisation for human capital and sustainable pathways.',
     );
-    expect(content).toContain('Mr AKA');
-    expect(content).toContain('Directeur Général /Co-Fondateur');
+    for (const expectedCopy of ENGLISH_COMPLETE_COPY) {
+      expect(content).toContain(expectedCopy);
+    }
+    expect(quote?.getAttribute('aria-label')).toBe(
+      'Quote from the Chief Executive Officer',
+    );
+    expect(images[0]?.getAttribute('alt')).toBe(
+      'Portrait of Mr AKA, Chief Executive Officer and Co-Founder of KRAAK',
+    );
+    expect(images[1]?.getAttribute('alt')).toBe('KRAAK symbol');
+    expect(page.querySelector('kraak-cta-banner a')?.getAttribute('href')).toBe(
+      '/en/contact',
+    );
+    expect(content).not.toContain('Une structure engagée');
+    expect(content).not.toContain('Notre cap');
+    expect(content).not.toContain('Nos valeurs');
+    expect(content).not.toContain('Directeur Général');
+    expect(content).not.toContain('[missing:web.about.');
+  });
+
+  it('Given one rendered French About fixture with the English route stubbed When the locale changes to English Then sections accessibility copy and CTA inputs update without recreating components', async () => {
+    const router = TestBed.inject(Router);
+    const i18n = TestBed.inject(KraakI18nService);
+    vi.spyOn(router, 'url', 'get').mockReturnValue('/en/about');
+    await i18n.setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(AboutPage);
+    const aboutPage = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+
+    expect(textList(page, 'section:nth-of-type(2) article h2')).toEqual(
+      FRENCH_FOCUS_TITLES,
+    );
+    expect(
+      textList(page, 'section:nth-of-type(4) article > p:first-child'),
+    ).toEqual(FRENCH_VALUE_TITLES);
+    expect(cta.ctaLabel).toBe('Nous contacter');
+
+    await i18n.setLocale('en-GB');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance).toBe(aboutPage);
+    expect(
+      fixture.debugElement.query(By.directive(CtaBanner)).componentInstance,
+    ).toBe(cta);
+    expect(textList(page, 'section:nth-of-type(2) article h2')).toEqual(
+      ENGLISH_FOCUS_TITLES,
+    );
+    expect(
+      textList(page, 'section:nth-of-type(4) article > p:first-child'),
+    ).toEqual(ENGLISH_VALUE_TITLES);
+    expect(
+      page
+        .querySelector('section:nth-of-type(5) article')
+        ?.getAttribute('aria-label'),
+    ).toBe('Quote from the Chief Executive Officer');
+    expect(
+      page.querySelector('section:nth-of-type(5) img')?.getAttribute('alt'),
+    ).toBe(
+      'Portrait of Mr AKA, Chief Executive Officer and Co-Founder of KRAAK',
+    );
+    expect(cta.heading).toBe('Do you share this ambition?');
+    expect(cta.body).toBe(
+      'Let us explore how KRAAK can contribute to your journey or organisation.',
+    );
+    expect(cta.ctaLabel).toBe('Contact us');
+    expect(page.querySelector('kraak-cta-banner a')?.getAttribute('href')).toBe(
+      '/en/contact',
+    );
+    expect(normalizedText(page)).not.toContain('[missing:web.about.');
+  });
+
+  it('Given the About narrative structure When the French page renders Then focus mission vision values icons and leadership assets remain intact', async () => {
+    await TestBed.inject(KraakI18nService).setLocale('fr-CI');
+
+    const fixture = TestBed.createComponent(AboutPage);
+    fixture.detectChanges();
+
+    const page = fixture.nativeElement as HTMLElement;
+    const directionArticles = page.querySelectorAll(
+      'article[data-motion="reversible"]',
+    );
+    const leadershipImages = page.querySelectorAll(
+      'section:nth-of-type(5) img',
+    );
+
+    expect(
+      page.querySelectorAll('section:nth-of-type(2) article'),
+    ).toHaveLength(3);
+    expect(directionArticles).toHaveLength(2);
+    expect(textList(page, 'article[data-motion="reversible"] h3')).toEqual([
+      'Révéler, former et accompagner les jeunes dans leur transformation.',
+      'Un acteur de référence pour les jeunes professionnels africains.',
+    ]);
+    expect(
+      page.querySelectorAll('section:nth-of-type(4) article'),
+    ).toHaveLength(6);
+    expect(page.querySelectorAll('i[aria-hidden="true"]')).not.toHaveLength(0);
+    expect(leadershipImages[0]?.getAttribute('src')).toBe(
+      '/assets/site-visuals/photos/about-ceo-mr-aka.png',
+    );
+    expect(leadershipImages[1]?.getAttribute('src')).toBe('/kraak-symbol.png');
+  });
+
+  it('Given the English About CTA When its conversion handler runs Then analytics keeps a stable event and context with a localized label and URL', async () => {
+    vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue('/en/about');
+    await TestBed.inject(KraakI18nService).setLocale('en-GB');
+
+    const fixture = TestBed.createComponent(AboutPage);
+    fixture.detectChanges();
+
+    const cta = fixture.debugElement.query(By.directive(CtaBanner))
+      .componentInstance as CtaBanner;
+
+    expect(cta.ctaLabel).toBe('Contact us');
+    expect(cta.ctaLink).toBe('/contact');
+
+    cta.onCtaClick();
+
+    expect(analyticsService.trackEvent).toHaveBeenCalledWith(
+      'conversion_cta_click',
+      {
+        cta_context: 'about_main_cta',
+        cta_label: 'Contact us',
+        cta_link: '/en/contact',
+      },
+    );
   });
 });

--- a/apps/client/projects/web/src/app/features/about/about.page.ts
+++ b/apps/client/projects/web/src/app/features/about/about.page.ts
@@ -5,6 +5,7 @@ import { buildHeroBackgroundStyle } from '../../shared/brand/brand-constants';
 import { CtaBanner } from '../../shared/cta-banner/cta-banner.component';
 import { RevealOnScrollDirective } from '../../shared/motion/reveal-on-scroll.directive';
 import type { GsapAnimationsService } from '../../core/animations/gsap-animations.service';
+import { KraakTranslatePipe } from '../../../../../shared/i18n';
 
 const ABOUT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
   '/assets/site-visuals/photos/about-hero-community-dialogue.avif',
@@ -13,7 +14,7 @@ const ABOUT_HERO_BACKGROUND_STYLE = buildHeroBackgroundStyle(
 @Component({
   selector: 'kraak-about-page',
   standalone: true,
-  imports: [NgStyle, CtaBanner, RevealOnScrollDirective],
+  imports: [NgStyle, CtaBanner, RevealOnScrollDirective, KraakTranslatePipe],
   templateUrl: './about.page.html',
 })
 export default class AboutPage implements OnInit, OnDestroy {

--- a/apps/client/tests/e2e/i18n-about.spec.ts
+++ b/apps/client/tests/e2e/i18n-about.spec.ts
@@ -1,0 +1,244 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const FRENCH_FOCUS_TITLES = [
+  'Développement des compétences',
+  'Structuration des projets',
+  'Accès aux opportunités internationales',
+] as const;
+
+const ENGLISH_FOCUS_TITLES = [
+  'Skills development',
+  'Project structuring',
+  'Access to international opportunities',
+] as const;
+
+const FRENCH_VALUE_TITLES = [
+  'Humanisme',
+  'Responsabilité personnelle',
+  'Leadership par le service',
+  'Solidarité et esprit collectif',
+  'Résilience et courage',
+  'Ouverture et connexion globale',
+] as const;
+
+const ENGLISH_VALUE_TITLES = [
+  'Humanism',
+  'Personal responsibility',
+  'Servant leadership',
+  'Solidarity and collective strength',
+  'Resilience and courage',
+  'Openness and global connection',
+] as const;
+
+function getLanguageSelector(page: Page, accessibleName: RegExp) {
+  return page.getByRole('group', { name: accessibleName });
+}
+
+async function expectHeadingsVisible(
+  page: Page,
+  headings: readonly string[],
+): Promise<void> {
+  for (const heading of headings) {
+    await expect(
+      page.getByRole('heading', { name: heading, exact: true }),
+    ).toBeVisible();
+  }
+}
+
+async function expectTextsVisible(
+  page: Page,
+  texts: readonly string[],
+): Promise<void> {
+  for (const text of texts) {
+    await expect(page.getByText(text, { exact: true })).toBeVisible();
+  }
+}
+
+test.describe('Internationalisation publique de la page À propos', () => {
+  test('Given the canonical French About route When the page loads Then the complete narrative leadership content and localized CTA remain French', async ({
+    page,
+  }) => {
+    await page.goto('/fr/a-propos', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Une structure engagée pour le capital humain et les trajectoires durables.',
+      }),
+    ).toBeVisible();
+    await expectHeadingsVisible(page, FRENCH_FOCUS_TITLES);
+    await expect(
+      page.getByRole('heading', {
+        name: 'Une mission claire, une vision utile.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Révéler, former et accompagner les jeunes dans leur transformation.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Un acteur de référence pour les jeunes professionnels africains.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expectTextsVisible(page, FRENCH_VALUE_TITLES);
+    await expect(
+      page.getByRole('article', { name: 'Citation du Directeur Général' }),
+    ).toContainText('Mr AKA');
+    await expect(
+      page.getByAltText(
+        'Portrait de Mr AKA, Directeur Général et Co-Fondateur de KRAAK',
+      ),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('kraak-cta-banner')
+        .getByRole('link', { name: 'Nous contacter', exact: true }),
+    ).toHaveAttribute('href', '/fr/contact');
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText('[missing:web.about.');
+  });
+
+  test('Given the English About route When every narrative section renders Then capabilities mission vision values leadership quote CTA and accessibility copy are English while SEO remains locked', async ({
+    page,
+  }) => {
+    await page.goto('/en/about', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'A purpose-driven organisation for human capital and sustainable pathways.',
+      }),
+    ).toBeVisible();
+    await expectHeadingsVisible(page, ENGLISH_FOCUS_TITLES);
+    await expect(
+      page.getByRole('heading', {
+        name: 'A clear mission and a meaningful vision.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Unlock potential, build skills and support young people through transformation.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'A leading partner for young African professionals.',
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expectTextsVisible(page, ENGLISH_VALUE_TITLES);
+    const quote = page.getByRole('article', {
+      name: 'Quote from the Chief Executive Officer',
+    });
+    await expect(quote).toContainText(
+      'KRAAK Consulting is more than a business venture; it is a life mission.',
+    );
+    await expect(quote).toContainText('Chief Executive Officer / Co-Founder');
+    await expect(
+      page.getByAltText(
+        'Portrait of Mr AKA, Chief Executive Officer and Co-Founder of KRAAK',
+      ),
+    ).toBeVisible();
+    await expect(quote.getByAltText('KRAAK symbol')).toBeVisible();
+    await expect(
+      page
+        .locator('kraak-cta-banner')
+        .getByRole('link', { name: 'Contact us', exact: true }),
+    ).toHaveAttribute('href', '/en/contact');
+    await expect(page.locator('body')).not.toContainText('Notre cap');
+    await expect(page.locator('body')).not.toContainText('Nos valeurs');
+    await expect(page.locator('body')).not.toContainText('Directeur Général');
+    await expect(page.locator('body')).not.toContainText('[missing:web.about.');
+
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex, nofollow',
+    );
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      /\/en\/about$/,
+    );
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="fr-CI"]'),
+    ).toHaveAttribute('href', /\/fr\/a-propos$/);
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="x-default"]'),
+    ).toHaveAttribute('href', /\/fr\/a-propos$/);
+    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+
+    const sitemapResponse = await page.request.get('/sitemap.xml');
+    expect(sitemapResponse.ok()).toBe(true);
+    const sitemap = await sitemapResponse.text();
+    expect(sitemap).toContain('/fr/a-propos');
+    expect(sitemap).not.toContain('/en/about');
+  });
+
+  test('Given the English About CTA When it is activated with the keyboard Then it opens the localized Contact route', async ({
+    page,
+  }) => {
+    await page.goto('/en/about');
+
+    const contactLink = page.locator('kraak-cta-banner').getByRole('link', {
+      name: 'Contact us',
+      exact: true,
+    });
+    await expect(contactLink).toBeVisible();
+    await contactLink.focus();
+    await expect(contactLink).toBeFocused();
+
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/en\/contact$/);
+  });
+
+  test('Given the French About route with query and fragment When the visitor switches language in both directions Then the equivalent About route query fragment and localized content are preserved', async ({
+    page,
+  }) => {
+    await page.goto('/fr/a-propos?campaign=about#mission', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const frenchLanguageSelector = getLanguageSelector(
+      page,
+      /langue|language/i,
+    );
+    await frenchLanguageSelector
+      .getByRole('link', { name: /anglais|english/i })
+      .click();
+
+    await expect(page).toHaveURL(/\/en\/about\?campaign=about#mission$/);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'A purpose-driven organisation for human capital and sustainable pathways.',
+      }),
+    ).toBeVisible();
+
+    const englishLanguageSelector = getLanguageSelector(
+      page,
+      /langue|language/i,
+    );
+    await englishLanguageSelector
+      .getByRole('link', { name: /français|french/i })
+      .click();
+
+    await expect(page).toHaveURL(/\/fr\/a-propos\?campaign=about#mission$/);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Une structure engagée pour le capital humain et les trajectoires durables.',
+      }),
+    ).toBeVisible();
+  });
+});

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -35,10 +35,10 @@ Le site web KRAAK est l'application Angular publique située dans
   coque publique partagée (pied de page, lien d'accès rapide et commande de
   retour en haut) forme le deuxième incrément. La page Contact constitue le
   troisième incrément localisé, la page Services le quatrième et la page
-  Programmes le cinquième. Parmi les pages de conversion de cette série, seule
-  la page À propos reste à localiser dans une PR dédiée. Les autres pages
-  `/en/...` restent un scaffold technique non indexable tant que leurs contenus
-  anglais ne sont pas traduits et relus.
+  Programmes le cinquième. La page À propos constitue le sixième incrément. Les
+  quatre pages de conversion de cette série sont désormais localisées. Les
+  autres pages `/en/...` restent un scaffold technique non indexable tant que
+  leurs contenus anglais ne sont pas traduits et relus.
 
 ## Implémentation active
 
@@ -46,7 +46,8 @@ Le site web KRAAK est l'application Angular publique située dans
 - Prerender public : [`../../apps/client/projects/web/src/app/app.routes.server.ts`](../../apps/client/projects/web/src/app/app.routes.server.ts).
 - Catalogues runtime : [`../../apps/client/projects/shared/i18n/catalogs/`](../../apps/client/projects/shared/i18n/catalogs/),
   avec les espaces de clés `web.home`, `web.nav`, `web.shell`, `web.contact`,
-  `web.services` et `web.programs` pour les incréments publics bilingues livrés.
+  `web.services`, `web.programs` et `web.about` pour les incréments publics
+  bilingues livrés.
 - Tests de surface : [`../../apps/client/projects/web/src/app/app.routes.spec.ts`](../../apps/client/projects/web/src/app/app.routes.spec.ts)
   et [`../../apps/client/projects/web/src/app/app.routes.server.spec.ts`](../../apps/client/projects/web/src/app/app.routes.server.spec.ts).
 - Historique design : [`../archive/vitrine-design/`](../archive/vitrine-design/),
@@ -64,26 +65,22 @@ entrées sitemap et l'attribut `<html lang>` sont générés par locale depuis l
 modèle de routes web localisées.
 
 La page d'accueil, la barre de navigation, la coque publique partagée, les pages
-Contact, Services et Programmes servent désormais leur contenu français ou
-anglais depuis les catalogues selon la locale de l'URL. Un sélecteur de langue
-relie les variantes d'une même page publique lorsque le mapping existe, puis
-revient à la page d'accueil de la langue cible lorsqu'aucune variante publique
-n'est disponible.
+Contact, Services, Programmes et À propos servent désormais leur contenu
+français ou anglais depuis les catalogues selon la locale de l'URL. Un sélecteur
+de langue relie les variantes d'une même page publique lorsque le mapping existe,
+puis revient à la page d'accueil de la langue cible lorsqu'aucune variante
+publique n'est disponible.
 
-Parmi les pages de conversion de cette série, seule la page À propos reste à
-localiser dans une PR distincte. L'activation de l'indexation anglaise, des
-entrées sitemap et des liens `hreflang` réciproques reste conditionnée à une
-revue humaine du contenu anglais de chaque page.
+Les quatre pages de conversion prévues dans cette série sont désormais
+localisées. L'activation de l'indexation anglaise, des entrées sitemap et des
+liens `hreflang` réciproques reste conditionnée à une revue humaine du contenu
+anglais de chaque page.
 
-La copie anglaise de Services est proposée mais n'a pas encore reçu cette revue
-humaine. En conséquence, `/en/services` reste `noindex, nofollow`, hors du
-sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis
-`/fr/services`.
-
-La copie anglaise de Programmes est elle aussi proposée mais n'a pas encore reçu
-de revue humaine. En conséquence, `/en/programs` reste `noindex, nofollow`, hors
-du sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis
-`/fr/programmes`.
+Les copies anglaises de Contact, Services, Programmes et À propos sont proposées
+mais n'ont pas encore reçu de revue humaine. En conséquence, `/en/contact`,
+`/en/services`, `/en/programs` et `/en/about` restent `noindex, nofollow`, hors
+du sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis leur
+page française respective.
 
 Ces incréments de contenu ne modifient pas encore la politique SEO du scaffold
 anglais : les routes anglaises restent `noindex, nofollow`, exclues


### PR DESCRIPTION
## Résumé

- sert l’intégralité de la page À propos depuis les catalogues `fr-CI` / `en-GB`, y compris les textes accessibles et les alternatives d’images
- conserve la structure du hero, les trois axes, mission/vision, les six valeurs, la citation du dirigeant, les assets et les sélecteurs GSAP
- localise le CTA et son libellé analytics tout en gardant `/contact` et `about_main_cta` stables
- ajoute des tests unitaires et Playwright Given/When/Then sur Chromium, Firefox et WebKit
- documente le sixième incrément et la fin des quatre slices de conversion

## Validation

- `pnpm i18n:check` — 383 clés partagées
- `pnpm typecheck:web`
- tests unitaires À propos — 6/6
- Playwright À propos — 12/12 sur Chromium, Firefox et WebKit
- tests web complets — 683/683
- tests mobile complets — 253/253
- tests d’intégration API — 31/31
- build/prerender web — 26 routes
- revue indépendante — aucun finding actionnable

## Garde-fou SEO

La copie anglaise reste proposée et non revue humainement, en particulier la citation attribuée. `/en/about` reste donc `noindex, nofollow`, hors sitemap et sans hreflang `en-GB` réciproque. Les mêmes verrous restent actifs pour Contact, Services et Programmes jusqu’à leur revue page par page.

Closes #648