### PR TITLE
feat(web): enrichir l'espace participant avec le LMS

### DIFF
--- a/apps/client/projects/web/src/app/app.component.html
+++ b/apps/client/projects/web/src/app/app.component.html
@@ -1,10 +1,14 @@
 <a href="#main-content" class="kr-skip-link" (click)="focusMainContent($event)">
   {{ 'web.shell.skipToMainContent' | kraakTranslate }}
 </a>
-<kraak-navbar />
+@if (!usesParticipantShell()) {
+  <kraak-navbar />
+}
 <main id="main-content" tabindex="-1" class="min-h-dvh">
   <router-outlet />
 </main>
-<kraak-footer />
+@if (!usesParticipantShell()) {
+  <kraak-footer />
+}
 <kraak-scroll-to-top />
 <p-toast key="app-feedback" position="top-right" />

--- a/apps/client/projects/web/src/app/app.component.spec.ts
+++ b/apps/client/projects/web/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { ApplicationInitStatus } from '@angular/core';
+import { ApplicationInitStatus, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   Event as RouterEvent,
@@ -11,6 +11,12 @@ import { Subject } from 'rxjs';
 import { vi } from 'vitest';
 import { KraakI18nService, provideKraakI18n } from '../../../shared/i18n';
 import { App } from './app.component';
+
+@Component({
+  standalone: true,
+  template: '<p>Participant test page</p>',
+})
+class ParticipantTestPage {}
 
 describe('App', () => {
   beforeEach(async () => {
@@ -35,6 +41,40 @@ describe('App', () => {
     expect(compiled.querySelector('kraak-navbar')).toBeTruthy();
     expect(compiled.querySelector('main')).toBeTruthy();
     expect(compiled.querySelector('kraak-footer')).toBeTruthy();
+  });
+
+  it('Given a participant app shell route, When navigation completes, Then public navbar and footer are hidden while main remains', async () => {
+    TestBed.resetTestingModule();
+
+    await TestBed.configureTestingModule({
+      imports: [App],
+      providers: [
+        provideRouter([
+          {
+            path: 'participant-test',
+            data: { appShell: 'participant' },
+            loadComponent: () => Promise.resolve(ParticipantTestPage),
+          },
+        ]),
+        provideKraakI18n(),
+        MessageService,
+      ],
+    }).compileComponents();
+
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+
+    const router = TestBed.inject(Router);
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    await router.navigateByUrl('/participant-test');
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    expect(compiled.querySelector('kraak-navbar')).toBeNull();
+    expect(compiled.querySelector('kraak-footer')).toBeNull();
+    expect(compiled.querySelector('main#main-content')).toBeTruthy();
   });
 
   it('Given a keyboard user When the application shell renders Then it exposes a skip link and main landmark target', async () => {

--- a/apps/client/projects/web/src/app/app.component.ts
+++ b/apps/client/projects/web/src/app/app.component.ts
@@ -1,6 +1,11 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, OnInit, inject } from '@angular/core';
-import { Router, NavigationEnd, RouterOutlet } from '@angular/router';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import {
+  NavigationEnd,
+  Router,
+  RouterOutlet,
+  type ActivatedRouteSnapshot,
+} from '@angular/router';
 import { Toast } from 'primeng/toast';
 import { filter } from 'rxjs';
 
@@ -25,27 +30,49 @@ export class App implements OnInit {
   private readonly document = inject(DOCUMENT);
   private readonly router = inject(Router);
 
+  protected readonly usesParticipantShell = signal(false);
+
   protected focusMainContent(event: Event): void {
     event.preventDefault();
     this.document.getElementById('main-content')?.focus();
   }
 
   ngOnInit(): void {
-    // Only set up scroll-to-top in browser environment (not during SSR)
+    this.refreshAppShell();
+
+    // Only set up browser navigation effects outside SSR.
     if (globalThis.window === undefined || document === undefined) {
       return;
     }
 
-    // Scroll to top smoothly when navigating to a new page
+    // Refresh route-aware shell state and reset scroll on navigation.
     this.router.events
       .pipe(filter((event) => event instanceof NavigationEnd))
       .subscribe(() => {
-        // Smoothly reset scroll position on each route change.
+        this.refreshAppShell();
+
         globalThis.window.scrollTo({
           top: 0,
           left: 0,
           behavior: 'smooth',
         });
       });
+  }
+
+  private refreshAppShell(): void {
+    let currentRoute: ActivatedRouteSnapshot | null =
+      this.router.routerState.snapshot.root;
+    let appShell: unknown;
+
+    while (currentRoute) {
+      const routeShell = currentRoute.data['appShell'];
+      if (routeShell !== undefined) {
+        appShell = routeShell;
+      }
+
+      currentRoute = currentRoute.firstChild;
+    }
+
+    this.usesParticipantShell.set(appShell === 'participant');
   }
 }

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.html
@@ -1,339 +1,440 @@
-<main
-  class="min-h-screen bg-[radial-gradient(circle_at_top,rgba(76,195,217,0.22),transparent_42%),linear-gradient(180deg,#f8fbfd_0%,#eef3f7_100%)]"
->
-  <div class="container-page py-10 sm:py-12">
-    <section
-      class="grid gap-6 rounded-4xl bg-white/88 p-6 shadow-sm ring-1 ring-slate-200/80 backdrop-blur sm:p-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,0.9fr)]"
+<div class="space-y-8">
+  <section
+    class="relative grid gap-8 overflow-hidden rounded-[2rem] bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_52%,#1673ae_100%)] p-6 text-white shadow-[0_2px_5px_rgba(18,55,105,0.08),0_24px_64px_-32px_rgba(18,43,74,0.45)] sm:p-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.75fr)] lg:items-end lg:p-10"
+    aria-labelledby="participant-dashboard-title"
+  >
+    <div class="max-w-3xl">
+      <p
+        class="text-sm font-semibold tracking-[0.24em] text-white/56 uppercase"
+      >
+        Accueil participant
+      </p>
+
+      <h1
+        id="participant-dashboard-title"
+        class="mt-4 text-3xl leading-tight font-semibold text-white sm:text-4xl lg:text-5xl"
+      >
+        Bonjour {{ currentProfile()?.appUser?.firstName || 'Participant' }},
+        <span class="text-white/64">voici votre vue d'ensemble.</span>
+      </h1>
+
+      <p class="mt-5 max-w-2xl text-base leading-7 text-white/64 sm:text-lg">
+        Retrouvez en un coup d'œil vos programmes, vos prochaines sessions et
+        les dernières informations utiles à votre parcours KRAAK.
+      </p>
+    </div>
+
+    <aside
+      class="rounded-3xl border border-white/12 bg-white/10 p-5 text-white shadow-[0_2px_5px_rgba(255,255,255,0.06)_inset,0_12px_20px_rgba(0,0,0,0.06)] backdrop-blur-[48px] sm:p-6"
+      aria-labelledby="dashboard-attention-title"
     >
-      <div class="space-y-4">
+      <span
+        class="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/12 bg-white/10 shadow-[0_2px_5px_rgba(255,255,255,0.06)_inset]"
+        aria-hidden="true"
+      >
+        <i class="pi pi-compass text-cyan-200"></i>
+      </span>
+
+      <p
+        class="mt-5 text-xs font-semibold tracking-[0.2em] text-cyan-100/80 uppercase"
+      >
+        Point d'attention
+      </p>
+
+      <h2 id="dashboard-attention-title" class="mt-2 text-xl font-semibold">
+        Rester aligné sur la prochaine étape
+      </h2>
+
+      <p class="mt-3 text-sm leading-6 text-white/64">
+        Votre espace rassemble les éléments prioritaires de votre parcours pour
+        vous aider à avancer sans perdre le fil.
+      </p>
+    </aside>
+  </section>
+
+  <section
+    class="rounded-[2rem] bg-white p-5 text-slate-950 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)] sm:p-7 lg:p-8"
+    aria-labelledby="dashboard-synthesis-title"
+  >
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+    >
+      <div>
         <p
-          class="text-brand-blue text-sm font-semibold tracking-[0.28em] uppercase"
+          class="text-sm font-semibold tracking-[0.2em] text-slate-400 uppercase"
         >
-          Accueil participant
+          Mon dashboard
         </p>
-        <div class="space-y-3">
-          <h1 class="text-3xl font-semibold text-slate-950 sm:text-4xl">
-            Bonjour {{ currentProfile()?.appUser?.firstName || 'Participant' }},
-            voici votre vue d'ensemble.
-          </h1>
-          <p class="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-            Ce dashboard MVP synthétise les contenus prioritaires issus de votre
-            parcours: programmes suivis, prochaines sessions et dernières
-            annonces, alimentés par le service dashboard de KRAAK.
-          </p>
-        </div>
+        <h2
+          id="dashboard-synthesis-title"
+          class="mt-2 text-2xl font-semibold text-slate-950"
+        >
+          Synthèse utile
+        </h2>
       </div>
 
-      <aside
-        class="rounded-3xl bg-slate-950 p-5 text-white shadow-sm"
-        aria-labelledby="dashboard-attention-title"
-      >
-        <p
-          class="text-sm font-semibold tracking-[0.22em] text-cyan-200 uppercase"
-        >
-          Point d'attention
+      @if (!loading() && !errorMessage()) {
+        <p class="text-sm font-medium text-slate-500">
+          {{ totalSummaryLabel() }}
         </p>
-        <h2 id="dashboard-attention-title" class="mt-3 text-2xl font-semibold">
-          Rester aligné sur la prochaine étape
-        </h2>
-        <p class="mt-3 text-sm leading-6 text-slate-200">
-          L'accueil sert de repère rapide: programmes actifs, prochaines
-          sessions et annonces récentes sont consolidés ici.
-        </p>
-      </aside>
-    </section>
+      }
+    </div>
 
-    <section
-      class="mt-8 rounded-[1.75rem] bg-white p-6 shadow-sm ring-1 ring-slate-200/80 sm:p-7"
-      aria-labelledby="dashboard-synthesis-title"
-    >
-      <div
-        class="flex flex-col gap-3 border-b border-slate-200/80 pb-4 sm:flex-row sm:items-end sm:justify-between"
-      >
-        <div>
-          <p
-            class="text-sm font-semibold tracking-[0.22em] text-slate-500 uppercase"
-          >
-            Accueil participant
-          </p>
-          <h2
-            id="dashboard-synthesis-title"
-            class="mt-2 text-2xl font-semibold text-slate-950"
-          >
-            Synthèse utile
-          </h2>
+    @if (loading()) {
+      <p class="mt-6 text-sm leading-6 text-slate-600">
+        La synthèse se met à jour avec vos dernières informations.
+      </p>
+    } @else if (errorMessage()) {
+      <p-message
+        severity="warn"
+        text="La synthèse n'a pas pu être chargée pour le moment."
+        [closable]="false"
+        styleClass="mt-6 w-full"
+      ></p-message>
+    } @else {
+      <div class="mt-7 grid gap-4 lg:grid-cols-[1.5fr_minmax(17rem,0.75fr)]">
+        <div class="grid gap-3 sm:grid-cols-3">
+          @for (indicator of summaryIndicators(); track indicator.id) {
+            <article
+              class="motion-hover-lift rounded-2xl bg-slate-50 p-5 shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+            >
+              <p
+                class="text-xs font-semibold tracking-[0.16em] text-slate-400 uppercase"
+              >
+                {{ indicator.label }}
+              </p>
+
+              <p class="mt-3 text-3xl font-semibold text-slate-950">
+                {{ indicator.value }}
+              </p>
+
+              <p class="mt-2 text-xs leading-5 text-slate-500">
+                {{ indicator.detail }}
+              </p>
+            </article>
+          }
         </div>
-        @if (!loading() && !errorMessage()) {
-          <p class="text-sm font-medium text-slate-600">
-            {{ totalSummaryLabel() }}
+
+        <aside
+          class="rounded-3xl bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_100%)] p-5 text-white shadow-[0_12px_32px_-16px_rgba(18,43,74,0.58)]"
+          aria-labelledby="dashboard-next-step-title"
+        >
+          <span
+            class="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/10"
+            aria-hidden="true"
+          >
+            <i class="pi pi-calendar text-cyan-200"></i>
+          </span>
+
+          <p
+            class="mt-5 text-xs font-semibold tracking-[0.18em] text-cyan-100 uppercase"
+          >
+            Prochaine étape
           </p>
-        }
+
+          <h3
+            id="dashboard-next-step-title"
+            class="mt-2 text-lg font-semibold text-white"
+          >
+            Prochaine session
+          </h3>
+
+          <p class="mt-3 text-sm leading-6 text-white/68">
+            {{ nextSessionSummary() }}
+          </p>
+        </aside>
+      </div>
+    }
+  </section>
+
+  <section
+    class="rounded-[2rem] bg-white p-5 text-slate-950 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)] sm:p-7 lg:p-8"
+    aria-labelledby="dashboard-overview-title"
+  >
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+    >
+      <div>
+        <p
+          class="text-sm font-semibold tracking-[0.2em] text-slate-400 uppercase"
+        >
+          Votre parcours
+        </p>
+
+        <h2
+          id="dashboard-overview-title"
+          class="mt-2 text-2xl font-semibold text-slate-950"
+        >
+          Votre vue d'ensemble personnalisée
+        </h2>
       </div>
 
       @if (loading()) {
-        <p class="mt-4 text-sm leading-6 text-slate-600">
-          La synthèse se met à jour avec vos dernières informations.
-        </p>
-      } @else if (errorMessage()) {
-        <p-message
-          severity="warn"
-          text="La synthèse n'a pas pu être chargée pour le moment."
-          [closable]="false"
-          styleClass="mt-4 w-full"
-        ></p-message>
-      } @else {
-        <div class="mt-5 grid gap-4 lg:grid-cols-[1.65fr_minmax(16rem,1fr)]">
-          <div class="grid gap-3 sm:grid-cols-3">
-            @for (indicator of summaryIndicators(); track indicator.id) {
-              <article
-                class="rounded-2xl bg-slate-50 p-4 ring-1 ring-slate-200/80"
-              >
-                <p
-                  class="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase"
-                >
-                  {{ indicator.label }}
-                </p>
-                <p class="mt-2 text-3xl font-semibold text-slate-950">
-                  {{ indicator.value }}
-                </p>
-                <p class="mt-2 text-xs leading-5 text-slate-600">
-                  {{ indicator.detail }}
-                </p>
-              </article>
-            }
-          </div>
-
-          <aside
-            class="rounded-2xl bg-slate-950 p-4 text-white ring-1 ring-slate-900"
-            aria-labelledby="dashboard-next-step-title"
-          >
-            <p
-              class="text-xs font-semibold tracking-[0.2em] text-cyan-200 uppercase"
-            >
-              Prochaine étape
-            </p>
-            <h3
-              id="dashboard-next-step-title"
-              class="mt-2 text-lg font-semibold"
-            >
-              Prochaine session
-            </h3>
-            <p class="mt-2 text-sm leading-6 text-slate-200">
-              {{ nextSessionSummary() }}
-            </p>
-          </aside>
-        </div>
+        <output
+          class="text-sm font-medium tracking-[0.14em] text-slate-400 uppercase"
+          aria-live="polite"
+        >
+          Chargement&hellip;
+        </output>
       }
-    </section>
+    </div>
 
-    <section
-      class="mt-8 rounded-[1.75rem] bg-white p-6 shadow-sm ring-1 ring-slate-200/80 sm:p-7"
-      aria-labelledby="dashboard-overview-title"
-    >
-      <div
-        class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
-      >
-        <div>
-          <p
-            class="text-sm font-semibold tracking-[0.22em] text-slate-500 uppercase"
-          >
-            Mon dashboard
-          </p>
-          <h2
-            id="dashboard-overview-title"
-            class="mt-2 text-2xl font-semibold text-slate-950"
-          >
-            Votre vue d'ensemble personnalisée
-          </h2>
-        </div>
-        @if (loading()) {
-          <output
-            class="text-sm font-medium tracking-[0.18em] text-slate-500 uppercase"
-            aria-live="polite"
-          >
-            Chargement&hellip;
-          </output>
-        }
+    @if (errorMessage()) {
+      <div class="mt-7 space-y-4">
+        <p-message
+          severity="error"
+          [text]="errorMessage()!"
+          [closable]="false"
+          styleClass="w-full"
+        ></p-message>
+
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="reloadDashboard()"
+        >
+          Réessayer
+        </button>
       </div>
+    } @else if (loading()) {
+      <p class="mt-7 text-sm leading-6 text-slate-600">
+        Chargement de votre dashboard&hellip;
+      </p>
+    } @else if (!hasDashboardContent()) {
+      <div
+        class="mt-7 rounded-3xl bg-slate-50 px-5 py-10 text-center shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+      >
+        <span
+          class="text-brand-blue mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-white shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+          aria-hidden="true"
+        >
+          <i class="pi pi-inbox"></i>
+        </span>
 
-      @if (errorMessage()) {
-        <div class="mt-6 space-y-3">
-          <p-message
-            severity="error"
-            [text]="errorMessage()!"
-            [closable]="false"
-            styleClass="w-full"
-          ></p-message>
-          <button
-            type="button"
-            class="btn btn-primary"
-            (click)="reloadDashboard()"
-          >
-            Réessayer
-          </button>
-        </div>
-      } @else if (loading()) {
-        <p class="mt-6 text-sm leading-6 text-slate-600">
-          Chargement de votre dashboard&hellip;
-        </p>
-      } @else if (!hasDashboardContent()) {
-        <p class="mt-6 text-sm leading-6 text-slate-600">
+        <p class="mt-4 text-sm leading-6 text-slate-600">
           Aucun contenu n'est disponible pour l'instant sur votre espace.
         </p>
-      } @else {
-        <div class="mt-6 grid gap-6 lg:grid-cols-3">
-          <article
-            class="rounded-[1.4rem] border border-slate-200/80 bg-slate-50 p-5"
-            aria-labelledby="dashboard-programs-title"
-          >
-            <p
-              class="text-brand-blue text-xs font-semibold tracking-[0.24em] uppercase"
-            >
-              Programmes actifs
-            </p>
-            <h3
-              id="dashboard-programs-title"
-              class="mt-2 text-lg font-semibold text-slate-950"
-            >
-              Vos parcours en cours
-            </h3>
-            @if (programs().length === 0) {
-              <p class="mt-3 text-sm leading-6 text-slate-600">
-                Aucun programme actif actuellement.
-              </p>
-            } @else {
-              <ul class="mt-4 space-y-3">
-                @for (program of programs(); track program.enrollmentId) {
-                  <li class="rounded-2xl bg-white p-4 ring-1 ring-slate-200/80">
-                    <p class="text-sm font-semibold text-slate-950">
-                      {{ program.title }}
-                    </p>
-                    @if (program.summary) {
-                      <p class="mt-1 text-xs leading-5 text-slate-600">
-                        {{ program.summary }}
-                      </p>
-                    }
-                    @if (program.cohortName) {
-                      <p
-                        class="mt-2 text-xs font-medium tracking-[0.16em] text-slate-500 uppercase"
-                      >
-                        {{ program.cohortName }}
-                      </p>
-                    }
-                  </li>
-                }
-              </ul>
-            }
-          </article>
-
-          <article
-            class="rounded-[1.4rem] border border-slate-200/80 bg-slate-50 p-5"
-            aria-labelledby="dashboard-sessions-title"
-          >
-            <p
-              class="text-brand-blue text-xs font-semibold tracking-[0.24em] uppercase"
-            >
-              Prochaines sessions
-            </p>
-            <h3
-              id="dashboard-sessions-title"
-              class="mt-2 text-lg font-semibold text-slate-950"
-            >
-              Les rappels à ne pas manquer
-            </h3>
-            @if (upcomingSessions().length === 0) {
-              <p class="mt-3 text-sm leading-6 text-slate-600">
-                Aucune session planifiée pour le moment.
-              </p>
-            } @else {
-              <ul class="mt-4 space-y-3">
-                @for (session of upcomingSessions(); track session.id) {
-                  <li class="rounded-2xl bg-white p-4 ring-1 ring-slate-200/80">
-                    <p class="text-sm font-semibold text-slate-950">
-                      {{ session.title }}
-                    </p>
-                    <p class="mt-1 text-xs leading-5 text-slate-600">
-                      {{ session.programTitle }}
-                    </p>
-                    <p
-                      class="mt-2 text-xs font-medium tracking-[0.16em] text-slate-500 uppercase"
-                    >
-                      {{ session.startsAt }}
-                    </p>
-                  </li>
-                }
-              </ul>
-            }
-          </article>
-
-          <article
-            class="rounded-[1.4rem] border border-slate-200/80 bg-slate-50 p-5"
-            aria-labelledby="dashboard-announcements-title"
-          >
-            <p
-              class="text-brand-blue text-xs font-semibold tracking-[0.24em] uppercase"
-            >
-              Annonces récentes
-            </p>
-            <h3
-              id="dashboard-announcements-title"
-              class="mt-2 text-lg font-semibold text-slate-950"
-            >
-              Ce qu'il faut suivre
-            </h3>
-            @if (recentAnnouncements().length === 0) {
-              <p class="mt-3 text-sm leading-6 text-slate-600">
-                Aucune annonce récente pour l'instant.
-              </p>
-            } @else {
-              <ul class="mt-4 space-y-3">
-                @for (
-                  announcement of recentAnnouncements();
-                  track announcement.id
-                ) {
-                  <li class="rounded-2xl bg-white p-4 ring-1 ring-slate-200/80">
-                    <p class="text-sm font-semibold text-slate-950">
-                      {{ announcement.title }}
-                    </p>
-                    <p class="mt-1 text-xs leading-5 text-slate-600">
-                      {{ announcement.body }}
-                    </p>
-                  </li>
-                }
-              </ul>
-            }
-          </article>
-        </div>
-      }
-    </section>
-
-    <section
-      class="mt-8 rounded-[1.75rem] bg-slate-950 p-6 text-white shadow-sm sm:p-7"
-      aria-labelledby="dashboard-quicklinks-title"
-    >
-      <p
-        class="text-sm font-semibold tracking-[0.22em] text-cyan-200 uppercase"
-      >
-        Accès rapides
-      </p>
-      <h2 id="dashboard-quicklinks-title" class="mt-2 text-2xl font-semibold">
-        Des sorties utiles depuis votre espace
-      </h2>
-      <div class="mt-6 grid gap-3 sm:grid-cols-2">
-        @for (quickLink of quickLinks; track quickLink.href) {
-          <a
-            [routerLink]="quickLink.href"
-            class="block rounded-[1.25rem] border border-white/12 bg-white/7 p-4 transition hover:border-cyan-200/60 hover:bg-white/12"
-          >
-            <span class="block text-lg font-semibold">{{
-              quickLink.label
-            }}</span>
-            <span class="mt-2 block text-sm leading-6 text-slate-200">{{
-              quickLink.detail
-            }}</span>
-          </a>
-        }
       </div>
-    </section>
-  </div>
-</main>
+    } @else {
+      <div
+        class="mt-8 grid gap-10 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-dashed lg:divide-slate-200"
+      >
+        <article class="lg:pr-7" aria-labelledby="dashboard-programs-title">
+          <div class="flex items-start gap-3">
+            <span
+              class="text-brand-blue flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-blue-50 shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+              aria-hidden="true"
+            >
+              <i class="pi pi-book"></i>
+            </span>
+
+            <div>
+              <p
+                class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+              >
+                Programmes actifs
+              </p>
+              <h3
+                id="dashboard-programs-title"
+                class="mt-1 text-lg font-semibold text-slate-950"
+              >
+                Vos parcours en cours
+              </h3>
+            </div>
+          </div>
+
+          @if (programs().length === 0) {
+            <p class="mt-5 text-sm leading-6 text-slate-500">
+              Aucun programme actif actuellement.
+            </p>
+          } @else {
+            <ul class="mt-6">
+              @for (
+                program of programs();
+                track program.enrollmentId;
+                let last = $last
+              ) {
+                <li
+                  class="py-4"
+                  [class.border-b]="!last"
+                  [class.border-dashed]="!last"
+                  [class.border-slate-200]="!last"
+                >
+                  <p class="text-sm font-semibold text-slate-950">
+                    {{ program.title }}
+                  </p>
+
+                  @if (program.summary) {
+                    <p class="mt-1.5 text-xs leading-5 text-slate-500">
+                      {{ program.summary }}
+                    </p>
+                  }
+
+                  @if (program.cohortName) {
+                    <span
+                      class="mt-3 inline-flex h-7 items-center rounded-full bg-slate-50 px-3 text-[11px] font-semibold tracking-[0.12em] text-slate-500 uppercase shadow-[0_1px_2px_rgba(164,172,185,0.2),0_0_0_1px_rgba(18,55,105,0.06)]"
+                    >
+                      {{ program.cohortName }}
+                    </span>
+                  }
+                </li>
+              }
+            </ul>
+          }
+        </article>
+
+        <article class="lg:px-7" aria-labelledby="dashboard-sessions-title">
+          <div class="flex items-start gap-3">
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-cyan-50 text-cyan-700 shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+              aria-hidden="true"
+            >
+              <i class="pi pi-calendar-clock"></i>
+            </span>
+
+            <div>
+              <p
+                class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+              >
+                Prochaines sessions
+              </p>
+              <h3
+                id="dashboard-sessions-title"
+                class="mt-1 text-lg font-semibold text-slate-950"
+              >
+                Les rappels à ne pas manquer
+              </h3>
+            </div>
+          </div>
+
+          @if (upcomingSessions().length === 0) {
+            <p class="mt-5 text-sm leading-6 text-slate-500">
+              Aucune session planifiée pour le moment.
+            </p>
+          } @else {
+            <ul class="mt-6">
+              @for (
+                session of upcomingSessions();
+                track session.id;
+                let last = $last
+              ) {
+                <li
+                  class="py-4"
+                  [class.border-b]="!last"
+                  [class.border-dashed]="!last"
+                  [class.border-slate-200]="!last"
+                >
+                  <p class="text-sm font-semibold text-slate-950">
+                    {{ session.title }}
+                  </p>
+                  <p class="mt-1.5 text-xs leading-5 text-slate-500">
+                    {{ session.programTitle }}
+                  </p>
+                  <span
+                    class="mt-3 inline-flex h-7 items-center rounded-full bg-slate-50 px-3 text-[11px] font-semibold tracking-[0.1em] text-slate-500 uppercase shadow-[0_1px_2px_rgba(164,172,185,0.2),0_0_0_1px_rgba(18,55,105,0.06)]"
+                  >
+                    {{ session.startsAt }}
+                  </span>
+                </li>
+              }
+            </ul>
+          }
+        </article>
+
+        <article
+          class="lg:pl-7"
+          aria-labelledby="dashboard-announcements-title"
+        >
+          <div class="flex items-start gap-3">
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-amber-50 text-amber-700 shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+              aria-hidden="true"
+            >
+              <i class="pi pi-megaphone"></i>
+            </span>
+
+            <div>
+              <p
+                class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+              >
+                Annonces récentes
+              </p>
+              <h3
+                id="dashboard-announcements-title"
+                class="mt-1 text-lg font-semibold text-slate-950"
+              >
+                Ce qu'il faut suivre
+              </h3>
+            </div>
+          </div>
+
+          @if (recentAnnouncements().length === 0) {
+            <p class="mt-5 text-sm leading-6 text-slate-500">
+              Aucune annonce récente pour l'instant.
+            </p>
+          } @else {
+            <ul class="mt-6">
+              @for (
+                announcement of recentAnnouncements();
+                track announcement.id;
+                let last = $last
+              ) {
+                <li
+                  class="py-4"
+                  [class.border-b]="!last"
+                  [class.border-dashed]="!last"
+                  [class.border-slate-200]="!last"
+                >
+                  <p class="text-sm font-semibold text-slate-950">
+                    {{ announcement.title }}
+                  </p>
+                  <p class="mt-1.5 text-xs leading-5 text-slate-500">
+                    {{ announcement.body }}
+                  </p>
+                </li>
+              }
+            </ul>
+          }
+        </article>
+      </div>
+    }
+  </section>
+
+  <section
+    class="rounded-[2rem] border border-white/12 bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_100%)] p-5 text-white shadow-[0_12px_32px_-16px_rgba(18,43,74,0.5)] sm:p-7"
+    aria-labelledby="dashboard-quicklinks-title"
+  >
+    <p class="text-sm font-semibold tracking-[0.2em] text-white/52 uppercase">
+      Accès rapides
+    </p>
+
+    <h2 id="dashboard-quicklinks-title" class="mt-2 text-2xl font-semibold">
+      Des sorties utiles depuis votre espace
+    </h2>
+
+    <div class="mt-6 grid gap-3 sm:grid-cols-2">
+      @for (quickLink of quickLinks; track quickLink.href) {
+        <a
+          [routerLink]="quickLink.href"
+          class="group flex items-center justify-between gap-5 rounded-2xl border border-white/12 bg-white/8 p-4 text-white no-underline shadow-[0_2px_5px_rgba(255,255,255,0.04)_inset] transition hover:bg-white/14 focus-visible:ring-2 focus-visible:ring-cyan-200 focus-visible:outline-none"
+        >
+          <span>
+            <span class="block text-base font-semibold">
+              {{ quickLink.label }}
+            </span>
+            <span class="mt-1.5 block text-sm leading-6 text-white/60">
+              {{ quickLink.detail }}
+            </span>
+          </span>
+
+          <span
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/10 transition group-hover:bg-white/16"
+            aria-hidden="true"
+          >
+            <i class="pi pi-arrow-right text-sm"></i>
+          </span>
+        </a>
+      }
+    </div>
+  </section>
+</div>

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.spec.ts
@@ -158,7 +158,7 @@ describe('Web Participant Dashboard Page', () => {
       expect(text).toContain('Rappel documents');
       expect(text).toContain('Cohorte printemps');
       expect(linkHrefs).toEqual(
-        expect.arrayContaining(['/programmes', '/contact']),
+        expect.arrayContaining(['/participant/programmes', '/contact']),
       );
     });
 

--- a/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/dashboard/dashboard.page.ts
@@ -34,9 +34,8 @@ interface DashboardSummaryIndicator {
 const QUICK_LINKS: readonly DashboardQuickLink[] = [
   {
     label: 'Voir les programmes',
-    detail:
-      "Retrouver l'offre, les parcours et les informations publiques utiles.",
-    href: '/programmes',
+    detail: 'Retrouver vos parcours inscrits et suivre votre progression.',
+    href: '/participant/programmes',
   },
   {
     label: "Contacter l'équipe",

--- a/apps/client/projects/web/src/app/features/participant/layout/participant-shell.component.html
+++ b/apps/client/projects/web/src/app/features/participant/layout/participant-shell.component.html
@@ -1,0 +1,113 @@
+<div class="min-h-dvh bg-[#f3f6f8] pb-16 sm:pb-20 lg:pb-24">
+  <section
+    class="relative overflow-hidden bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_52%,#1673ae_100%)] text-white shadow-[0_2px_5px_rgba(18,55,105,0.08),0_24px_64px_-32px_rgba(18,43,74,0.55)] lg:mx-4 lg:mt-4 lg:rounded-[2rem]"
+  >
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute -top-24 -right-24 h-72 w-72 rounded-full bg-cyan-300/15 blur-3xl"
+    ></div>
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute -bottom-32 -left-24 h-80 w-80 rounded-full bg-white/8 blur-3xl"
+    ></div>
+
+    <div
+      class="relative mx-auto w-full max-w-6xl px-4 pt-6 pb-10 lg:px-6 lg:pt-7 lg:pb-14"
+    >
+      <header class="flex flex-wrap items-center justify-between gap-4">
+        <a
+          routerLink="/participant/dashboard"
+          class="focus-visible:ring-offset-brand-navy flex items-center gap-3 rounded-full text-white no-underline outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 focus-visible:ring-offset-2"
+          aria-label="Espace participant KRAAK Consulting"
+        >
+          <span
+            class="flex h-11 w-11 items-center justify-center rounded-full bg-white shadow-[0_1px_2px_rgba(18,55,105,0.12)]"
+          >
+            <img
+              src="/kraak_symbol.svg"
+              alt=""
+              width="36"
+              height="36"
+              loading="eager"
+              decoding="async"
+              class="h-9 w-9"
+            />
+          </span>
+
+          <span class="hidden sm:block">
+            <span class="block text-base leading-none font-semibold">
+              KRAAK Consulting
+            </span>
+            <span class="mt-1 block text-xs text-white/60">
+              Espace participant
+            </span>
+          </span>
+        </a>
+
+        <div class="flex items-center gap-3">
+          <div class="hidden text-right sm:block">
+            <p class="text-sm font-medium text-white">
+              {{ displayName() }}
+            </p>
+            @if (currentProfile()?.appUser?.email; as email) {
+              <p class="mt-0.5 max-w-48 truncate text-xs text-white/60">
+                {{ email }}
+              </p>
+            }
+          </div>
+
+          <span
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/16 bg-white/12 text-sm font-semibold text-white shadow-[0_2px_5px_rgba(255,255,255,0.06)_inset,0_12px_20px_rgba(0,0,0,0.06)] backdrop-blur-xl"
+            aria-hidden="true"
+          >
+            {{ initials() }}
+          </span>
+
+          <button
+            type="button"
+            class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border border-white/16 bg-white/8 text-white/72 shadow-[0_2px_5px_rgba(255,255,255,0.06)_inset] backdrop-blur-xl transition hover:bg-white/16 hover:text-white focus-visible:ring-2 focus-visible:ring-cyan-200 focus-visible:outline-none"
+            aria-label="Se déconnecter"
+            (click)="logout()"
+          >
+            <i class="pi pi-sign-out text-sm" aria-hidden="true"></i>
+          </button>
+        </div>
+      </header>
+
+      <nav
+        aria-label="Navigation de l'espace participant"
+        class="mx-auto mt-8 flex w-full max-w-[calc(100%_-_1rem)] flex-col items-center gap-2 rounded-3xl bg-white/12 p-2 shadow-[0_2px_5px_rgba(255,255,255,0.06)_inset,0_12px_20px_rgba(0,0,0,0.06)] backdrop-blur-[48px] md:max-w-none md:flex-row md:rounded-full"
+      >
+        <a
+          routerLink="/participant/dashboard"
+          routerLinkActive="bg-white/16 text-white"
+          [routerLinkActiveOptions]="{ exact: true }"
+          ariaCurrentWhenActive="page"
+          class="flex h-10 w-full items-center justify-center rounded-full px-5 text-sm font-medium text-white/64 transition hover:bg-white/10 hover:text-white md:flex-1"
+        >
+          Tableau de bord
+        </a>
+
+        <a
+          routerLink="/participant/programmes"
+          routerLinkActive="bg-white/16 text-white"
+          ariaCurrentWhenActive="page"
+          class="flex h-10 w-full items-center justify-center rounded-full px-5 text-sm font-medium text-white/64 transition hover:bg-white/10 hover:text-white md:flex-1"
+        >
+          Programmes
+        </a>
+
+        <a
+          routerLink="/contact"
+          class="flex h-10 w-full items-center justify-center rounded-full px-5 text-sm font-medium text-white/64 transition hover:bg-white/10 hover:text-white md:flex-1"
+        >
+          Support
+        </a>
+      </nav>
+    </div>
+  </section>
+
+  <div class="mx-auto w-full max-w-6xl px-4 py-10 lg:px-6 lg:py-14">
+    <router-outlet />
+  </div>
+</div>

--- a/apps/client/projects/web/src/app/features/participant/layout/participant-shell.component.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/layout/participant-shell.component.spec.ts
@@ -1,0 +1,87 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import ParticipantShell from './participant-shell.component';
+
+describe('ParticipantShell', () => {
+  const clearSession = vi.fn();
+  const currentProfile = signal({
+    appUser: {
+      id: 'user-1',
+      email: 'ange@example.com',
+      role: 'participant' as const,
+      firstName: 'Ange',
+      lastName: 'Kouakou',
+      phone: null,
+      preferredContactChannel: null,
+      isActive: true,
+      createdAt: '2026-08-27T00:00:00.000Z',
+      updatedAt: '2026-08-27T00:00:00.000Z',
+    },
+    participant: null,
+  });
+
+  beforeEach(async () => {
+    clearSession.mockReset();
+
+    await TestBed.configureTestingModule({
+      imports: [ParticipantShell],
+      providers: [
+        provideRouter([]),
+        {
+          provide: WebAuthService,
+          useValue: {
+            currentProfile,
+            clearSession,
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('Given an authenticated participant, When the shell renders, Then identity and participant navigation are visible', () => {
+    const fixture = TestBed.createComponent(ParticipantShell);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    const text = element.textContent ?? '';
+    const hrefs = Array.from(element.querySelectorAll('a')).map((anchor) =>
+      anchor.getAttribute('href'),
+    );
+
+    expect(text).toContain('Ange Kouakou');
+    expect(text).toContain('ange@example.com');
+    expect(text).toContain('AK');
+    expect(text).toContain('Tableau de bord');
+    expect(text).toContain('Programmes');
+    expect(text).toContain('Support');
+    expect(hrefs).toEqual(
+      expect.arrayContaining([
+        '/participant/dashboard',
+        '/participant/programmes',
+        '/contact',
+      ]),
+    );
+  });
+
+  it('Given an authenticated participant, When logout is activated, Then the local session is cleared and navigation returns to sign in', async () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    const fixture = TestBed.createComponent(ParticipantShell);
+    fixture.detectChanges();
+
+    const logoutButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Se déconnecter"]',
+    ) as HTMLButtonElement | null;
+
+    logoutButton?.click();
+    await fixture.whenStable();
+
+    expect(clearSession).toHaveBeenCalledOnce();
+    expect(navigateSpy).toHaveBeenCalledWith(['/connexion']);
+  });
+});

--- a/apps/client/projects/web/src/app/features/participant/layout/participant-shell.component.ts
+++ b/apps/client/projects/web/src/app/features/participant/layout/participant-shell.component.ts
@@ -1,0 +1,45 @@
+import { Component, computed, inject } from '@angular/core';
+import {
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from '@angular/router';
+
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+
+@Component({
+  selector: 'kraak-web-participant-shell',
+  standalone: true,
+  imports: [RouterLink, RouterLinkActive, RouterOutlet],
+  templateUrl: './participant-shell.component.html',
+})
+export default class ParticipantShell {
+  private readonly authService = inject(WebAuthService);
+  private readonly router = inject(Router);
+
+  protected readonly currentProfile = this.authService.currentProfile;
+
+  protected readonly displayName = computed(() => {
+    const user = this.currentProfile()?.appUser;
+    if (!user) {
+      return 'Participant';
+    }
+
+    return `${user.firstName} ${user.lastName}`.trim();
+  });
+
+  protected readonly initials = computed(() => {
+    const user = this.currentProfile()?.appUser;
+    if (!user) {
+      return 'KR';
+    }
+
+    return `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
+  });
+
+  protected logout(): void {
+    this.authService.clearSession();
+    void this.router.navigate(['/connexion']);
+  }
+}

--- a/apps/client/projects/web/src/app/features/participant/programs/program-detail.page.html
+++ b/apps/client/projects/web/src/app/features/participant/programs/program-detail.page.html
@@ -1,0 +1,448 @@
+<div class="space-y-10">
+  <a
+    routerLink="/participant/programmes"
+    class="hover:text-brand-blue inline-flex items-center gap-2 text-sm font-semibold text-slate-500 transition"
+  >
+    <i class="pi pi-arrow-left text-xs" aria-hidden="true"></i>
+    Tous les programmes
+  </a>
+
+  @if (errorMessage()) {
+    <section
+      class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)] sm:p-8"
+      role="alert"
+    >
+      <span
+        class="flex h-11 w-11 items-center justify-center rounded-2xl bg-red-50 text-red-700"
+        aria-hidden="true"
+      >
+        <i class="pi pi-exclamation-circle"></i>
+      </span>
+
+      <h1 class="mt-5 text-2xl font-semibold text-slate-950">
+        Impossible de charger ce programme
+      </h1>
+
+      <p class="mt-2 max-w-xl text-sm leading-6 text-slate-600">
+        {{ errorMessage() }}
+      </p>
+
+      <button
+        type="button"
+        class="kr-button-primary mt-6"
+        (click)="reloadProgram()"
+      >
+        Réessayer
+      </button>
+    </section>
+  } @else if (loading()) {
+    <section aria-label="Chargement du programme" aria-busy="true">
+      <div
+        class="h-80 animate-pulse rounded-[2rem] bg-slate-200 lg:h-[25rem]"
+      ></div>
+
+      <div class="mt-8 grid gap-6 lg:grid-cols-[1.4fr_0.6fr]">
+        <div class="h-72 animate-pulse rounded-[2rem] bg-white"></div>
+        <div class="h-72 animate-pulse rounded-[2rem] bg-white"></div>
+      </div>
+    </section>
+  } @else if (programDetail(); as detail) {
+    <header
+      class="relative overflow-hidden rounded-[2rem] bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_50%,#1673ae_100%)] px-6 py-8 text-white shadow-[0_2px_5px_rgba(18,55,105,0.08),0_30px_70px_-40px_rgba(18,43,74,0.75)] sm:px-8 sm:py-10 lg:px-12 lg:py-12"
+    >
+      <div
+        aria-hidden="true"
+        class="absolute -top-28 -right-20 h-72 w-72 rounded-full bg-cyan-300/24 blur-3xl"
+      ></div>
+      <div
+        aria-hidden="true"
+        class="absolute -bottom-32 -left-24 h-80 w-80 rounded-full bg-amber-300/14 blur-3xl"
+      ></div>
+
+      <div
+        class="relative grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-end"
+      >
+        <div class="max-w-3xl">
+          <div class="flex flex-wrap items-center gap-2">
+            <span
+              class="inline-flex rounded-full border border-white/16 bg-white/12 px-3 py-1.5 text-[11px] font-semibold tracking-[0.12em] uppercase backdrop-blur-xl"
+            >
+              {{ enrollmentStatusLabel(detail.enrollmentStatus) }}
+            </span>
+            <span
+              class="inline-flex rounded-full border border-white/16 bg-white/8 px-3 py-1.5 text-[11px] font-semibold tracking-[0.12em] text-white/72 uppercase backdrop-blur-xl"
+            >
+              {{ progressStatusLabel(detail.progress.status) }}
+            </span>
+          </div>
+
+          <p
+            class="mt-8 text-xs font-semibold tracking-[0.22em] text-cyan-100/72 uppercase"
+          >
+            KRAAK Learning
+          </p>
+
+          <h1
+            class="mt-3 text-3xl leading-tight font-semibold sm:text-4xl lg:text-5xl"
+          >
+            {{ detail.program.title }}
+          </h1>
+
+          <p class="mt-5 max-w-2xl text-base leading-7 text-white/72">
+            {{ detail.program.summary }}
+          </p>
+        </div>
+
+        <div
+          class="rounded-3xl border border-white/14 bg-white/10 p-5 backdrop-blur-[48px]"
+        >
+          <div class="flex items-end justify-between gap-4">
+            <div>
+              <p
+                class="text-[11px] font-semibold tracking-[0.14em] text-white/56 uppercase"
+              >
+                Progression
+              </p>
+              <p class="mt-2 text-4xl font-semibold">
+                {{ detail.progress.completionRate }}%
+              </p>
+            </div>
+
+            <span
+              class="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/14 bg-white/10"
+              aria-hidden="true"
+            >
+              <img
+                src="/kraak_symbol.svg"
+                alt=""
+                width="38"
+                height="38"
+                class="h-9 w-9 brightness-0 invert"
+              />
+            </span>
+          </div>
+
+          <div class="mt-5 h-1.5 overflow-hidden rounded-full bg-white/14">
+            <div
+              class="h-full rounded-full bg-white"
+              [style.width.%]="detail.progress.completionRate"
+            ></div>
+          </div>
+
+          <p class="mt-3 text-xs leading-5 text-white/64">
+            {{ detail.progress.completedSessions }}/{{
+              detail.progress.totalSessions
+            }}
+            sessions terminées
+          </p>
+        </div>
+      </div>
+    </header>
+
+    <section
+      class="grid gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.55fr)]"
+    >
+      <article
+        class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_12px_30px_-18px_rgba(18,43,74,0.18)] sm:p-8"
+      >
+        <p
+          class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+        >
+          À propos
+        </p>
+        <h2 class="mt-3 text-2xl font-semibold text-slate-950">
+          Votre parcours
+        </h2>
+        <p class="mt-4 text-sm leading-7 whitespace-pre-line text-slate-600">
+          {{ detail.program.description }}
+        </p>
+      </article>
+
+      <aside
+        class="rounded-[2rem] bg-slate-950 p-6 text-white shadow-[0_18px_45px_-28px_rgba(15,23,42,0.75)] sm:p-8"
+      >
+        <p
+          class="text-xs font-semibold tracking-[0.18em] text-cyan-200/72 uppercase"
+        >
+          Repères
+        </p>
+
+        @if (detail.cohort) {
+          <h2 class="mt-3 text-xl font-semibold">
+            {{ detail.cohort.name }}
+          </h2>
+
+          <dl class="mt-6 space-y-5 text-sm">
+            @if (detail.cohort.code) {
+              <div>
+                <dt class="text-xs font-semibold text-white/44 uppercase">
+                  Code
+                </dt>
+                <dd class="mt-1 text-white/82">{{ detail.cohort.code }}</dd>
+              </div>
+            }
+
+            <div>
+              <dt class="text-xs font-semibold text-white/44 uppercase">
+                Début
+              </dt>
+              <dd class="mt-1 text-white/82">
+                {{ formatDate(detail.cohort.startDate) }}
+              </dd>
+            </div>
+
+            @if (detail.cohort.endDate) {
+              <div>
+                <dt class="text-xs font-semibold text-white/44 uppercase">
+                  Fin
+                </dt>
+                <dd class="mt-1 text-white/82">
+                  {{ formatDate(detail.cohort.endDate) }}
+                </dd>
+              </div>
+            }
+
+            @if (detail.cohort.capacity) {
+              <div>
+                <dt class="text-xs font-semibold text-white/44 uppercase">
+                  Capacité
+                </dt>
+                <dd class="mt-1 text-white/82">
+                  {{ detail.cohort.capacity }} participants
+                </dd>
+              </div>
+            }
+          </dl>
+        } @else {
+          <h2 class="mt-3 text-xl font-semibold">Parcours individuel</h2>
+          <p class="mt-3 text-sm leading-6 text-white/60">
+            Aucune cohorte n'est associée à ce programme.
+          </p>
+        }
+      </aside>
+    </section>
+
+    <section aria-labelledby="program-sessions-title">
+      <div
+        class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+      >
+        <div>
+          <p
+            class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+          >
+            Parcours
+          </p>
+          <h2
+            id="program-sessions-title"
+            class="mt-2 text-2xl font-semibold text-slate-950 sm:text-3xl"
+          >
+            Sessions
+          </h2>
+        </div>
+
+        <span class="text-sm font-semibold text-slate-500">
+          {{ detail.sessions.length }}
+          {{ detail.sessions.length === 1 ? 'session' : 'sessions' }}
+        </span>
+      </div>
+
+      @if (detail.sessions.length > 0) {
+        <div class="mt-6 divide-y divide-dashed divide-slate-200">
+          @for (
+            session of detail.sessions;
+            track session.id;
+            let index = $index
+          ) {
+            <article
+              class="grid gap-5 py-6 first:pt-0 sm:grid-cols-[3rem_minmax(0,1fr)_auto] sm:items-center"
+            >
+              <span
+                class="text-brand-blue flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-sm font-semibold shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+                aria-hidden="true"
+              >
+                {{ (index + 1).toString().padStart(2, '0') }}
+              </span>
+
+              <div class="min-w-0">
+                <div class="flex flex-wrap items-center gap-2">
+                  <h3 class="text-lg font-semibold text-slate-950">
+                    {{ session.title }}
+                  </h3>
+
+                  <span
+                    class="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-600"
+                  >
+                    {{ sessionStatusLabel(session.status) }}
+                  </span>
+                </div>
+
+                @if (session.description) {
+                  <p class="mt-2 line-clamp-2 text-sm leading-6 text-slate-600">
+                    {{ session.description }}
+                  </p>
+                }
+
+                <div
+                  class="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-xs font-medium text-slate-500"
+                >
+                  <span>
+                    {{ formatDateTime(session.startsAt) }}
+                  </span>
+                  <span>
+                    {{ locationTypeLabel(session.locationType) }}
+                  </span>
+                  @if (session.locationLabel) {
+                    <span>{{ session.locationLabel }}</span>
+                  }
+                </div>
+              </div>
+
+              <a
+                [routerLink]="[
+                  '/participant/programmes',
+                  detail.program.id,
+                  'sessions',
+                  session.id,
+                ]"
+                class="text-brand-blue inline-flex w-fit items-center gap-2 text-sm font-semibold transition hover:gap-3"
+              >
+                Ouvrir la session
+                <i class="pi pi-arrow-right text-xs" aria-hidden="true"></i>
+              </a>
+            </article>
+          }
+        </div>
+      } @else {
+        <div
+          class="mt-6 rounded-3xl border border-dashed border-slate-200 bg-white/60 px-6 py-8"
+        >
+          <p class="text-sm leading-6 text-slate-600">
+            Aucune session programmée pour le moment.
+          </p>
+        </div>
+      }
+    </section>
+
+    <section
+      class="grid gap-8 lg:grid-cols-2"
+      aria-label="Ressources et annonces du programme"
+    >
+      <article
+        class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_12px_30px_-18px_rgba(18,43,74,0.16)] sm:p-8"
+      >
+        <div class="flex items-end justify-between gap-4">
+          <div>
+            <p
+              class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+            >
+              Bibliothèque
+            </p>
+            <h2 class="mt-2 text-2xl font-semibold text-slate-950">
+              Ressources
+            </h2>
+          </div>
+          <span class="text-sm font-semibold text-slate-400">
+            {{ detail.resources.length }}
+          </span>
+        </div>
+
+        @if (detail.resources.length > 0) {
+          <div class="mt-6 divide-y divide-dashed divide-slate-200">
+            @for (resource of detail.resources; track resource.id) {
+              <div class="py-5 first:pt-0">
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <p class="font-semibold text-slate-950">
+                      {{ resource.title }}
+                    </p>
+                    <p
+                      class="mt-1 text-[11px] font-semibold tracking-[0.12em] text-slate-400 uppercase"
+                    >
+                      {{ resourceTypeLabel(resource.resourceType) }}
+                    </p>
+                  </div>
+
+                  @if (resource.url) {
+                    <a
+                      [href]="resource.url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-950 text-white transition hover:-translate-y-0.5"
+                      [attr.aria-label]="'Ouvrir ' + resource.title"
+                    >
+                      <i
+                        class="pi pi-arrow-up-right text-xs"
+                        aria-hidden="true"
+                      ></i>
+                    </a>
+                  }
+                </div>
+
+                @if (resource.description) {
+                  <p class="mt-3 text-sm leading-6 text-slate-600">
+                    {{ resource.description }}
+                  </p>
+                }
+              </div>
+            }
+          </div>
+        } @else {
+          <p class="mt-6 text-sm leading-6 text-slate-600">
+            Aucune ressource disponible pour le moment.
+          </p>
+        }
+      </article>
+
+      <article
+        class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_12px_30px_-18px_rgba(18,43,74,0.16)] sm:p-8"
+      >
+        <div class="flex items-end justify-between gap-4">
+          <div>
+            <p
+              class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+            >
+              Actualités
+            </p>
+            <h2 class="mt-2 text-2xl font-semibold text-slate-950">Annonces</h2>
+          </div>
+          <span class="text-sm font-semibold text-slate-400">
+            {{ detail.announcements.length }}
+          </span>
+        </div>
+
+        @if (detail.announcements.length > 0) {
+          <div class="mt-6 divide-y divide-dashed divide-slate-200">
+            @for (announcement of detail.announcements; track announcement.id) {
+              <div class="py-5 first:pt-0">
+                <p class="font-semibold text-slate-950">
+                  {{ announcement.title }}
+                </p>
+                <p class="mt-2 text-xs font-medium text-slate-500">
+                  Publiée le {{ formatDate(announcement.publishedAt) }}
+                </p>
+              </div>
+            }
+          </div>
+        } @else {
+          <p class="mt-6 text-sm leading-6 text-slate-600">
+            Aucune annonce liée à ce programme pour le moment.
+          </p>
+        }
+      </article>
+    </section>
+  } @else {
+    <section
+      class="rounded-[2rem] bg-white p-8 text-center shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)]"
+    >
+      <h1 class="text-2xl font-semibold text-slate-950">
+        Programme introuvable
+      </h1>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Ce programme n'a pas pu être résolu depuis votre espace participant.
+      </p>
+      <a routerLink="/participant/programmes" class="kr-button-primary mt-6">
+        Retour aux programmes
+      </a>
+    </section>
+  }
+</div>

--- a/apps/client/projects/web/src/app/features/participant/programs/program-detail.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/programs/program-detail.page.spec.ts
@@ -1,0 +1,243 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParticipantProgramDetailDto } from '@kraak/contracts';
+
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import ProgramDetailPage from './program-detail.page';
+
+describe('Web Participant ProgramDetailPage', () => {
+  let activatedRoute: {
+    snapshot: {
+      paramMap: {
+        get: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+
+  const detail: ParticipantProgramDetailDto = {
+    enrollmentId: 'enr-1',
+    enrollmentStatus: 'active',
+    program: {
+      id: 'prog-1',
+      slug: 'programme-test',
+      title: 'Programme test',
+      summary: 'Un programme de test',
+      description: 'Description complète du programme.',
+      status: 'published',
+      visibility: 'participants',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    cohort: {
+      id: 'cohort-1',
+      programId: 'prog-1',
+      name: 'Cohorte pilote',
+      code: 'COH-001',
+      status: 'active',
+      startDate: '2026-01-15T09:00:00.000Z',
+      endDate: '2026-06-30T17:00:00.000Z',
+      capacity: 20,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    progress: {
+      totalSessions: 4,
+      completedSessions: 1,
+      completionRate: 25,
+      status: 'in_progress',
+      completedSessionIds: ['session-0'],
+      updatedAt: '2026-01-20T00:00:00.000Z',
+    },
+    sessions: [
+      {
+        id: 'session-1',
+        cohortId: 'cohort-1',
+        title: 'Session de démarrage',
+        description: 'Présentation du parcours et des objectifs.',
+        status: 'scheduled',
+        startsAt: '2026-02-01T10:00:00.000Z',
+        endsAt: '2026-02-01T12:00:00.000Z',
+        locationType: 'online',
+        locationLabel: null,
+        meetingLink: 'https://meet.example.com/session-1',
+        trainerUserId: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    resources: [
+      {
+        id: 'resource-1',
+        programId: 'prog-1',
+        cohortId: null,
+        title: 'Guide de formation',
+        description: 'Document de référence.',
+        resourceType: 'document',
+        resourceTheme: 'training',
+        resourceAudience: 'all',
+        url: 'https://example.com/guide.pdf',
+        filePath: null,
+        status: 'published',
+        publishedAt: '2026-01-10T00:00:00.000Z',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    announcements: [
+      {
+        id: 'announcement-1',
+        title: 'Bienvenue dans le programme',
+        audienceType: 'all_participants',
+        publishedAt: '2026-01-12T00:00:00.000Z',
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    activatedRoute = {
+      snapshot: {
+        paramMap: {
+          get: vi.fn((key: string) => (key === 'programId' ? 'prog-1' : null)),
+        },
+      },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProgramDetailPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: WebAuthService,
+          useValue: {
+            currentSession: () => null,
+          },
+        },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+      ],
+    }).compileComponents();
+  });
+
+  function configureClient(
+    fixture: ReturnType<typeof TestBed.createComponent<ProgramDetailPage>>,
+    result: Promise<ParticipantProgramDetailDto>,
+  ): ReturnType<typeof vi.fn> {
+    const getById = vi.fn().mockImplementation(() => result);
+    fixture.componentInstance['programsClient'] = { getById };
+    return getById;
+  }
+
+  async function render(
+    result: Promise<ParticipantProgramDetailDto>,
+  ): Promise<ReturnType<typeof TestBed.createComponent<ProgramDetailPage>>> {
+    const fixture = TestBed.createComponent(ProgramDetailPage);
+    configureClient(fixture, result);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('Given a program id, When detail loads, Then it renders the program, progression and cohort', async () => {
+    const fixture = await render(Promise.resolve(detail));
+    const text = fixture.nativeElement.textContent ?? '';
+
+    expect(text).toContain('Programme test');
+    expect(text).toContain('Un programme de test');
+    expect(text).toContain('Description complète du programme.');
+    expect(text).toContain('25%');
+    expect(text).toContain('1/4');
+    expect(text).toContain('Cohorte pilote');
+    expect(text).toContain('COH-001');
+  });
+
+  it('Given rich LMS content, When detail loads, Then sessions, resources and announcements are rendered', async () => {
+    const fixture = await render(Promise.resolve(detail));
+    const element = fixture.nativeElement as HTMLElement;
+    const text = element.textContent ?? '';
+
+    expect(text).toContain('Session de démarrage');
+    expect(text).toContain('En ligne');
+    expect(text).toContain('Guide de formation');
+    expect(text).toContain('Document de référence.');
+    expect(text).toContain('Bienvenue dans le programme');
+
+    const externalResource = element.querySelector(
+      'a[href="https://example.com/guide.pdf"]',
+    );
+    expect(externalResource?.getAttribute('target')).toBe('_blank');
+    expect(externalResource?.getAttribute('rel')).toContain('noopener');
+
+    expect(
+      element.querySelector(
+        'a[href="/participant/programmes/prog-1/sessions/session-1"]',
+      ),
+    ).not.toBeNull();
+  });
+
+  it('Given optional collections are empty and cohort is null, When detail loads, Then useful empty states are rendered', async () => {
+    const fixture = await render(
+      Promise.resolve({
+        ...detail,
+        cohort: null,
+        sessions: [],
+        resources: [],
+        announcements: [],
+      }),
+    );
+    const text = fixture.nativeElement.textContent ?? '';
+
+    expect(text).toContain('Parcours individuel');
+    expect(text).toContain('Aucune session programmée');
+    expect(text).toContain('Aucune ressource disponible');
+    expect(text).toContain('Aucune annonce liée');
+  });
+
+  it('Given detail loading fails, When the page settles, Then the resolved error and retry action are shown', async () => {
+    const fixture = await render(Promise.reject(new Error('API Error')));
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('API Error');
+    expect(element.querySelector('button')?.textContent).toContain('Réessayer');
+  });
+
+  it('Given a failed load, When retry succeeds, Then the program is requested again and rendered', async () => {
+    const fixture = TestBed.createComponent(ProgramDetailPage);
+    const getById = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Temporary failure'))
+      .mockResolvedValueOnce(detail);
+
+    fixture.componentInstance['programsClient'] = { getById };
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const retry = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement;
+    retry.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getById).toHaveBeenCalledTimes(2);
+    expect(getById).toHaveBeenLastCalledWith('prog-1');
+    expect(fixture.nativeElement.textContent).toContain('Programme test');
+  });
+
+  it('Given the route has no program id, When the page initializes, Then no API request is made and not-found state is shown', async () => {
+    activatedRoute.snapshot.paramMap.get.mockReturnValue(null);
+
+    const fixture = TestBed.createComponent(ProgramDetailPage);
+    const getById = configureClient(fixture, Promise.resolve(detail));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getById).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain(
+      'Programme introuvable',
+    );
+  });
+});

--- a/apps/client/projects/web/src/app/features/participant/programs/program-detail.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/programs/program-detail.page.ts
@@ -1,0 +1,186 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import {
+  createApiClient,
+  logDebugError,
+  resolveAuthErrorMessage,
+  type ApiClient,
+} from '@kraak/api-client';
+import type { ParticipantProgramDetailDto } from '@kraak/contracts';
+
+import { environment } from '../../../../environments/environment';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+
+@Component({
+  selector: 'kraak-web-participant-program-detail',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './program-detail.page.html',
+})
+export default class ProgramDetailPage implements OnInit {
+  private readonly authService = inject(WebAuthService);
+  private readonly route = inject(ActivatedRoute);
+
+  protected programsClient: Pick<ApiClient['participantPrograms'], 'getById'> =
+    createApiClient({
+      baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+      getAuthToken: () =>
+        this.authService.currentSession()?.accessToken ?? null,
+    }).participantPrograms;
+
+  protected readonly programDetail = signal<ParticipantProgramDetailDto | null>(
+    null,
+  );
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    const programId = this.readProgramId();
+
+    if (!programId) {
+      this.loading.set(false);
+      return;
+    }
+
+    void this.loadProgramDetail(programId);
+  }
+
+  protected async reloadProgram(): Promise<void> {
+    const programId = this.readProgramId();
+
+    if (programId) {
+      await this.loadProgramDetail(programId);
+    }
+  }
+
+  protected enrollmentStatusLabel(
+    status: ParticipantProgramDetailDto['enrollmentStatus'],
+  ): string {
+    switch (status) {
+      case 'pending':
+        return 'En attente';
+      case 'active':
+        return 'Actif';
+      case 'completed':
+        return 'Terminé';
+      case 'cancelled':
+        return 'Annulé';
+    }
+  }
+
+  protected progressStatusLabel(
+    status: ParticipantProgramDetailDto['progress']['status'],
+  ): string {
+    switch (status) {
+      case 'not_started':
+        return 'Non commencé';
+      case 'in_progress':
+        return 'En cours';
+      case 'completed':
+        return 'Terminé';
+    }
+  }
+
+  protected sessionStatusLabel(
+    status: ParticipantProgramDetailDto['sessions'][number]['status'],
+  ): string {
+    switch (status) {
+      case 'scheduled':
+        return 'Planifiée';
+      case 'live':
+        return 'En direct';
+      case 'completed':
+        return 'Terminée';
+      case 'cancelled':
+        return 'Annulée';
+    }
+  }
+
+  protected locationTypeLabel(
+    type: ParticipantProgramDetailDto['sessions'][number]['locationType'],
+  ): string {
+    switch (type) {
+      case 'online':
+        return 'En ligne';
+      case 'onsite':
+        return 'Sur site';
+      case 'hybrid':
+        return 'Hybride';
+    }
+  }
+
+  protected resourceTypeLabel(
+    type: ParticipantProgramDetailDto['resources'][number]['resourceType'],
+  ): string {
+    switch (type) {
+      case 'link':
+        return 'Lien';
+      case 'file':
+        return 'Fichier';
+      case 'video':
+        return 'Vidéo';
+      case 'document':
+        return 'Document';
+    }
+  }
+
+  protected formatDate(rawDate: string | null): string {
+    if (!rawDate) {
+      return 'À venir';
+    }
+
+    const parsedDate = new Date(rawDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return rawDate;
+    }
+
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    }).format(parsedDate);
+  }
+
+  protected formatDateTime(rawDate: string): string {
+    const parsedDate = new Date(rawDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return rawDate;
+    }
+
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(parsedDate);
+  }
+
+  private readProgramId(): string | null {
+    return this.route.snapshot.paramMap.get('programId');
+  }
+
+  private async loadProgramDetail(programId: string): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.errorMessage.set(null);
+
+      const detail = await this.programsClient.getById(programId);
+      this.programDetail.set(detail);
+    } catch (error) {
+      logDebugError('web.participant.programs.detail', error, {
+        route: `/participant/programmes/${programId}`,
+      });
+
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Erreur lors du chargement du programme.',
+        ),
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/client/projects/web/src/app/features/participant/programs/program-list.page.html
+++ b/apps/client/projects/web/src/app/features/participant/programs/program-list.page.html
@@ -1,0 +1,264 @@
+<div class="space-y-10">
+  <header
+    class="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between"
+    aria-labelledby="participant-programs-title"
+  >
+    <div class="max-w-2xl">
+      <p
+        class="text-brand-blue text-sm font-semibold tracking-[0.22em] uppercase"
+      >
+        Programmes
+      </p>
+
+      <h1
+        id="participant-programs-title"
+        class="mt-3 text-3xl leading-tight font-semibold text-slate-950 sm:text-4xl lg:text-5xl"
+      >
+        Vos parcours
+      </h1>
+
+      <p class="mt-4 max-w-xl text-base leading-7 text-slate-600">
+        Explorez les programmes auxquels vous êtes inscrit et suivez votre
+        progression session après session.
+      </p>
+    </div>
+
+    @if (!loading() && !errorMessage()) {
+      <span
+        class="inline-flex w-fit items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+      >
+        {{ programs().length }}
+        {{ programs().length === 1 ? 'parcours' : 'parcours' }}
+      </span>
+    }
+  </header>
+
+  @if (errorMessage()) {
+    <section
+      class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)] sm:p-8"
+      role="alert"
+    >
+      <span
+        class="flex h-11 w-11 items-center justify-center rounded-2xl bg-red-50 text-red-700"
+        aria-hidden="true"
+      >
+        <i class="pi pi-exclamation-circle"></i>
+      </span>
+
+      <h2 class="mt-5 text-xl font-semibold text-slate-950">
+        Impossible de charger vos programmes
+      </h2>
+
+      <p class="mt-2 max-w-xl text-sm leading-6 text-slate-600">
+        {{ errorMessage() }}
+      </p>
+
+      <button
+        type="button"
+        class="kr-button-primary mt-6"
+        (click)="reloadPrograms()"
+      >
+        Réessayer
+      </button>
+    </section>
+  } @else if (loading()) {
+    <section
+      class="grid gap-7 sm:grid-cols-2 lg:grid-cols-3"
+      aria-label="Chargement de vos programmes"
+      aria-busy="true"
+    >
+      @for (placeholder of [1, 2, 3]; track placeholder) {
+        <article>
+          <div
+            class="h-62 animate-pulse rounded-2xl bg-slate-200"
+            aria-hidden="true"
+          ></div>
+          <div class="mt-5 space-y-3 px-3">
+            <div
+              class="h-5 w-2/3 animate-pulse rounded-full bg-slate-200"
+            ></div>
+            <div
+              class="h-4 w-full animate-pulse rounded-full bg-slate-100"
+            ></div>
+            <div
+              class="h-4 w-4/5 animate-pulse rounded-full bg-slate-100"
+            ></div>
+          </div>
+        </article>
+      }
+    </section>
+  } @else if (programs().length === 0) {
+    <section
+      class="rounded-[2rem] bg-white px-6 py-12 text-center shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)] sm:px-8"
+    >
+      <span
+        class="text-brand-blue mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-50 shadow-[0_1px_2px_rgba(164,172,185,0.24),0_0_0_1px_rgba(18,55,105,0.08)]"
+        aria-hidden="true"
+      >
+        <i class="pi pi-book text-lg"></i>
+      </span>
+
+      <h2 class="mt-5 text-xl font-semibold text-slate-950">
+        Aucun programme disponible
+      </h2>
+
+      <p class="mx-auto mt-2 max-w-lg text-sm leading-6 text-slate-600">
+        Aucun programme n'est actuellement disponible pour vous. Les nouveaux
+        parcours apparaîtront ici dès leur activation.
+      </p>
+
+      <a routerLink="/participant/dashboard" class="kr-button-secondary mt-6">
+        Retour au tableau de bord
+      </a>
+    </section>
+  } @else {
+    <section
+      class="grid gap-x-7 gap-y-12 sm:grid-cols-2 lg:grid-cols-3"
+      aria-label="Vos programmes"
+    >
+      @for (
+        program of programs();
+        track program.enrollmentId;
+        let index = $index
+      ) {
+        <article class="group min-w-0">
+          <div
+            class="relative h-62 overflow-hidden rounded-2xl bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_52%,#1673ae_100%)] shadow-[0_2px_5px_rgba(18,55,105,0.08),0_18px_40px_-24px_rgba(18,43,74,0.5)]"
+          >
+            <div
+              aria-hidden="true"
+              class="absolute -top-14 -right-12 h-44 w-44 rounded-full bg-cyan-300/30 blur-2xl transition-transform duration-500 group-hover:scale-110"
+            ></div>
+            <div
+              aria-hidden="true"
+              class="absolute -bottom-16 -left-10 h-48 w-48 rounded-full bg-amber-300/16 blur-3xl transition-transform duration-500 group-hover:scale-110"
+            ></div>
+
+            <div class="absolute inset-0 flex flex-col justify-between p-5">
+              <div class="flex items-start justify-between gap-4">
+                <span
+                  class="inline-flex h-8 items-center rounded-full border border-white/16 bg-white/12 px-3 text-[11px] font-semibold tracking-[0.12em] text-white uppercase backdrop-blur-xl"
+                >
+                  {{ enrollmentStatusLabel(program.enrollmentStatus) }}
+                </span>
+
+                <span
+                  class="text-sm font-semibold text-white/48"
+                  aria-hidden="true"
+                >
+                  {{ (index + 1).toString().padStart(2, '0') }}
+                </span>
+              </div>
+
+              <div class="flex items-end justify-between gap-5">
+                <div>
+                  <p
+                    class="text-xs font-semibold tracking-[0.18em] text-cyan-100/72 uppercase"
+                  >
+                    KRAAK Learning
+                  </p>
+                  <p class="mt-1 text-sm font-medium text-white/70">
+                    {{ progressStatusLabel(program.progress.status) }}
+                  </p>
+                </div>
+
+                <span
+                  class="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-white/16 bg-white/12 shadow-[0_2px_5px_rgba(255,255,255,0.08)_inset] backdrop-blur-xl"
+                  aria-hidden="true"
+                >
+                  <img
+                    src="/kraak_symbol.svg"
+                    alt=""
+                    width="44"
+                    height="44"
+                    class="h-11 w-11 brightness-0 invert"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5 px-3">
+            <h2
+              class="group-hover:text-brand-blue text-xl leading-7 font-semibold text-slate-950 transition-colors"
+            >
+              {{ program.program.title }}
+            </h2>
+
+            <p class="mt-2 line-clamp-3 text-sm leading-6 text-slate-600">
+              {{ program.program.summary }}
+            </p>
+
+            <div class="mt-5">
+              <div class="flex items-center justify-between gap-4 text-xs">
+                <span class="font-semibold text-slate-500">Progression</span>
+                <span class="font-semibold text-slate-950">
+                  {{ program.progress.completionRate }}%
+                </span>
+              </div>
+
+              <div
+                class="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-100"
+                role="progressbar"
+                [attr.aria-label]="'Progression de ' + program.program.title"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                [attr.aria-valuenow]="program.progress.completionRate"
+              >
+                <div
+                  class="h-full rounded-full bg-[linear-gradient(90deg,#1673ae_0%,#4cc3d9_100%)]"
+                  [style.width.%]="program.progress.completionRate"
+                ></div>
+              </div>
+
+              <p class="mt-2 text-xs leading-5 text-slate-500">
+                {{ program.progress.completedSessions }}/{{
+                  program.progress.totalSessions
+                }}
+                sessions terminées
+              </p>
+            </div>
+
+            @if (program.cohort) {
+              <div
+                class="mt-5 flex items-start justify-between gap-4 border-t border-dashed border-slate-200 pt-4"
+              >
+                <div>
+                  <p
+                    class="text-[11px] font-semibold tracking-[0.14em] text-slate-400 uppercase"
+                  >
+                    Cohorte
+                  </p>
+                  <p class="mt-1 text-sm font-semibold text-slate-700">
+                    {{ program.cohort.name }}
+                  </p>
+                </div>
+
+                @if (program.cohort.startDate) {
+                  <div class="text-right">
+                    <p
+                      class="text-[11px] font-semibold tracking-[0.14em] text-slate-400 uppercase"
+                    >
+                      Début
+                    </p>
+                    <p class="mt-1 text-sm font-medium text-slate-600">
+                      {{ formatDate(program.cohort.startDate) }}
+                    </p>
+                  </div>
+                }
+              </div>
+            }
+
+            <a
+              [routerLink]="['/participant/programmes', program.program.id]"
+              class="text-brand-blue mt-5 inline-flex items-center gap-2 text-sm font-semibold transition hover:gap-3"
+            >
+              Ouvrir le programme
+              <i class="pi pi-arrow-right text-xs" aria-hidden="true"></i>
+            </a>
+          </div>
+        </article>
+      }
+    </section>
+  }
+</div>

--- a/apps/client/projects/web/src/app/features/participant/programs/program-list.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/programs/program-list.page.spec.ts
@@ -1,0 +1,142 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParticipantProgramListItemDto } from '@kraak/contracts';
+
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import ProgramListPage from './program-list.page';
+
+describe('Web Participant ProgramListPage', () => {
+  const mockProgram: ParticipantProgramListItemDto = {
+    enrollmentId: 'enr-1',
+    enrollmentStatus: 'active',
+    program: {
+      id: 'prog-1',
+      slug: 'programme-test',
+      title: 'Programme test',
+      summary: 'Un programme de test',
+      description: 'Description du programme',
+      status: 'published',
+      visibility: 'participants',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    cohort: {
+      id: 'cohort-1',
+      programId: 'prog-1',
+      name: 'Cohorte pilote',
+      code: 'COH-001',
+      status: 'active',
+      startDate: '2026-01-15T09:00:00.000Z',
+      endDate: null,
+      capacity: 20,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    progress: {
+      totalSessions: 8,
+      completedSessions: 3,
+      completionRate: 38,
+      status: 'in_progress',
+      completedSessionIds: ['session-1', 'session-2', 'session-3'],
+      updatedAt: '2026-01-20T00:00:00.000Z',
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProgramListPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: WebAuthService,
+          useValue: {
+            currentSession: () => null,
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  function configureClient(
+    fixture: ReturnType<typeof TestBed.createComponent<ProgramListPage>>,
+    result: Promise<ParticipantProgramListItemDto[]>,
+  ): void {
+    fixture.componentInstance['programsClient'] = {
+      list: vi.fn().mockImplementation(() => result),
+    };
+  }
+
+  async function render(
+    result: Promise<ParticipantProgramListItemDto[]>,
+  ): Promise<ReturnType<typeof TestBed.createComponent<ProgramListPage>>> {
+    const fixture = TestBed.createComponent(ProgramListPage);
+    configureClient(fixture, result);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('Given enrolled programs, When the page loads, Then it renders title, progress and cohort metadata', async () => {
+    const fixture = await render(Promise.resolve([mockProgram]));
+    const element = fixture.nativeElement as HTMLElement;
+    const text = element.textContent ?? '';
+
+    expect(text).toContain('Vos parcours');
+    expect(text).toContain('Programme test');
+    expect(text).toContain('Un programme de test');
+    expect(text).toContain('38%');
+    expect(text).toContain('3/8');
+    expect(text).toContain('Cohorte pilote');
+
+    const progress = element.querySelector('[role="progressbar"]');
+    expect(progress?.getAttribute('aria-valuenow')).toBe('38');
+    expect(
+      element.querySelector('a[href="/participant/programmes/prog-1"]'),
+    ).not.toBeNull();
+  });
+
+  it('Given no enrolled programs, When the page loads, Then it renders the empty state', async () => {
+    const fixture = await render(Promise.resolve([]));
+
+    expect(fixture.nativeElement.textContent).toContain(
+      "Aucun programme n'est actuellement disponible",
+    );
+  });
+
+  it('Given program loading fails, When the page settles, Then it renders the resolved error and retry action', async () => {
+    const fixture = await render(Promise.reject(new Error('API Error')));
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('API Error');
+    expect(element.querySelector('button')?.textContent?.trim()).toContain(
+      'Réessayer',
+    );
+  });
+
+  it('Given a failed load, When retry succeeds, Then fresh programs are rendered', async () => {
+    const fixture = TestBed.createComponent(ProgramListPage);
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Temporary failure'))
+      .mockResolvedValueOnce([mockProgram]);
+
+    fixture.componentInstance['programsClient'] = { list };
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Temporary failure');
+
+    const retry = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement;
+    retry.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(fixture.nativeElement.textContent).toContain('Programme test');
+  });
+});

--- a/apps/client/projects/web/src/app/features/participant/programs/program-list.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/programs/program-list.page.ts
@@ -1,0 +1,106 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import {
+  createApiClient,
+  logDebugError,
+  resolveAuthErrorMessage,
+  type ApiClient,
+} from '@kraak/api-client';
+import type { ParticipantProgramListItemDto } from '@kraak/contracts';
+
+import { environment } from '../../../../environments/environment';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+
+@Component({
+  selector: 'kraak-web-participant-program-list',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './program-list.page.html',
+})
+export default class ProgramListPage implements OnInit {
+  private readonly authService = inject(WebAuthService);
+
+  protected programsClient: Pick<ApiClient['participantPrograms'], 'list'> =
+    createApiClient({
+      baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+      getAuthToken: () =>
+        this.authService.currentSession()?.accessToken ?? null,
+    }).participantPrograms;
+
+  protected readonly programs = signal<ParticipantProgramListItemDto[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    void this.loadPrograms();
+  }
+
+  protected async reloadPrograms(): Promise<void> {
+    await this.loadPrograms();
+  }
+
+  protected enrollmentStatusLabel(
+    status: ParticipantProgramListItemDto['enrollmentStatus'],
+  ): string {
+    switch (status) {
+      case 'pending':
+        return 'En attente';
+      case 'active':
+        return 'Actif';
+      case 'completed':
+        return 'Terminé';
+      case 'cancelled':
+        return 'Annulé';
+    }
+  }
+
+  protected progressStatusLabel(
+    status: ParticipantProgramListItemDto['progress']['status'],
+  ): string {
+    switch (status) {
+      case 'not_started':
+        return 'Non commencé';
+      case 'in_progress':
+        return 'En cours';
+      case 'completed':
+        return 'Terminé';
+    }
+  }
+
+  protected formatDate(rawDate: string): string {
+    const parsedDate = new Date(rawDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return rawDate;
+    }
+
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    }).format(parsedDate);
+  }
+
+  private async loadPrograms(): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.errorMessage.set(null);
+
+      const data = await this.programsClient.list();
+      this.programs.set(data);
+    } catch (error) {
+      logDebugError('web.participant.programs.list', error, {
+        route: '/participant/programmes',
+      });
+
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Erreur lors du chargement des programmes.',
+        ),
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/client/projects/web/src/app/features/participant/programs/session-detail.page.html
+++ b/apps/client/projects/web/src/app/features/participant/programs/session-detail.page.html
@@ -1,0 +1,292 @@
+<div class="space-y-10">
+  <a
+    [routerLink]="['/participant/programmes', programId()]"
+    class="hover:text-brand-blue inline-flex items-center gap-2 text-sm font-semibold text-slate-500 transition"
+  >
+    <i class="pi pi-arrow-left text-xs" aria-hidden="true"></i>
+    Retour au programme
+  </a>
+
+  @if (errorMessage()) {
+    <section
+      class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)] sm:p-8"
+      role="alert"
+    >
+      <span
+        class="flex h-11 w-11 items-center justify-center rounded-2xl bg-red-50 text-red-700"
+        aria-hidden="true"
+      >
+        <i class="pi pi-exclamation-circle"></i>
+      </span>
+
+      <h1 class="mt-5 text-2xl font-semibold text-slate-950">
+        Impossible de charger cette session
+      </h1>
+
+      <p class="mt-2 max-w-xl text-sm leading-6 text-slate-600">
+        {{ errorMessage() }}
+      </p>
+
+      <button
+        type="button"
+        class="kr-button-primary mt-6"
+        (click)="reloadSession()"
+      >
+        Réessayer
+      </button>
+    </section>
+  } @else if (loading()) {
+    <section aria-label="Chargement de la session" aria-busy="true">
+      <div class="h-72 animate-pulse rounded-[2rem] bg-slate-200 lg:h-80"></div>
+      <div class="mt-8 grid gap-6 lg:grid-cols-[1fr_22rem]">
+        <div class="h-72 animate-pulse rounded-[2rem] bg-white"></div>
+        <div class="h-72 animate-pulse rounded-[2rem] bg-white"></div>
+      </div>
+    </section>
+  } @else if (session(); as sess) {
+    <header
+      class="relative overflow-hidden rounded-[2rem] bg-[linear-gradient(135deg,#122b4a_0%,#1c4e86_54%,#1673ae_100%)] px-6 py-8 text-white shadow-[0_2px_5px_rgba(18,55,105,0.08),0_30px_70px_-40px_rgba(18,43,74,0.75)] sm:px-8 sm:py-10 lg:px-12"
+    >
+      <div
+        aria-hidden="true"
+        class="absolute -top-28 -right-20 h-72 w-72 rounded-full bg-cyan-300/24 blur-3xl"
+      ></div>
+      <div
+        aria-hidden="true"
+        class="absolute -bottom-36 -left-16 h-80 w-80 rounded-full bg-amber-300/12 blur-3xl"
+      ></div>
+
+      <div class="relative max-w-4xl">
+        <div class="flex flex-wrap items-center gap-2">
+          <span
+            class="inline-flex rounded-full border border-white/16 bg-white/12 px-3 py-1.5 text-[11px] font-semibold tracking-[0.12em] uppercase backdrop-blur-xl"
+          >
+            {{ sessionStatusLabel(sess.status) }}
+          </span>
+
+          <span
+            class="inline-flex rounded-full border border-white/16 bg-white/8 px-3 py-1.5 text-[11px] font-semibold tracking-[0.12em] text-white/72 uppercase backdrop-blur-xl"
+          >
+            {{ locationTypeLabel(sess.locationType) }}
+          </span>
+        </div>
+
+        <p
+          class="mt-8 text-xs font-semibold tracking-[0.22em] text-cyan-100/72 uppercase"
+        >
+          Session · {{ programDetail()?.program?.title }}
+        </p>
+
+        <h1
+          class="mt-3 max-w-3xl text-3xl leading-tight font-semibold sm:text-4xl lg:text-5xl"
+        >
+          {{ sess.title }}
+        </h1>
+
+        @if (sess.description) {
+          <p class="mt-5 max-w-2xl text-base leading-7 text-white/72">
+            {{ sess.description }}
+          </p>
+        }
+      </div>
+    </header>
+
+    <section class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem]">
+      <div class="space-y-8">
+        <article
+          class="rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_12px_30px_-18px_rgba(18,43,74,0.16)] sm:p-8"
+        >
+          <p
+            class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+          >
+            Rendez-vous
+          </p>
+          <h2 class="mt-2 text-2xl font-semibold text-slate-950">
+            Informations de session
+          </h2>
+
+          <dl class="mt-7 grid gap-5 sm:grid-cols-2">
+            <div class="rounded-3xl bg-slate-50 p-5">
+              <dt
+                class="text-[11px] font-semibold tracking-[0.14em] text-slate-400 uppercase"
+              >
+                Début
+              </dt>
+              <dd class="mt-2 text-sm font-semibold text-slate-800">
+                {{ formatDateTime(sess.startsAt) }}
+              </dd>
+            </div>
+
+            <div class="rounded-3xl bg-slate-50 p-5">
+              <dt
+                class="text-[11px] font-semibold tracking-[0.14em] text-slate-400 uppercase"
+              >
+                Fin
+              </dt>
+              <dd class="mt-2 text-sm font-semibold text-slate-800">
+                {{ formatDateTime(sess.endsAt) }}
+              </dd>
+            </div>
+
+            <div class="rounded-3xl bg-slate-50 p-5">
+              <dt
+                class="text-[11px] font-semibold tracking-[0.14em] text-slate-400 uppercase"
+              >
+                Format
+              </dt>
+              <dd class="mt-2 text-sm font-semibold text-slate-800">
+                {{ locationTypeLabel(sess.locationType) }}
+              </dd>
+            </div>
+
+            <div class="rounded-3xl bg-slate-50 p-5">
+              <dt
+                class="text-[11px] font-semibold tracking-[0.14em] text-slate-400 uppercase"
+              >
+                Lieu
+              </dt>
+              <dd class="mt-2 text-sm font-semibold text-slate-800">
+                {{ sess.locationLabel || 'Non précisé' }}
+              </dd>
+            </div>
+          </dl>
+
+          @if (sess.meetingLink) {
+            <div
+              class="mt-6 flex flex-col gap-4 rounded-3xl bg-slate-950 p-5 text-white sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <p class="text-sm font-semibold">Session en ligne</p>
+                <p class="mt-1 text-xs leading-5 text-white/56">
+                  Ouvrez le lien de réunion dans un nouvel onglet.
+                </p>
+              </div>
+
+              <a
+                [href]="sess.meetingLink"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-slate-950 transition hover:-translate-y-0.5"
+              >
+                Rejoindre la session
+                <i class="pi pi-arrow-up-right text-xs" aria-hidden="true"></i>
+              </a>
+            </div>
+          }
+        </article>
+      </div>
+
+      <aside
+        class="h-fit rounded-[2rem] bg-white p-6 shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_12px_30px_-18px_rgba(18,43,74,0.16)] sm:p-8"
+      >
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p
+              class="text-brand-blue text-xs font-semibold tracking-[0.18em] uppercase"
+            >
+              Progression
+            </p>
+            <h2 class="mt-2 text-xl font-semibold text-slate-950">
+              Votre suivi
+            </h2>
+          </div>
+
+          <span
+            class="flex h-10 w-10 items-center justify-center rounded-2xl"
+            [class.bg-emerald-50]="isSessionCompleted()"
+            [class.text-emerald-700]="isSessionCompleted()"
+            [class.bg-slate-100]="!isSessionCompleted()"
+            [class.text-slate-500]="!isSessionCompleted()"
+            aria-hidden="true"
+          >
+            <i
+              class="pi"
+              [class.pi-check]="isSessionCompleted()"
+              [class.pi-clock]="!isSessionCompleted()"
+            ></i>
+          </span>
+        </div>
+
+        <p class="mt-5 text-sm leading-6 text-slate-600">
+          @if (isSessionCompleted()) {
+            Session marquée comme terminée.
+          } @else {
+            Session non terminée.
+          }
+        </p>
+
+        @if (markErrorMessage()) {
+          <p
+            class="mt-4 rounded-2xl bg-red-50 px-4 py-3 text-sm leading-6 text-red-700"
+            role="alert"
+          >
+            {{ markErrorMessage() }}
+          </p>
+        }
+
+        @if (isSessionCompleted()) {
+          <button
+            type="button"
+            class="kr-button-secondary mt-6 w-full"
+            [disabled]="markingProgress()"
+            (click)="markSessionCompletion(false)"
+          >
+            Marquer comme non terminée
+          </button>
+        } @else {
+          <button
+            type="button"
+            class="kr-button-primary mt-6 w-full"
+            [disabled]="markingProgress()"
+            (click)="markSessionCompletion(true)"
+          >
+            Marquer comme terminée
+          </button>
+        }
+
+        @if (programDetail(); as detail) {
+          <div class="mt-7 border-t border-dashed border-slate-200 pt-6">
+            <div class="flex items-end justify-between gap-3">
+              <span class="text-xs font-semibold text-slate-500">
+                Progression globale
+              </span>
+              <span class="text-sm font-semibold text-slate-950">
+                {{ detail.progress.completionRate }}%
+              </span>
+            </div>
+
+            <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-100">
+              <div
+                class="h-full rounded-full bg-[linear-gradient(90deg,#1673ae_0%,#4cc3d9_100%)]"
+                [style.width.%]="detail.progress.completionRate"
+              ></div>
+            </div>
+
+            <p class="mt-2 text-xs leading-5 text-slate-500">
+              {{ detail.progress.completedSessions }}/{{
+                detail.progress.totalSessions
+              }}
+              sessions terminées
+            </p>
+          </div>
+        }
+      </aside>
+    </section>
+  } @else {
+    <section
+      class="rounded-[2rem] bg-white p-8 text-center shadow-[0_1px_1px_rgba(0,0,0,0.06),0_-1px_1px_rgba(0,0,0,0.06)_inset,0_8px_24px_rgba(18,43,74,0.08)]"
+    >
+      <h1 class="text-2xl font-semibold text-slate-950">Session introuvable</h1>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        La session n'a pas pu être trouvée dans ce programme.
+      </p>
+
+      <a
+        [routerLink]="['/participant/programmes', programId()]"
+        class="kr-button-primary mt-6"
+      >
+        Retour au programme
+      </a>
+    </section>
+  }
+</div>

--- a/apps/client/projects/web/src/app/features/participant/programs/session-detail.page.spec.ts
+++ b/apps/client/projects/web/src/app/features/participant/programs/session-detail.page.spec.ts
@@ -1,0 +1,278 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParticipantProgramDetailDto } from '@kraak/contracts';
+
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import SessionDetailPage from './session-detail.page';
+
+describe('Web Participant SessionDetailPage', () => {
+  let activatedRoute: {
+    snapshot: {
+      paramMap: {
+        get: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+
+  const detail: ParticipantProgramDetailDto = {
+    enrollmentId: 'enr-1',
+    enrollmentStatus: 'active',
+    program: {
+      id: 'prog-1',
+      slug: 'programme-test',
+      title: 'Programme test',
+      summary: 'Un programme de test',
+      description: 'Description du programme.',
+      status: 'published',
+      visibility: 'participants',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    cohort: {
+      id: 'cohort-1',
+      programId: 'prog-1',
+      name: 'Cohorte pilote',
+      code: 'COH-001',
+      status: 'active',
+      startDate: '2026-01-15T09:00:00.000Z',
+      endDate: null,
+      capacity: 20,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    progress: {
+      totalSessions: 2,
+      completedSessions: 0,
+      completionRate: 0,
+      status: 'not_started',
+      completedSessionIds: [],
+      updatedAt: null,
+    },
+    sessions: [
+      {
+        id: 'session-1',
+        cohortId: 'cohort-1',
+        title: 'Session de démarrage',
+        description: 'Présentation du parcours.',
+        status: 'scheduled',
+        startsAt: '2026-02-01T10:00:00.000Z',
+        endsAt: '2026-02-01T12:00:00.000Z',
+        locationType: 'online',
+        locationLabel: 'Classe virtuelle',
+        meetingLink: 'https://meet.example.com/session-1',
+        trainerUserId: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    resources: [],
+    announcements: [],
+  };
+
+  beforeEach(async () => {
+    activatedRoute = {
+      snapshot: {
+        paramMap: {
+          get: vi.fn((key: string) => {
+            if (key === 'programId') {
+              return 'prog-1';
+            }
+            if (key === 'sessionId') {
+              return 'session-1';
+            }
+            return null;
+          }),
+        },
+      },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SessionDetailPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: WebAuthService,
+          useValue: {
+            currentSession: () => null,
+          },
+        },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+      ],
+    }).compileComponents();
+  });
+
+  function configureClient(
+    fixture: ReturnType<typeof TestBed.createComponent<SessionDetailPage>>,
+    getByIdResult: Promise<ParticipantProgramDetailDto>,
+  ): {
+    getById: ReturnType<typeof vi.fn>;
+    markSessionProgress: ReturnType<typeof vi.fn>;
+  } {
+    const client = {
+      getById: vi.fn().mockImplementation(() => getByIdResult),
+      markSessionProgress: vi.fn().mockResolvedValue({
+        enrollmentId: 'enr-1',
+        enrollmentStatus: 'active',
+        progress: detail.progress,
+      }),
+    };
+
+    fixture.componentInstance['programsClient'] = client;
+    return client;
+  }
+
+  async function render(
+    result: Promise<ParticipantProgramDetailDto>,
+  ): Promise<ReturnType<typeof TestBed.createComponent<SessionDetailPage>>> {
+    const fixture = TestBed.createComponent(SessionDetailPage);
+    configureClient(fixture, result);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('Given valid program and session ids, When detail loads, Then the session information and meeting action are rendered', async () => {
+    const fixture = await render(Promise.resolve(detail));
+    const element = fixture.nativeElement as HTMLElement;
+    const text = element.textContent ?? '';
+
+    expect(text).toContain('Session de démarrage');
+    expect(text).toContain('Présentation du parcours.');
+    expect(text).toContain('En ligne');
+    expect(text).toContain('Classe virtuelle');
+    expect(text).toContain('Session non terminée.');
+
+    const meetingLink = element.querySelector(
+      'a[href="https://meet.example.com/session-1"]',
+    );
+    expect(meetingLink?.getAttribute('target')).toBe('_blank');
+    expect(meetingLink?.getAttribute('rel')).toContain('noopener');
+  });
+
+  it('Given the session is completed, When detail loads, Then the completed state and reversal action are rendered', async () => {
+    const fixture = await render(
+      Promise.resolve({
+        ...detail,
+        progress: {
+          ...detail.progress,
+          completedSessions: 1,
+          completionRate: 50,
+          status: 'in_progress',
+          completedSessionIds: ['session-1'],
+        },
+      }),
+    );
+    const text = fixture.nativeElement.textContent ?? '';
+
+    expect(text).toContain('Session marquée comme terminée.');
+    expect(text).toContain('Marquer comme non terminée');
+    expect(text).toContain('50%');
+  });
+
+  it('Given the session has no optional meeting or location label, When detail loads, Then no meeting action is rendered', async () => {
+    const fixture = await render(
+      Promise.resolve({
+        ...detail,
+        sessions: [
+          {
+            ...detail.sessions[0]!,
+            locationLabel: null,
+            meetingLink: null,
+          },
+        ],
+      }),
+    );
+    const text = fixture.nativeElement.textContent ?? '';
+
+    expect(text).toContain('Non précisé');
+    expect(text).not.toContain('Rejoindre la session');
+  });
+
+  it('Given session loading fails, When the page settles, Then the resolved error and retry action are rendered', async () => {
+    const fixture = await render(Promise.reject(new Error('API Error')));
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('API Error');
+    expect(element.querySelector('button')?.textContent).toContain('Réessayer');
+  });
+
+  it('Given an incomplete session, When completion succeeds, Then progress is persisted and canonical detail is reloaded', async () => {
+    const fixture = TestBed.createComponent(SessionDetailPage);
+    const client = {
+      getById: vi.fn().mockResolvedValue(detail),
+      markSessionProgress: vi.fn().mockResolvedValue({
+        enrollmentId: 'enr-1',
+        enrollmentStatus: 'active',
+        progress: {
+          ...detail.progress,
+          completedSessions: 1,
+          completionRate: 50,
+          status: 'in_progress',
+          completedSessionIds: ['session-1'],
+        },
+      }),
+    };
+
+    fixture.componentInstance['programsClient'] = client;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance['markSessionCompletion'](true);
+
+    expect(client.markSessionProgress).toHaveBeenCalledWith('prog-1', {
+      sessionId: 'session-1',
+      completed: true,
+    });
+    expect(client.getById).toHaveBeenCalledTimes(2);
+  });
+
+  it('Given completion persistence fails, When the participant marks the session, Then the exact error is rendered', async () => {
+    const fixture = TestBed.createComponent(SessionDetailPage);
+    const client = configureClient(fixture, Promise.resolve(detail));
+    client.markSessionProgress.mockRejectedValue(
+      new Error('Erreur progression explicite'),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await fixture.componentInstance['markSessionCompletion'](true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'Erreur progression explicite',
+    );
+  });
+
+  it('Given an unknown session id, When program detail loads, Then the not-found state is rendered', async () => {
+    activatedRoute.snapshot.paramMap.get.mockImplementation((key: string) => {
+      if (key === 'programId') {
+        return 'prog-1';
+      }
+      if (key === 'sessionId') {
+        return 'missing-session';
+      }
+      return null;
+    });
+
+    const fixture = await render(Promise.resolve(detail));
+
+    expect(fixture.nativeElement.textContent).toContain('Session introuvable');
+  });
+
+  it('Given no program id, When the page initializes, Then no API request is made', async () => {
+    activatedRoute.snapshot.paramMap.get.mockReturnValue(null);
+
+    const fixture = TestBed.createComponent(SessionDetailPage);
+    const client = configureClient(fixture, Promise.resolve(detail));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(client.getById).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Session introuvable');
+  });
+});

--- a/apps/client/projects/web/src/app/features/participant/programs/session-detail.page.ts
+++ b/apps/client/projects/web/src/app/features/participant/programs/session-detail.page.ts
@@ -1,0 +1,186 @@
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import {
+  createApiClient,
+  logDebugError,
+  resolveAuthErrorMessage,
+  type ApiClient,
+} from '@kraak/api-client';
+import type { ParticipantProgramDetailDto, SessionDto } from '@kraak/contracts';
+
+import { environment } from '../../../../environments/environment';
+import { WebAuthService } from '../../../core/auth/web-auth.service';
+import { resolveApiBaseUrl } from '../../../core/runtime/runtime-config';
+
+@Component({
+  selector: 'kraak-web-participant-session-detail',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './session-detail.page.html',
+})
+export default class SessionDetailPage implements OnInit {
+  private readonly authService = inject(WebAuthService);
+  private readonly route = inject(ActivatedRoute);
+
+  protected programsClient: Pick<
+    ApiClient['participantPrograms'],
+    'getById' | 'markSessionProgress'
+  > = createApiClient({
+    baseUrl: resolveApiBaseUrl(environment.apiBaseUrl),
+    getAuthToken: () => this.authService.currentSession()?.accessToken ?? null,
+  }).participantPrograms;
+
+  protected readonly programDetail = signal<ParticipantProgramDetailDto | null>(
+    null,
+  );
+  protected readonly loading = signal(true);
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly markingProgress = signal(false);
+  protected readonly markErrorMessage = signal<string | null>(null);
+
+  protected readonly programId = computed(
+    () =>
+      this.route.snapshot.paramMap.get('programId') ??
+      this.programDetail()?.program.id ??
+      null,
+  );
+
+  protected readonly session = computed<SessionDto | null>(() => {
+    const sessionId = this.route.snapshot.paramMap.get('sessionId');
+    const detail = this.programDetail();
+
+    if (!sessionId || !detail) {
+      return null;
+    }
+
+    return detail.sessions.find((item) => item.id === sessionId) ?? null;
+  });
+
+  protected readonly isSessionCompleted = computed(() => {
+    const detail = this.programDetail();
+    const session = this.session();
+
+    return Boolean(
+      detail &&
+      session &&
+      detail.progress.completedSessionIds.includes(session.id),
+    );
+  });
+
+  ngOnInit(): void {
+    const programId = this.route.snapshot.paramMap.get('programId');
+
+    if (!programId) {
+      this.loading.set(false);
+      return;
+    }
+
+    void this.loadProgramDetail(programId);
+  }
+
+  protected async reloadSession(): Promise<void> {
+    const programId = this.route.snapshot.paramMap.get('programId');
+
+    if (programId) {
+      await this.loadProgramDetail(programId);
+    }
+  }
+
+  protected async markSessionCompletion(completed: boolean): Promise<void> {
+    const programId = this.programId();
+    const session = this.session();
+
+    if (!programId || !session || this.markingProgress()) {
+      return;
+    }
+
+    try {
+      this.markingProgress.set(true);
+      this.markErrorMessage.set(null);
+
+      await this.programsClient.markSessionProgress(programId, {
+        sessionId: session.id,
+        completed,
+      });
+
+      await this.loadProgramDetail(programId);
+    } catch (error) {
+      logDebugError('web.participant.programs.session.progress', error, {
+        route: `/participant/programmes/${programId}/sessions/${session.id}`,
+        completed,
+      });
+
+      this.markErrorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Impossible de mettre à jour votre progression.',
+        ),
+      );
+    } finally {
+      this.markingProgress.set(false);
+    }
+  }
+
+  protected sessionStatusLabel(status: SessionDto['status']): string {
+    switch (status) {
+      case 'scheduled':
+        return 'Planifiée';
+      case 'live':
+        return 'En direct';
+      case 'completed':
+        return 'Terminée';
+      case 'cancelled':
+        return 'Annulée';
+    }
+  }
+
+  protected locationTypeLabel(type: SessionDto['locationType']): string {
+    switch (type) {
+      case 'online':
+        return 'En ligne';
+      case 'onsite':
+        return 'Sur site';
+      case 'hybrid':
+        return 'Hybride';
+    }
+  }
+
+  protected formatDateTime(rawDate: string): string {
+    const parsedDate = new Date(rawDate);
+
+    if (Number.isNaN(parsedDate.getTime())) {
+      return rawDate;
+    }
+
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(parsedDate);
+  }
+
+  private async loadProgramDetail(programId: string): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.errorMessage.set(null);
+
+      const detail = await this.programsClient.getById(programId);
+      this.programDetail.set(detail);
+    } catch (error) {
+      logDebugError('web.participant.programs.session.load', error, {
+        route: `/participant/programmes/${programId}/sessions`,
+      });
+
+      this.errorMessage.set(
+        resolveAuthErrorMessage(
+          error,
+          'Erreur lors du chargement de la session.',
+        ),
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/client/projects/web/src/app/participant-area.routes.spec.ts
+++ b/apps/client/projects/web/src/app/participant-area.routes.spec.ts
@@ -17,6 +17,18 @@ describe('participant-area.routes', () => {
     );
   });
 
+  it('Given la route parent participant, When sa configuration est lue, Then elle déclare le shell participant et son composant lazy', async () => {
+    const participantRoot = participantAreaRoutes.find(
+      (route) => route.path === 'participant',
+    );
+
+    expect(participantRoot?.data?.['appShell']).toBe('participant');
+    expect(participantRoot?.loadComponent).toBeTypeOf('function');
+
+    const shell = await participantRoot?.loadComponent?.();
+    expect(shell).toBeDefined();
+  });
+
   it('Given les routes participant, When la route parent est lue, Then la redirection dashboard est déclarée', () => {
     const participantRoot = participantAreaRoutes.find(
       (route) => route.path === 'participant',
@@ -40,6 +52,48 @@ describe('participant-area.routes', () => {
     expect(dashboardRoute?.loadComponent).toBeTypeOf('function');
 
     const module = await dashboardRoute?.loadComponent?.();
+    expect(module).toBeDefined();
+  });
+
+  it('Given la route programmes participant, When son loadComponent est invoqué, Then la page de liste est résolue', async () => {
+    const participantRoot = participantAreaRoutes.find(
+      (route) => route.path === 'participant',
+    );
+    const programmesRoute = participantRoot?.children?.find(
+      (child) => child.path === 'programmes',
+    );
+
+    expect(programmesRoute?.loadComponent).toBeTypeOf('function');
+
+    const module = await programmesRoute?.loadComponent?.();
+    expect(module).toBeDefined();
+  });
+
+  it('Given la route détail programme participant, When son loadComponent est invoqué, Then la page de détail est résolue', async () => {
+    const participantRoot = participantAreaRoutes.find(
+      (route) => route.path === 'participant',
+    );
+    const detailRoute = participantRoot?.children?.find(
+      (child) => child.path === 'programmes/:programId',
+    );
+
+    expect(detailRoute?.loadComponent).toBeTypeOf('function');
+
+    const module = await detailRoute?.loadComponent?.();
+    expect(module).toBeDefined();
+  });
+
+  it('Given la route détail session participant, When son loadComponent est invoqué, Then la page de session est résolue', async () => {
+    const participantRoot = participantAreaRoutes.find(
+      (route) => route.path === 'participant',
+    );
+    const sessionRoute = participantRoot?.children?.find(
+      (child) => child.path === 'programmes/:programId/sessions/:sessionId',
+    );
+
+    expect(sessionRoute?.loadComponent).toBeTypeOf('function');
+
+    const module = await sessionRoute?.loadComponent?.();
     expect(module).toBeDefined();
   });
 });

--- a/apps/client/projects/web/src/app/participant-area.routes.ts
+++ b/apps/client/projects/web/src/app/participant-area.routes.ts
@@ -96,9 +96,16 @@ export const participantAreaRoutes: Routes = [
   },
   {
     path: 'participant',
-    data: { seo: participantDashboardSeo },
+    data: {
+      seo: participantDashboardSeo,
+      appShell: 'participant',
+    },
     canActivate: [participantRoleGuard],
     canActivateChild: [participantRoleChildGuard],
+    loadComponent: () =>
+      import('./features/participant/layout/participant-shell.component').then(
+        (m) => m.default,
+      ),
     children: [
       {
         path: '',
@@ -109,6 +116,27 @@ export const participantAreaRoutes: Routes = [
         path: 'dashboard',
         loadComponent: () =>
           import('./features/participant/dashboard/dashboard.page').then(
+            (m) => m.default,
+          ),
+      },
+      {
+        path: 'programmes',
+        loadComponent: () =>
+          import('./features/participant/programs/program-list.page').then(
+            (m) => m.default,
+          ),
+      },
+      {
+        path: 'programmes/:programId/sessions/:sessionId',
+        loadComponent: () =>
+          import('./features/participant/programs/session-detail.page').then(
+            (m) => m.default,
+          ),
+      },
+      {
+        path: 'programmes/:programId',
+        loadComponent: () =>
+          import('./features/participant/programs/program-detail.page').then(
             (m) => m.default,
           ),
       },


### PR DESCRIPTION
## Résumé

- introduit un shell dédié à l’espace participant et masque le navbar/footer publics sur les routes protégées via `appShell: 'participant'`
- refond visuellement le tableau de bord participant avec la palette KRAAK, Poppins et une composition inspirée du langage visuel Genesis sans reprendre son architecture ni ses données factices
- ajoute les parcours protégés `/participant/programmes`, `/participant/programmes/:programId` et `/participant/programmes/:programId/sessions/:sessionId`
- ajoute la liste des programmes, le détail programme et le détail session avec chargement authentifié via `participantPrograms`
- permet de marquer une session terminée/non terminée via `markSessionProgress`, puis recharge l’état canonique du programme
- conserve les DTO, guards, auth, API client, routage, accessibilité, analytics et architecture existants de KRAAK sous la nouvelle couche visuelle
- utilise des couvertures KRAAK déterministes côté UI plutôt que des images aléatoires ou des métadonnées fictives

## Validation

- tests participant ciblés : 55/55
- tests web complets : 710/710 sur 85 fichiers
- tests d’intégration API : 31/31
- `pnpm typecheck:web`
- `pnpm build:web:local` — browser + SSR, 26 routes pré-rendues
- lint web : 0 erreur ; les 3 avertissements Playwright existants restent dans `tests/e2e/analytics.spec.ts`
- `git diff --check`
- validation du nom de branche

Le commit final est `bb52e13a` et la branche est synchronisée avec `origin/feat/participant-lms-genesis-ui`.