### PR TITLE
feat(web): activer le SEO anglais de l’accueil

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,14 +64,14 @@ publique partagée constitue le deuxième incrément et la page Contact le
 troisième. La page Services constitue le quatrième incrément public localisé.
 La page Programmes constitue le cinquième et la page À propos le sixième. Les
 quatre pages de conversion de cette série, Contact, Services, Programmes et À
-propos, sont désormais localisées. Leurs copies anglaises restent proposées et
-n'ont pas encore reçu de revue humaine : `/en/contact`, `/en/services`,
-`/en/programs` et `/en/about` restent donc `noindex, nofollow`, hors du sitemap
-et sans lien `hreflang="en-GB"` réciproque depuis leur page française. Les autres
-pages publiques anglaises et leurs métadonnées SEO restent dans l'état de
-scaffold non indexable jusqu'à leur traduction et leur revue humaine dédiées.
-L'indexation anglaise, les entrées sitemap et les liens `hreflang` réciproques ne
-sont activés qu'après cette revue pour chaque page.
+propos, sont désormais localisées. La revue humaine de leur copie anglaise, de
+celle de l'accueil et de la coque publique a été approuvée le 16 août 2026.
+`/en/` est désormais indexable, présent dans le sitemap et relié à `/fr/` par
+des liens `hreflang` réciproques. Contact, Services, Programmes et À propos
+restent temporairement `noindex, nofollow`, hors du sitemap et sans
+`hreflang="en-GB"` réciproque jusqu'à leur PR d'activation SEO respective. Les
+autres pages publiques anglaises restent dans l'état de scaffold non indexable
+jusqu'à leur traduction et leur revue humaine dédiées.
 
 Les incréments suivants doivent rester courts, documentés et validés sans
 localiser implicitement les routes privées, admin ou mobiles.

--- a/apps/client/projects/web/public/sitemap.xml
+++ b/apps/client/projects/web/public/sitemap.xml
@@ -4,6 +4,15 @@
   <url>
     <loc>https://kraak-web-prod.onrender.com/fr/</loc>
     <xhtml:link rel="alternate" hreflang="fr-CI" href="https://kraak-web-prod.onrender.com/fr/" />
+    <xhtml:link rel="alternate" hreflang="en-GB" href="https://kraak-web-prod.onrender.com/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://kraak-web-prod.onrender.com/fr/" />
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://kraak-web-prod.onrender.com/en/</loc>
+    <xhtml:link rel="alternate" hreflang="fr-CI" href="https://kraak-web-prod.onrender.com/fr/" />
+    <xhtml:link rel="alternate" hreflang="en-GB" href="https://kraak-web-prod.onrender.com/en/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://kraak-web-prod.onrender.com/fr/" />
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>

--- a/apps/client/projects/web/src/app/app.routes.spec.ts
+++ b/apps/client/projects/web/src/app/app.routes.spec.ts
@@ -117,7 +117,7 @@ describe('Web routes', () => {
       }
     });
 
-    it('When inspecting English scaffold routes Then their SEO policy blocks indexing', () => {
+    it('Given the approved English homepage, When inspecting English routes, Then only the homepage is indexable', () => {
       const englishRoute = localeRoute(
         buildRoutes({ includeParticipantArea: false }),
         'en',
@@ -125,8 +125,12 @@ describe('Web routes', () => {
       const pageRoutes = (englishRoute?.children ?? []).filter(
         (route) => route.path !== '**',
       );
+      const homeRoute = pageRoutes.find((route) => route.path === '');
 
-      for (const route of pageRoutes) {
+      expect(homeRoute?.data?.['seo']?.robots).toBeUndefined();
+      expect(homeRoute?.data?.['seo']?.temporary).toBe(false);
+
+      for (const route of pageRoutes.filter((route) => route.path !== '')) {
         expect(route.data?.['seo']?.robots).toBe('noindex, nofollow');
         expect(route.data?.['seo']?.temporary).toBe(true);
       }

--- a/apps/client/projects/web/src/app/routing/localized-public-routes.json
+++ b/apps/client/projects/web/src/app/routing/localized-public-routes.json
@@ -21,6 +21,9 @@
       "component": "home",
       "seoPath": "",
       "includeInSitemap": true,
+      "indexableByLocale": {
+        "en-GB": true
+      },
       "paths": {
         "fr-CI": "/fr/",
         "en-GB": "/en/"

--- a/apps/client/projects/web/src/app/routing/localized-public-routes.spec.ts
+++ b/apps/client/projects/web/src/app/routing/localized-public-routes.spec.ts
@@ -49,6 +49,22 @@ describe('Given the localized public route model', () => {
     expect(findLocalizedPublicRouteEntry('home', 'en').path).toBe('/en/');
   });
 
+  it('Given human approval for the English homepage, When route policy is resolved, Then only that English conversion entry is indexable', () => {
+    expect(findLocalizedPublicRouteEntry('home', 'en-GB').indexable).toBe(true);
+    expect(findLocalizedPublicRouteEntry('contact', 'en-GB').indexable).toBe(
+      false,
+    );
+    expect(findLocalizedPublicRouteEntry('services', 'en-GB').indexable).toBe(
+      false,
+    );
+    expect(findLocalizedPublicRouteEntry('programs', 'en-GB').indexable).toBe(
+      false,
+    );
+    expect(findLocalizedPublicRouteEntry('about', 'en-GB').indexable).toBe(
+      false,
+    );
+  });
+
   it('Given localized paths, when the model is checked, then every public path is unique', () => {
     const paths = localizedPublicRouteEntries.map((entry) => entry.path);
 

--- a/apps/client/projects/web/src/app/seo/seo.service.spec.ts
+++ b/apps/client/projects/web/src/app/seo/seo.service.spec.ts
@@ -155,7 +155,7 @@ describe('SeoService', () => {
     ).toBe('en_GB');
   });
 
-  it('Given canonical and alternate links already exist, when applyPageSeo is called again, then existing SEO links are updated without duplicates', () => {
+  it('Given canonical and alternate links already exist, When approved homepage SEO is applied again, Then reciprocal links are updated without duplicates', () => {
     const service = TestBed.inject(SeoService);
     const contactPage = findLocalizedSeoPageByPath('/fr/contact');
     const homePage = findLocalizedSeoPageByPath('/fr/');
@@ -170,8 +170,13 @@ describe('SeoService', () => {
     expect(
       document.querySelector('link[rel="canonical"]')?.getAttribute('href'),
     ).toBe(LOCAL_HOME_URL);
-    expect(
-      document.querySelectorAll('link[rel="alternate"][hreflang]'),
-    ).toHaveLength(2);
+    const alternateLinks = [
+      ...document.querySelectorAll('link[rel="alternate"][hreflang]'),
+    ];
+
+    expect(alternateLinks).toHaveLength(3);
+    expect(alternateLinks.map((link) => link.getAttribute('hreflang'))).toEqual(
+      ['fr-CI', 'en-GB', 'x-default'],
+    );
   });
 });

--- a/apps/client/projects/web/src/app/seo/site-seo.en-GB.json
+++ b/apps/client/projects/web/src/app/seo/site-seo.en-GB.json
@@ -1,0 +1,17 @@
+[
+  {
+    "path": "",
+    "title": "Build your skills. Launch your projects. | KRAAK Consulting",
+    "description": "KRAAK Consulting supports students, professionals, businesses and members of the diaspora with practical solutions in training, project management and immigration.",
+    "openGraph": {
+      "title": "Build your skills. Launch your projects. | KRAAK Consulting",
+      "description": "KRAAK Consulting supports students, professionals, businesses and members of the diaspora with practical solutions in training, project management and immigration.",
+      "imagePath": "/assets/site-visuals/photos/home-hero-workshop.jpg",
+      "imageAlt": "Participants attending a professional development session in a collaborative workshop"
+    },
+    "sitemap": {
+      "changeFrequency": "weekly",
+      "priority": 1
+    }
+  }
+]

--- a/apps/client/projects/web/src/app/seo/site-seo.spec.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.spec.ts
@@ -92,11 +92,34 @@ describe('site-seo', () => {
     expect(servicesPage?.temporary).toBe(true);
   });
 
-  it('Given localized sitemap generation, when XML is built, then it contains only indexable French canonical URLs', () => {
+  it('Given the approved English homepage, When SEO is resolved, Then reviewed metadata and reciprocal locale links are indexable', () => {
+    const homePage = findLocalizedSeoPageByPath('/en/');
+
+    expect(homePage).toBeDefined();
+    expect(homePage?.title).toBe(
+      'Build your skills. Launch your projects. | KRAAK Consulting',
+    );
+    expect(homePage?.description).toBe(
+      'KRAAK Consulting supports students, professionals, businesses and members of the diaspora with practical solutions in training, project management and immigration.',
+    );
+    expect(homePage?.canonicalPath).toBe('/en/');
+    expect(homePage?.htmlLang).toBe('en-GB');
+    expect(homePage?.openGraphLocale).toBe('en_GB');
+    expect(homePage?.robots).toBeUndefined();
+    expect(homePage?.temporary).toBe(false);
+    expect(homePage?.hreflangLinks).toEqual([
+      { hreflang: 'fr-CI', path: '/fr/' },
+      { hreflang: 'en-GB', path: '/en/' },
+      { hreflang: 'x-default', path: '/fr/' },
+    ]);
+  });
+
+  it('Given approved English homepage SEO, When XML is built, Then the English homepage is included while unreviewed English pages stay excluded', () => {
     const sitemap = buildSitemapXml(DEFAULT_SITE_URL);
 
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/fr/services</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/fr/</loc>`);
+    expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/en/</loc>`);
     expect(sitemap).toContain(`<loc>${DEFAULT_SITE_URL}/fr/a-propos</loc>`);
     expect(sitemap).not.toContain(`<loc>${DEFAULT_SITE_URL}/en/services</loc>`);
     expect(sitemap).not.toContain(`<loc>${DEFAULT_SITE_URL}/connexion</loc>`);
@@ -105,7 +128,7 @@ describe('site-seo', () => {
     expect(sitemap).not.toContain(`<loc>${DEFAULT_SITE_URL}/about</loc>`);
   });
 
-  it('Given localized sitemap generation, when alternates are emitted, then fr-CI and x-default are present without en-GB in PR 3', () => {
+  it('Given approved English homepage SEO, When alternates are emitted, Then the homepage is reciprocal while unreviewed pages remain French-only', () => {
     const sitemap = buildSitemapXml(DEFAULT_SITE_URL);
 
     expect(sitemap).toContain('xmlns:xhtml="http://www.w3.org/1999/xhtml"');
@@ -115,7 +138,12 @@ describe('site-seo', () => {
     expect(sitemap).toContain(
       `<xhtml:link rel="alternate" hreflang="x-default" href="${DEFAULT_SITE_URL}/fr/services" />`,
     );
-    expect(sitemap).not.toContain('hreflang="en-GB"');
+    expect(sitemap).toContain(
+      `<xhtml:link rel="alternate" hreflang="en-GB" href="${DEFAULT_SITE_URL}/en/" />`,
+    );
+    expect(sitemap).not.toContain(
+      `<xhtml:link rel="alternate" hreflang="en-GB" href="${DEFAULT_SITE_URL}/en/services" />`,
+    );
   });
 
   it('Given an English page becomes indexable later, when sitemap XML is built with that fixture, then hreflang pairs can be emitted without changing routes', () => {

--- a/apps/client/projects/web/src/app/seo/site-seo.ts
+++ b/apps/client/projects/web/src/app/seo/site-seo.ts
@@ -1,6 +1,7 @@
 import { SOURCE_LOCALE, type SupportedLocale } from '@kraak/domain';
 
 import blogSitemapDefinitions from './blog-sitemap-pages.json';
+import englishSiteSeoDefinitions from './site-seo.en-GB.json';
 import siteSeoDefinitions from './site-seo.json';
 import { resolveSiteUrl } from '../core/runtime/runtime-config';
 import {
@@ -72,6 +73,11 @@ const runtimeGlobals = globalThis as typeof globalThis & {
 };
 
 export const seoPages = siteSeoDefinitions as readonly SeoPageDefinition[];
+const reviewedSeoPagesByLocale: Partial<
+  Record<SupportedLocale, readonly SeoPageDefinition[]>
+> = {
+  'en-GB': englishSiteSeoDefinitions as readonly SeoPageDefinition[],
+};
 const blogSitemapPages = blogSitemapDefinitions as readonly SeoPageDefinition[];
 
 const statusSeoPages = Object.freeze([
@@ -233,12 +239,14 @@ function buildLocalizedSeoPage(
     };
   }
 
+  const reviewedSeo = findReviewedSeoPage(entry, sourceSeo);
+
   return {
-    ...sourceSeo,
+    ...reviewedSeo,
     path: entry.path,
     robots: entry.indexable
-      ? sourceSeo.robots
-      : (sourceSeo.robots ?? NOINDEX_ROBOTS_DIRECTIVE),
+      ? reviewedSeo.robots
+      : (reviewedSeo.robots ?? NOINDEX_ROBOTS_DIRECTIVE),
     locale: entry.locale,
     htmlLang: entry.htmlLang,
     openGraphLocale: entry.openGraphLocale,
@@ -247,6 +255,28 @@ function buildLocalizedSeoPage(
     temporary: false,
     hreflangLinks: buildHreflangLinks(entry),
   };
+}
+
+function findReviewedSeoPage(
+  entry: LocalizedPublicRouteEntry,
+  sourceSeo: SeoPageDefinition,
+): SeoPageDefinition {
+  if (entry.locale === SOURCE_LOCALE) {
+    return sourceSeo;
+  }
+
+  const localizedSeo = reviewedSeoPagesByLocale[entry.locale]?.find(
+    (page) =>
+      normalizeRoutePath(page.path) === normalizeRoutePath(entry.seoPath),
+  );
+
+  if (!localizedSeo) {
+    throw new Error(
+      `Métadonnées SEO révisées introuvables pour la route publique "${entry.path}".`,
+    );
+  }
+
+  return localizedSeo;
 }
 
 function findRawSeoPageByPath(path: string): SeoPageDefinition | undefined {

--- a/apps/client/tests/e2e/seo.spec.ts
+++ b/apps/client/tests/e2e/seo.spec.ts
@@ -64,8 +64,45 @@ test.describe(`SEO i18n du site vitrine`, () => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'fr-CI');
     await expectCanonicalPath(page, '/fr/');
     await expectAlternatePath(page, 'fr-CI', '/fr/');
+    await expectAlternatePath(page, 'en-GB', '/en/');
     await expectAlternatePath(page, 'x-default', '/fr/');
-    await expect(page.locator('link[hreflang="en-GB"]')).toHaveCount(0);
+    expect(errors.consoleErrors).toEqual([]);
+    expect(errors.pageErrors).toEqual([]);
+  });
+
+  test(`Given the approved English homepage, When it loads, Then reviewed metadata indexing reciprocal hreflang and sitemap discovery are active`, async ({
+    page,
+  }) => {
+    const errors = captureSeoRuntimeErrors(page);
+
+    await page.goto('/en/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveTitle(
+      'Build your skills. Launch your projects. | KRAAK Consulting',
+    );
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB');
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      'content',
+      'KRAAK Consulting supports students, professionals, businesses and members of the diaspora with practical solutions in training, project management and immigration.',
+    );
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      /index, follow/i,
+    );
+    await expectCanonicalPath(page, '/en/');
+    await expectAlternatePath(page, 'fr-CI', '/fr/');
+    await expectAlternatePath(page, 'en-GB', '/en/');
+    await expectAlternatePath(page, 'x-default', '/fr/');
+
+    const sitemapResponse = await page.request.get('/sitemap.xml');
+    expect(sitemapResponse.ok()).toBe(true);
+    const sitemap = await sitemapResponse.text();
+    expect(sitemap).toContain(
+      '<loc>https://kraak-web-prod.onrender.com/en/</loc>',
+    );
+    expect(sitemap).not.toContain(
+      '<loc>https://kraak-web-prod.onrender.com/en/contact</loc>',
+    );
     expect(errors.consoleErrors).toEqual([]);
     expect(errors.pageErrors).toEqual([]);
   });

--- a/docs/architecture/WEB.md
+++ b/docs/architecture/WEB.md
@@ -71,23 +71,17 @@ de langue relie les variantes d'une même page publique lorsque le mapping exist
 puis revient à la page d'accueil de la langue cible lorsqu'aucune variante
 publique n'est disponible.
 
-Les quatre pages de conversion prévues dans cette série sont désormais
-localisées. L'activation de l'indexation anglaise, des entrées sitemap et des
-liens `hreflang` réciproques reste conditionnée à une revue humaine du contenu
-anglais de chaque page.
+La revue humaine du contenu anglais de l'accueil, de la coque publique et des
+quatre pages de conversion a été approuvée le 16 août 2026. `/en/` dispose
+désormais de métadonnées anglaises révisées, est indexable, figure dans le
+sitemap et échange des liens `hreflang="fr-CI"` et `hreflang="en-GB"` avec
+`/fr/`. `x-default` continue de pointer vers `/fr/`.
 
-Les copies anglaises de Contact, Services, Programmes et À propos sont proposées
-mais n'ont pas encore reçu de revue humaine. En conséquence, `/en/contact`,
-`/en/services`, `/en/programs` et `/en/about` restent `noindex, nofollow`, hors
-du sitemap de production et sans lien `hreflang="en-GB"` réciproque depuis leur
-page française respective.
-
-Ces incréments de contenu ne modifient pas encore la politique SEO du scaffold
-anglais : les routes anglaises restent `noindex, nofollow`, exclues
-du sitemap de production et non annoncées en `hreflang="en-GB"` depuis les
-pages françaises indexables. Leurs métadonnées anglaises restent temporaires
-jusqu'à une traduction et une revue SEO dédiées. `x-default` continue de pointer
-vers la route française correspondante.
+Les activations SEO des pages de conversion restent livrées une par une afin de
+garder chaque changement vérifiable et réversible. Malgré leur copie approuvée,
+`/en/contact`, `/en/services`, `/en/programs` et `/en/about` restent donc
+temporairement `noindex, nofollow`, hors du sitemap et sans lien
+`hreflang="en-GB"` réciproque jusqu'à leur PR d'activation respective.
 
 Les routes d'authentification technique, notamment les callbacks et liens de
 réinitialisation, restent compatibles avec Supabase Auth avant toute localisation

--- a/scripts/generate-web-seo.mjs
+++ b/scripts/generate-web-seo.mjs
@@ -17,6 +17,17 @@ const seoSourcePath = join(
   'seo',
   'site-seo.json',
 );
+const englishSeoSourcePath = join(
+  repoRoot,
+  'apps',
+  'client',
+  'projects',
+  'web',
+  'src',
+  'app',
+  'seo',
+  'site-seo.en-GB.json',
+);
 const blogSitemapSourcePath = join(
   repoRoot,
   'apps',
@@ -137,19 +148,29 @@ export function buildLocalizedRouteEntries(routeModel) {
 
 export function buildLocalizedSitemapPages({
   seoPages,
+  localizedSeoPages = {},
   routeModel,
   entries = buildLocalizedRouteEntries(routeModel),
 }) {
-  const seoByPath = new Map(
-    seoPages.map((page) => [trimSlashes(page.path), page]),
+  const seoByLocaleAndPath = buildSeoByLocaleAndPath(
+    seoPages,
+    localizedSeoPages,
   );
 
   return entries
     .filter((entry) => entry.includeInSitemap && entry.indexable)
     .map((entry) => {
-      const seo = seoByPath.get(trimSlashes(entry.seoPath));
+      const seo = seoByLocaleAndPath
+        .get(entry.locale)
+        ?.get(trimSlashes(entry.seoPath));
 
       if (!seo) {
+        if (entry.locale !== sourceLocale) {
+          throw new Error(
+            `SEO anglais revu introuvable pour la route ${entry.path}.`,
+          );
+        }
+
         throw new Error(`SEO introuvable pour la route ${entry.path}.`);
       }
 
@@ -161,6 +182,20 @@ export function buildLocalizedSitemapPages({
         alternates: buildSitemapAlternates(entry, entries),
       };
     });
+}
+
+function buildSeoByLocaleAndPath(seoPages, localizedSeoPages) {
+  const entries = [
+    [sourceLocale, seoPages],
+    ...Object.entries(localizedSeoPages),
+  ];
+
+  return new Map(
+    entries.map(([locale, pages]) => [
+      locale,
+      new Map(pages.map((page) => [trimSlashes(page.path), page])),
+    ]),
+  );
 }
 
 export function buildSitemapXml({
@@ -202,9 +237,14 @@ async function readJson(filePath) {
 
 const main = async () => {
   const seoPages = await readJson(seoSourcePath);
+  const englishSeoPages = await readJson(englishSeoSourcePath);
   const blogSitemapPages = await readJson(blogSitemapSourcePath);
   const routeModel = await readJson(routeModelSourcePath);
-  const sitemapPages = buildLocalizedSitemapPages({ seoPages, routeModel });
+  const sitemapPages = buildLocalizedSitemapPages({
+    seoPages,
+    localizedSeoPages: { 'en-GB': englishSeoPages },
+    routeModel,
+  });
   const siteUrl = normalizeSiteUrl(
     process.env['PUBLIC_SITE_URL'] || defaultSiteUrl,
   );

--- a/scripts/generate-web-seo.test.mjs
+++ b/scripts/generate-web-seo.test.mjs
@@ -28,6 +28,22 @@ const seoPages = JSON.parse(
     'utf8',
   ),
 );
+const approvedEnglishHomeSeo = JSON.parse(
+  readFileSync(
+    join(
+      repoRoot,
+      'apps',
+      'client',
+      'projects',
+      'web',
+      'src',
+      'app',
+      'seo',
+      'site-seo.en-GB.json',
+    ),
+    'utf8',
+  ),
+);
 const routeModel = JSON.parse(
   readFileSync(
     join(
@@ -44,13 +60,28 @@ const routeModel = JSON.parse(
     'utf8',
   ),
 );
+const localizedSeoPages = { 'en-GB': approvedEnglishHomeSeo };
 
-test('Given the PR 3 route model, When localized sitemap pages are built, Then only indexable French public routes are included', () => {
-  const pages = buildLocalizedSitemapPages({ seoPages, routeModel });
+function buildHomeApprovedRouteModel() {
+  const approvedRouteModel = structuredClone(routeModel);
+  const home = approvedRouteModel.pages.find((page) => page.id === 'home');
+
+  home.indexableByLocale = { 'en-GB': true };
+
+  return approvedRouteModel;
+}
+
+test('Given the approved English homepage, When localized sitemap pages are built, Then it joins the indexable French routes', () => {
+  const pages = buildLocalizedSitemapPages({
+    seoPages,
+    localizedSeoPages,
+    routeModel,
+  });
   const paths = pages.map((page) => page.path);
 
   assert.deepEqual(paths, [
     '/fr/',
+    '/en/',
     '/fr/a-propos',
     '/fr/services',
     '/fr/faq',
@@ -62,8 +93,12 @@ test('Given the PR 3 route model, When localized sitemap pages are built, Then o
   ]);
 });
 
-test('Given the PR 3 route model, When sitemap XML is generated, Then English scaffold and private routes are excluded', () => {
-  const pages = buildLocalizedSitemapPages({ seoPages, routeModel });
+test('Given the approved English homepage, When sitemap XML is generated, Then unreviewed English and private routes are excluded', () => {
+  const pages = buildLocalizedSitemapPages({
+    seoPages,
+    localizedSeoPages,
+    routeModel,
+  });
   const sitemap = buildSitemapXml({
     pages,
     routeModel,
@@ -75,6 +110,10 @@ test('Given the PR 3 route model, When sitemap XML is generated, Then English sc
     sitemap,
     /<loc>https:\/\/kraak-web-prod\.onrender\.com\/fr\/services<\/loc>/,
   );
+  assert.match(
+    sitemap,
+    /<loc>https:\/\/kraak-web-prod\.onrender\.com\/en\/<\/loc>/,
+  );
   assert.doesNotMatch(sitemap, /\/en\/services/);
   assert.doesNotMatch(sitemap, /\/connexion/);
   assert.doesNotMatch(sitemap, /\/auth\/reset/);
@@ -84,8 +123,12 @@ test('Given the PR 3 route model, When sitemap XML is generated, Then English sc
   );
 });
 
-test('Given localized French sitemap entries, When alternates are generated, Then fr-CI and x-default are present without en-GB', () => {
-  const pages = buildLocalizedSitemapPages({ seoPages, routeModel });
+test('Given localized sitemap entries, When alternates are generated, Then only approved pages expose reciprocal en-GB links', () => {
+  const pages = buildLocalizedSitemapPages({
+    seoPages,
+    localizedSeoPages,
+    routeModel,
+  });
   const sitemap = buildSitemapXml({
     pages,
     routeModel,
@@ -100,31 +143,40 @@ test('Given localized French sitemap entries, When alternates are generated, The
     sitemap,
     /<xhtml:link rel="alternate" hreflang="x-default" href="https:\/\/kraak-web-prod\.onrender\.com\/fr\/services" \/>/,
   );
-  assert.doesNotMatch(sitemap, /hreflang="en-GB"/);
-});
-
-test('Given English indexability is enabled later, When sitemap pages are built, Then English URLs and hreflang pairs are supported by data only', () => {
-  const futureRouteModel = structuredClone(routeModel);
-  futureRouteModel.locales = futureRouteModel.locales.map((localeDefinition) =>
-    localeDefinition.locale === 'en-GB'
-      ? { ...localeDefinition, defaultIndexable: true }
-      : localeDefinition,
-  );
-  const pages = buildLocalizedSitemapPages({
-    seoPages,
-    routeModel: futureRouteModel,
-  });
-  const sitemap = buildSitemapXml({
-    pages,
-    routeModel: futureRouteModel,
-    siteUrl: defaultSiteUrl,
-  });
-
   assert.match(
     sitemap,
-    /<loc>https:\/\/kraak-web-prod\.onrender\.com\/en\/services<\/loc>/,
+    /hreflang="en-GB" href="https:\/\/kraak-web-prod\.onrender\.com\/en\/"/,
   );
-  assert.match(sitemap, /hreflang="en-GB"/);
+  assert.doesNotMatch(
+    sitemap,
+    /hreflang="en-GB" href="https:\/\/kraak-web-prod\.onrender\.com\/en\/services"/,
+  );
+});
+
+test('Given approved locale metadata for an indexable English homepage, When sitemap pages are built, Then the reviewed English metadata is selected', () => {
+  const approvedRouteModel = buildHomeApprovedRouteModel();
+  const pages = buildLocalizedSitemapPages({
+    seoPages,
+    localizedSeoPages: { 'en-GB': approvedEnglishHomeSeo },
+    routeModel: approvedRouteModel,
+  });
+  const englishHome = pages.find((page) => page.path === '/en/');
+
+  assert.equal(englishHome?.title, approvedEnglishHomeSeo[0].title);
+});
+
+test('Given an indexable English homepage without reviewed locale metadata, When sitemap pages are built, Then activation is rejected', () => {
+  const approvedRouteModel = buildHomeApprovedRouteModel();
+
+  assert.throws(
+    () =>
+      buildLocalizedSitemapPages({
+        seoPages,
+        localizedSeoPages: { 'en-GB': [] },
+        routeModel: approvedRouteModel,
+      }),
+    /SEO anglais revu introuvable pour la route \/en\//,
+  );
 });
 
 test('Given XML-sensitive values, When sitemap XML is generated, Then URLs are escaped', () => {
@@ -148,7 +200,11 @@ test('Given XML-sensitive values, When sitemap XML is generated, Then URLs are e
 });
 
 test('Given sitemap generation, When it is run twice, Then output ordering is deterministic', () => {
-  const pages = buildLocalizedSitemapPages({ seoPages, routeModel });
+  const pages = buildLocalizedSitemapPages({
+    seoPages,
+    localizedSeoPages,
+    routeModel,
+  });
   const first = buildSitemapXml({ pages, routeModel, siteUrl: defaultSiteUrl });
   const second = buildSitemapXml({
     pages,


### PR DESCRIPTION
## Résumé

- ajoute un catalogue de métadonnées SEO révisées par locale et bloque l’indexation lorsqu’une route anglaise n’en possède pas
- rend `/en/` indexable avec canonical, `hreflang` réciproques et entrée sitemap
- maintient Contact, Services, Programmes et À propos en `noindex, nofollow` jusqu’à leur PR d’activation dédiée
- documente l’approbation humaine du 16 août 2026

## Validation

- 685 tests unitaires web
- 253 tests unitaires mobile via le hook pre-push
- 31 tests d’intégration API via le hook pre-push
- 88 tests workspace
- 18 scénarios Playwright SEO sur Chromium, Firefox et WebKit
- typecheck web, lint code/Markdown, contrôle i18n et build production de 26 routes

Le build conserve l’avertissement de budget initial existant et le lint conserve les trois avertissements existants dans `analytics.spec.ts`.

Closes #650